### PR TITLE
fix(compat mode): don't inject inline scripts on server

### DIFF
--- a/components/HTMLBlock.jsx
+++ b/components/HTMLBlock.jsx
@@ -7,8 +7,11 @@ const PropTypes = require('prop-types');
  * @arg {string} html the HTML from which to extract script tags.
  */
 const extractScripts = html => {
+  if (typeof window === 'undefined' || !html) return () => {};
+
   const regex = /<script\b[^>]*>([\s\S]*?)<\/script>/gim;
   const scripts = [...html.matchAll(regex)].map(m => m[1].trim());
+
   return () => scripts.map(js => window.eval(js));
 };
 


### PR DESCRIPTION
### 🧰  Changes

In compatibility mode, we `eval` inline scripts found in Custom HTML/CSS blocks. This logic fails on the server-side rendered pass for various reasons.

- [x] Add a conditional check on the `window` global to avoid evaluating scripts on the server.
