### PR TITLE
ci: setting up bundlewatch

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -13,5 +13,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build dist files
+        run: npm run build
+
       - name: Analyze Bundle
         run: npx bundlewatch

--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -1,0 +1,17 @@
+name: BundleWatch
+on: [push]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions/setup-node@v2.1.2
+        with:
+          node-version: 14.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Analyze Bundle
+        run: npx bundlewatch

--- a/package.json
+++ b/package.json
@@ -101,11 +101,11 @@
     "files": [
       {
         "path": "dist/main.js",
-        "maxSize": "1mb"
+        "maxSize": "400KB"
       },
       {
         "path": "dist/main.node.js",
-        "maxSize": "1mb"
+        "maxSize": "250KB"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -96,5 +96,17 @@
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
     }
+  },
+  "bundlewatch": {
+    "files": [
+      {
+        "path": "dist/main.js",
+        "maxSize": "1mb"
+      },
+      {
+        "path": "dist/main.node.js",
+        "maxSize": "1mb"
+      }
+    ]
   }
 }


### PR DESCRIPTION
### 🧰  Changes

Configures [Bundlewatch](https://bundlewatch.io) to help us keep bundle sizes in check. Bundle limit is currently set at 1MB for gzipped files.