### PR TITLE
fix(magic-block-parser): handle excess table data

### DIFF
--- a/__tests__/components.test.js
+++ b/__tests__/components.test.js
@@ -3,6 +3,8 @@ const { mount } = require('enzyme');
 const React = require('react');
 const markdown = require('../index');
 
+const { silenceConsole } = require('./helpers');
+
 describe('Data Replacements', () => {
   it('Variables', () => {
     const wrapper = mount(
@@ -124,14 +126,15 @@ describe('Components', () => {
       [/block]`,
       rdmd: `[](https://www.nytimes.com/2020/05/03/us/politics/george-w-bush-coronavirus-unity.html "@embed")`,
     };
-    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    Object.values(fixtures).map(fx => {
-      const wrap = mount(markdown.react(fx));
-      return expect(wrap.html()).toMatchSnapshot();
+    silenceConsole(({ error }) => {
+      Object.values(fixtures).map(fx => {
+        const wrap = mount(markdown.react(fx));
+        return expect(wrap.html()).toMatchSnapshot();
+      });
+
+      expect(error).toHaveBeenCalledTimes(1);
     });
-
-    expect(error).toHaveBeenCalledTimes(1);
   });
 
   it('Image', () => {

--- a/__tests__/components.test.js
+++ b/__tests__/components.test.js
@@ -127,7 +127,7 @@ describe('Components', () => {
       rdmd: `[](https://www.nytimes.com/2020/05/03/us/politics/george-w-bush-coronavirus-unity.html "@embed")`,
     };
 
-    silenceConsole(({ error }) => {
+    silenceConsole()(error => {
       Object.values(fixtures).map(fx => {
         const wrap = mount(markdown.react(fx));
         return expect(wrap.html()).toMatchSnapshot();

--- a/__tests__/components.test.js
+++ b/__tests__/components.test.js
@@ -124,10 +124,14 @@ describe('Components', () => {
       [/block]`,
       rdmd: `[](https://www.nytimes.com/2020/05/03/us/politics/george-w-bush-coronavirus-unity.html "@embed")`,
     };
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
     Object.values(fixtures).map(fx => {
       const wrap = mount(markdown.react(fx));
       return expect(wrap.html()).toMatchSnapshot();
     });
+
+    expect(error).toHaveBeenCalledTimes(1);
   });
 
   it('Image', () => {

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -1,15 +1,16 @@
-module.exports.silenceConsole = fn => {
-  const handlers = {
-    get: (target, prop) => {
-      if (!(prop in target) && prop in console) {
-        const spy = jest.spyOn(console, prop).mockImplementation(() => {});
-        target[prop] = spy;
-      }
+const consoleStubHandler = {
+  get: (target, prop) => {
+    if (!(prop in target) && prop in console) {
+      const spy = jest.spyOn(console, prop).mockImplementation(() => {});
+      target[prop] = spy;
+    }
 
-      return target[prop];
-    },
-  };
-  const potentialSpies = new Proxy({}, handlers);
+    return target[prop];
+  },
+};
+
+module.exports.silenceConsole = fn => {
+  const potentialSpies = new Proxy({}, consoleStubHandler);
 
   try {
     return fn(potentialSpies);

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -1,20 +1,11 @@
-const consoleStubHandler = {
-  get: (target, prop) => {
-    if (!(prop in target) && prop in console) {
-      const spy = jest.spyOn(console, prop).mockImplementation(() => {});
-      target[prop] = spy;
-    }
-
-    return target[prop];
-  },
-};
-
-module.exports.silenceConsole = fn => {
-  const potentialSpies = new Proxy({}, consoleStubHandler);
+module.exports.silenceConsole = (prop = 'error', impl = () => {}) => fn => {
+  let spy;
 
   try {
-    return fn(potentialSpies);
+    spy = jest.spyOn(console, prop).mockImplementation(impl);
+
+    return fn(spy);
   } finally {
-    Object.values(potentialSpies).forEach(spy => spy.mockRestore());
+    spy.mockRestore();
   }
 };

--- a/__tests__/helpers.js
+++ b/__tests__/helpers.js
@@ -1,0 +1,19 @@
+module.exports.silenceConsole = fn => {
+  const handlers = {
+    get: (target, prop) => {
+      if (!(prop in target) && prop in console) {
+        const spy = jest.spyOn(console, prop).mockImplementation(() => {});
+        target[prop] = spy;
+      }
+
+      return target[prop];
+    },
+  };
+  const potentialSpies = new Proxy({}, handlers);
+
+  try {
+    return fn(potentialSpies);
+  } finally {
+    Object.values(potentialSpies).forEach(spy => spy.mockRestore());
+  }
+};

--- a/__tests__/magic-block-parser.test.js
+++ b/__tests__/magic-block-parser.test.js
@@ -226,7 +226,7 @@ describe('Parse Magic Blocks', () => {
     }
     [/block]`;
 
-    silenceConsole(({ error }) => {
+    silenceConsole()(error => {
       expect(process(text)).toMatchSnapshot();
       expect(error).toHaveBeenCalledTimes(1);
     });

--- a/__tests__/magic-block-parser.test.js
+++ b/__tests__/magic-block-parser.test.js
@@ -223,7 +223,10 @@ describe('Parse Magic Blocks', () => {
       "link": "http://test.com",
     }
     [/block]`;
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+
     expect(process(text)).toMatchSnapshot();
+    expect(error).toHaveBeenCalledTimes(1);
   });
 
   it('Unrecognized Blocks', () => {

--- a/__tests__/magic-block-parser.test.js
+++ b/__tests__/magic-block-parser.test.js
@@ -5,6 +5,8 @@ const rehypeSanitize = require('rehype-sanitize');
 const parser = require('../processor/parse/magic-block-parser');
 const options = require('../options.json').markdownOptions;
 
+const { silenceConsole } = require('./helpers');
+
 const sanitize = { attributes: [] };
 const process = (text, opts = options) =>
   text &&
@@ -223,10 +225,11 @@ describe('Parse Magic Blocks', () => {
       "link": "http://test.com",
     }
     [/block]`;
-    const error = jest.spyOn(console, 'error').mockImplementation(() => {});
 
-    expect(process(text)).toMatchSnapshot();
-    expect(error).toHaveBeenCalledTimes(1);
+    silenceConsole(({ error }) => {
+      expect(process(text)).toMatchSnapshot();
+      expect(error).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('Unrecognized Blocks', () => {

--- a/__tests__/magic-block-parser/__snapshots__/table.test.js.snap
+++ b/__tests__/magic-block-parser/__snapshots__/table.test.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Table Blocks does not display data outside the declared dimensions 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "align": Array [
+        "left",
+        "left",
+      ],
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Left",
+                },
+              ],
+              "type": "tableHead",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Center",
+                },
+              ],
+              "type": "tableHead",
+            },
+          ],
+          "type": "tableRow",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Left 0",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Center 0",
+                },
+              ],
+              "type": "tableCell",
+            },
+          ],
+          "type": "tableRow",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Left 1",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "Center 1",
+                },
+              ],
+              "type": "tableCell",
+            },
+          ],
+          "type": "tableRow",
+        },
+      ],
+      "type": "table",
+    },
+  ],
+  "type": "root",
+}
+`;

--- a/__tests__/magic-block-parser/table.test.js
+++ b/__tests__/magic-block-parser/table.test.js
@@ -1,0 +1,43 @@
+const unified = require('unified');
+const remarkParse = require('remark-parse');
+const rehypeSanitize = require('rehype-sanitize');
+
+const parser = require('../../processor/parse/magic-block-parser');
+const options = require('../../options.json').markdownOptions;
+
+const sanitize = { attributes: [] };
+const process = (text, opts = options) =>
+  text &&
+  unified()
+    .use(remarkParse, opts)
+    .data('settings', { position: false })
+    .use(parser.sanitize(sanitize))
+    .use(rehypeSanitize)
+    .parse(text);
+
+describe('Table Blocks', () => {
+  it('does not display data outside the declared dimensions', () => {
+    const text = `[block:parameters]
+    {
+      "data": {
+        "h-0": "Left",
+        "h-1": "Center",
+        "h-2": "Right",
+        "0-0": "Left 0",
+        "0-1": "Center 0",
+        "0-2": "Right 0",
+        "1-0": "Left 1",
+        "1-1": "Center 1",
+        "1-2": "Right 1",
+        "2-0": "Left 2",
+        "2-1": "Center 2",
+        "2-2": "Right 2"
+      },
+      "cols": 2,
+      "rows": 2
+    }
+    [/block]`;
+
+    expect(process(text)).toMatchSnapshot();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,9 @@ module.exports = {
   moduleNameMapper: {
     '.+\\.(css|styl|less|sass|scss)$': 'identity-obj-proxy',
   },
+  modulePathIgnorePatterns: ['<rootDir>/__tests__/helpers'],
   setupFiles: ['<rootDir>/lib/enzyme'],
+  setupAfterEnvFiles: ['<rootDir>/__tests__/helpers'],
   testURL: 'http://localhost',
   transform: {
     '^.+\\.jsx?$': '<rootDir>/lib/babel-jest',

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -159,8 +159,8 @@ function tokenize(eat, value) {
         col = parseInt(col, 10);
 
         // NOTE:
-        // The magic block tables allowed decreases the dimensions, but
-        // left the data intact.
+        // The magic block tables allowed decreasing the dimensions, but
+        // would leave the data intact.
         // Also, note that the header row is required, so having 1 rows,
         // means we allow upto index 1.
         if (row > rows || col >= cols) return sum;

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -162,7 +162,7 @@ function tokenize(eat, value) {
         // The magic block tables allowed decreasing the dimensions, but
         // would leave the data intact.
         // Also, note that the header row is required, so having 1 rows,
-        // means we allow upto index 1.
+        // means we allow up to index 1.
         if (row > rows || col >= cols) return sum;
 
         sum[row] = sum[row] || { type: 'tableRow', children: [] };


### PR DESCRIPTION
### 🧰  Changes

The old magic block syntax allowed shrinking the dimensions of a table,
and would leave the data in place. Unknown if that's a bug or a feature.
In any event, the new engine should needs to handle that.
