### PR TITLE
style(tables): hide empty table header rows

### DIFF
--- a/components/Table/style.scss
+++ b/components/Table/style.scss
@@ -22,12 +22,18 @@
     
     tr {
       background-color: var(--table-row, #{$row});
-      border-top: 1px solid var(--table-edges, #{$edges});
+      & + tr {
+        border-top: 1px solid var(--table-edges, #{$edges});
+      }
     }
 
     th,
     thead td {
       font-weight: 600;
+      &:empty {
+        padding: 0;
+        border: none;
+      }
     }
 
     td,
@@ -40,7 +46,7 @@
       > :first-child, > :only-child { margin-top:    0 !important }
       > :last-child, > :only-child  { margin-bottom: 0 !important }
     }
-    
+
     &:not(.plain) tr:nth-child(2n) {
       background-color: var(--table-stripe, #{$stripe});
     }


### PR DESCRIPTION
### 🧰  Changes
- [x] Hide empty table header rows.

   <img width=60% src=https://user-images.githubusercontent.com/886627/102000816-08806c00-3ca0-11eb-8d3f-68b9e648795c.gif>