### PR TITLE
chore(deps): bump @readme packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3434,9 +3434,9 @@
       }
     },
     "@readme/emojis": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/emojis/-/emojis-1.0.0.tgz",
-      "integrity": "sha512-zqnvyz2FAw9ah6dHkcaiOpL85DPMj8KgaW1Z14Lhf4qECPKRsid4IBd30ljuAV1gdX1JA8HCuFIY8SRU1Lvb2g=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/emojis/-/emojis-3.0.0.tgz",
+      "integrity": "sha512-qbuhp2lugNXl3evFqG7kd/+SMMMlm461dcr/vFputoU3S/fwY6W9J1HzFqsp2kH0otzKLS/6og/t3OxjLx7O0g=="
     },
     "@readme/eslint-config": {
       "version": "3.7.1",
@@ -3460,9 +3460,9 @@
       }
     },
     "@readme/syntax-highlighter": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.4.0.tgz",
-      "integrity": "sha512-psFsZZTlULDkbBFuGDZBzpviuZnzThB38w5AYWgopReS0UhlZGE+jxxCUvAXk8HtSo98TCG4jjCdZyKUihv7OA==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.4.1.tgz",
+      "integrity": "sha512-6TcJkxEs+Q+6t/tHYy8mNe8FQNQXiGUTE1llyVONyMfoFQ2gS/OQv0ld0V3NaR+kcq0Skcok/KJHr5l0F07DJg==",
       "requires": {
         "codemirror": "^5.48.2",
         "prop-types": "^15.7.2",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "release.dry": "npx semantic-release --dry-run"
   },
   "dependencies": {
-    "@readme/emojis": "^1.0.0",
-    "@readme/syntax-highlighter": "^10.4.0",
+    "@readme/emojis": "^3.0.0",
+    "@readme/syntax-highlighter": "^10.4.1",
     "copy-to-clipboard": "^3.3.1",
     "hast-util-sanitize": "^2.0.2",
     "hast-util-to-string": "^1.0.3",


### PR DESCRIPTION
## <img height=30 src=https://readme.com/static/favicon.ico align=center>  Changes
Pull in updates to our various `@readme` packages.

- [x] Bump `@readme/emojis` to [v3.0.0](https://github.com/readmeio/emojis/releases/tag/3.0.0)
- [x] Bump `@readme/syntax-highlighter` to [v10.4.1](https://github.com/readmeio/syntax-highlighter/releases/tag/10.4.1)
- [x] Bump `@readme/variable` to [v10.0.7](https://github.com/readmeio/api-explorer/releases/tag/v10.0.7)

[demo]: #demo-app-link-to-come
