### PR TITLE
fix(bundlewatch): honor skip commit message

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -3,7 +3,9 @@ on: [push]
 
 jobs:
   check:
+    name: Bundle Watch
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'SKIP CI')"
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: actions/setup-node@v2.1.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,13 @@
 name: CI
-
 on: [push]
 
 jobs:
   Test:
-
     if: "!contains(github.event.head_commit.message, 'SKIP CI')"
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-
     steps:
     - uses: actions/checkout@v2.3.4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,12 @@
 name: Release
-
 on:
   push:
     branches:
       - master
       - next
+
 jobs:
-  semantic-release:
-    name: Build & Publish Release
+  Release:
     if: "!contains(github.event.head_commit.message, 'SKIP CI')"
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
### 🧰  Changes
Our bundle analysis CI/CD workflow was running on release commits, as you can see [here](https://github.com/readmeio/markdown/runs/1571530277).

- [x] Prevent this by honoring the `SKIP CI` commit message.
   https://github.com/readmeio/markdown/blob/2d30f3afc32756b40cbfcbba734f80ea9400a9e5/.github/workflows/bundlewatch.yml#L8
- [x] Assorted YAML reformatting for our GitHub workflows.

[demo]: #demo-app-link-to-come
[ticket]: #ticket-link-to-come
