### PR TITLE
enhance: expose the core setup method

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ sanitize.ancestors.input = ['li'];
 /**
  * Normalize Magic Block Raw Text
  */
-function setup(blocks, opts = {}) {
+export function setup(blocks, opts = {}) {
   // merge default and user options
   opts = { ...options, ...opts };
 


### PR DESCRIPTION
### 🧰  Changes

- [x] expose the core `setup` method for normalizing magic block text and RDMD options.