### PR TITLE
feat: adding a new `copyButtons` option for disabling code copy btns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img align=right width=26% src=http://owlbert.io/images/owlberts-png/Reading.psd.png>
+<img align="right" width="26%" src="https://owlbert.io/images/owlberts-png/Reading.psd.png">
 
 @readme/markdown
 ===
@@ -42,9 +42,10 @@ In addition to the default React processor, the package exports some other metho
 
 Each processor method takes an options object which you can use to adjust the output HTML or React tree. These options include:
 
-- **`correctnewlines`**—render new line delimeters as `<br>` tags.
-- **`markdownOptions`**—Remark [parser options](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#processorusestringify-options).
-- **`compatibilityMode`**—enable [compatibility features](https://github.com/readmeio/api-explorer/issues/668) from our old markdown engine.
+- **`compatibilityMode`** — Enable [compatibility features](https://github.com/readmeio/api-explorer/issues/668) from our old markdown engine.
+- **`copyCodeButton`** — Automatically insert a button alongside `<code>` elemnets to copy them to the clipboard.
+- **`correctnewlines`** — Render new line delimeters as `<br>` tags.
+- **`markdownOptions`** — Remark [parser options](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#processorusestringify-options).
 
 ## Flavored Syntax
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In addition to the default React processor, the package exports some other metho
 Each processor method takes an options object which you can use to adjust the output HTML or React tree. These options include:
 
 - **`compatibilityMode`** — Enable [compatibility features](https://github.com/readmeio/api-explorer/issues/668) from our old markdown engine.
-- **`copyCodeButton`** — Automatically insert a button alongside `<code>` elemnets to copy them to the clipboard.
+- **`copyButtons`** — Automatically insert a button to copy a block of text to the clipboard. Currently used on `<code>` elements.
 - **`correctnewlines`** — Render new line delimeters as `<br>` tags.
 - **`markdownOptions`** — Remark [parser options](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#processorusestringify-options).
 

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -144,19 +144,34 @@ test('emojis', () => {
   ).toMatchSnapshot();
 });
 
-test('code samples', () => {
-  const wrap = mount(
-    markdown.default(`
-\`\`\`javascript
-var a = 1;
-\`\`\`
+describe('code samples', () => {
+  it('should codify code', () => {
+    const wrap = mount(
+      markdown.default(`
+  \`\`\`javascript
+  var a = 1;
+  \`\`\`
 
-\`\`\`
-code-without-language
-\`\`\`
-`)
-  );
-  expect(wrap.find('pre')).toHaveLength(2);
+  \`\`\`
+  code-without-language
+  \`\`\`
+  `)
+    );
+    expect(wrap.find('pre')).toHaveLength(2);
+    expect(wrap.find('button')).toHaveLength(2);
+  });
+
+  describe('`copyCodeButton` option', () => {
+    it('should not insert the CopyCode component if `copyCodeButton=false`', () => {
+      const elem = mount(
+        markdown.react('This is a sentence and it contains a piece of `code` wrapped in backticks.', {
+          copyCodeButton: false,
+        })
+      );
+
+      expect(elem.find('button')).toHaveLength(0);
+    });
+  });
 });
 
 test('should render nothing if nothing passed in', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -161,11 +161,11 @@ describe('code samples', () => {
     expect(wrap.find('button')).toHaveLength(2);
   });
 
-  describe('`copyCodeButton` option', () => {
-    it('should not insert the CopyCode component if `copyCodeButton=false`', () => {
+  describe('`copyButtons` option', () => {
+    it('should not insert the CopyCode component if `copyButtons=false`', () => {
       const elem = mount(
         markdown.react('This is a sentence and it contains a piece of `code` wrapped in backticks.', {
-          copyCodeButton: false,
+          copyButtons: false,
         })
       );
 

--- a/components/Code/index.jsx
+++ b/components/Code/index.jsx
@@ -29,7 +29,7 @@ CopyCode.propTypes = {
 };
 
 function Code(props) {
-  const { children, className, copyCodeButton, lang, meta } = props;
+  const { children, className, copyButtons, lang, meta } = props;
 
   const langClass = className.search(/lang(?:uage)?-\w+/) >= 0 ? className.match(/\s?lang(?:uage)?-(\w+)/)[1] : '';
   const language = canonicalLanguage(lang) || langClass;
@@ -42,32 +42,32 @@ function Code(props) {
         name={meta}
         suppressHydrationWarning={true}
       >
-        {copyCodeButton && <CopyCode className="fa" code={children[0]} />}
+        {copyButtons && <CopyCode className="fa" code={children[0]} />}
         {syntaxHighlighter ? syntaxHighlighter(children[0], language, { tokenizeVariables: true }) : children[0]}
       </code>
     </React.Fragment>
   );
 }
 
-function CreateCode(sanitizeSchema, { copyCodeButton }) {
+function CreateCode(sanitizeSchema, { copyButtons }) {
   // This is for code blocks class name
   sanitizeSchema.attributes.code = ['className', 'lang', 'meta', 'value'];
 
   // eslint-disable-next-line react/display-name
-  return props => <Code {...props} copyCodeButton={copyCodeButton} />;
+  return props => <Code {...props} copyButtons={copyButtons} />;
 }
 
 Code.propTypes = {
   children: PropTypes.arrayOf(PropTypes.string).isRequired,
   className: PropTypes.string,
-  copyCodeButton: PropTypes.bool,
+  copyButtons: PropTypes.bool,
   lang: PropTypes.string,
   meta: PropTypes.string,
 };
 
 Code.defaultProps = {
   className: '',
-  copyCodeButton: true,
+  copyButtons: true,
   lang: '',
   meta: '',
 };

--- a/components/Code/index.jsx
+++ b/components/Code/index.jsx
@@ -29,7 +29,7 @@ CopyCode.propTypes = {
 };
 
 function Code(props) {
-  const { className, children, lang, meta } = props;
+  const { children, className, copyCodeButton, lang, meta } = props;
 
   const langClass = className.search(/lang(?:uage)?-\w+/) >= 0 ? className.match(/\s?lang(?:uage)?-(\w+)/)[1] : '';
   const language = canonicalLanguage(lang) || langClass;
@@ -42,28 +42,34 @@ function Code(props) {
         name={meta}
         suppressHydrationWarning={true}
       >
-        <CopyCode className="fa" code={children[0]} />
+        {copyCodeButton && <CopyCode className="fa" code={children[0]} />}
         {syntaxHighlighter ? syntaxHighlighter(children[0], language, { tokenizeVariables: true }) : children[0]}
       </code>
     </React.Fragment>
   );
 }
 
+function CreateCode(sanitizeSchema, { copyCodeButton }) {
+  // This is for code blocks class name
+  sanitizeSchema.attributes.code = ['className', 'lang', 'meta', 'value'];
+
+  // eslint-disable-next-line react/display-name
+  return props => <Code {...props} copyCodeButton={copyCodeButton} />;
+}
+
 Code.propTypes = {
   children: PropTypes.arrayOf(PropTypes.string).isRequired,
   className: PropTypes.string,
+  copyCodeButton: PropTypes.bool,
   lang: PropTypes.string,
   meta: PropTypes.string,
 };
 
 Code.defaultProps = {
   className: '',
+  copyCodeButton: true,
   lang: '',
   meta: '',
 };
 
-module.exports = sanitizeSchema => {
-  // This is for code blocks class name
-  sanitizeSchema.attributes.code = ['className', 'lang', 'meta', 'value'];
-  return Code;
-};
+module.exports = (sanitizeSchema, opts) => CreateCode(sanitizeSchema, opts);

--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ export function reactProcessor(opts = {}, components = {}) {
         h4: Heading(4, count, opts),
         h5: Heading(5, count, opts),
         h6: Heading(6, count, opts),
-        code: Code(sanitize),
+        code: Code(sanitize, opts),
         img: Image(sanitize),
         ...components,
       }),

--- a/options.json
+++ b/options.json
@@ -1,6 +1,6 @@
 {
   "compatibilityMode": false,
-  "copyCodeButton": true,
+  "copyButtons": true,
   "correctnewlines": false,
   "markdownOptions": {
     "fences": true,

--- a/options.json
+++ b/options.json
@@ -1,4 +1,6 @@
 {
+  "compatibilityMode": false,
+  "copyCodeButton": true,
   "correctnewlines": false,
   "markdownOptions": {
     "fences": true,
@@ -10,9 +12,8 @@
     "paddedTable": true,
     "setext": true
   },
+  "normalize": true,
   "settings": {
     "position": false
-  },
-  "normalize": true,
-  "compatibilityMode": false
+  }
 }


### PR DESCRIPTION
### 🧰  Changes

This adds a new `copyCodeButton` option to allow for the `CopyCode` button that's automatically inserted alongside `code` elements to not be added.

Adding this because in some cases within the API Explorer we have description markdown getting the copy button where it doesn't need to be, and with the way the CSS is set up in that project it's not easily pheasable to disable it otherwise.

![Screen Shot 2020-10-14 at 3 53 30 PM](https://user-images.githubusercontent.com/33762/96054017-90c7c980-0e35-11eb-8570-a219c2b98dd3.png)