### PR TITLE
fix: pinned callouts dont render body

### DIFF
--- a/components/Callout/index.jsx
+++ b/components/Callout/index.jsx
@@ -6,8 +6,14 @@ const Callout = props => {
   const { attributes, theme, title, icon } = props;
   if (!(title || children)) return '';
 
-  const content = title ? children.splice(1) : children;
-  children = title ? children : '';
+  let content;
+  if (title) {
+    //[children, ...content] = children;
+    content = children.splice(1);
+  } else {
+    [children, content] = ['', children];
+  }
+
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <blockquote {...attributes} className={`callout callout_${theme}`} theme={icon}>

--- a/components/Callout/index.jsx
+++ b/components/Callout/index.jsx
@@ -8,8 +8,7 @@ const Callout = props => {
 
   let content;
   if (title) {
-    //[children, ...content] = children;
-    content = children.splice(1);
+    [children, ...content] = children;
   } else {
     [children, content] = ['', children];
   }


### PR DESCRIPTION
<img height=20 src=https://readme.com/static/favicon.ico align=center> [Demo][demo] | 🎫 [Ticket][ticket]
:---:|:---:

### 🧰  Changes

This removes a call to .splice() on the Callout component's children.
Modifying the children meant that the component couldn't render twice,
which happens when the callout is pinned to the sidebar. It's rendered
once for spacing, then again for display.

Writing a test using enzyme is somewhere between not possible and
contrived. A follow-up PR in the api-explorer will test this.

#35 

[demo]: #demo-app-link-to-come
[ticket]: https://app.asana.com/0/1178132843162889/1198496636781214/f
