### PR TITLE
style: fix glossary term overflow in tables

### DIFF
--- a/components/Table/style.scss
+++ b/components/Table/style.scss
@@ -8,7 +8,7 @@
     display: table;
     border-collapse: collapse;
     border-spacing: 0;
-    overflow: auto;
+    // overflow: auto;
     width: 100%;
     color: var(--table-text);
 
@@ -54,7 +54,7 @@
     & {
       position: relative;
       display: block;
-      overflow: hidden;
+      // overflow: hidden;
       border-radius: var(--table-radius, var(--markdown-radius, 2px));
     }
     &:after {
@@ -69,7 +69,7 @@
       border-radius: inherit;
     }
     &-inner {
-      overflow: auto;
+      // overflow: auto;
       min-width: 100%;
       box-sizing: content-box;
       width: 100%;

--- a/components/Table/style.scss
+++ b/components/Table/style.scss
@@ -8,7 +8,6 @@
     display: table;
     border-collapse: collapse;
     border-spacing: 0;
-    // overflow: auto;
     width: 100%;
     color: var(--table-text);
 
@@ -54,8 +53,6 @@
     & {
       position: relative;
       display: block;
-      // overflow: hidden;
-      border-radius: var(--table-radius, var(--markdown-radius, 2px));
     }
     &:after {
       content: ' ';
@@ -66,14 +63,11 @@
       top: 0;
       pointer-events: none;
       z-index: 1;
-      border-radius: inherit;
     }
     &-inner {
-      // overflow: auto;
       min-width: 100%;
       box-sizing: content-box;
       width: 100%;
-      border-radius: inherit;
     }
     table:only-child {
       margin: 0 !important;


### PR DESCRIPTION
<img height=20 src=https://readme.com/static/favicon.ico align=center> [Demo][demo] | 🎫 [Ticket][ticket]
:---:|:---:

### 🧰  Changes

RDMD tables hide overflow content (in order to achieve some fancy `border-radius` shit) [which cuts off glossary terms' written in table cells][broke]!
- [x] Unset `overflow: hidden` on RDMD tables.


[demo]: #demo-app-link-to-come
[ticket]: #ticket-link-to-come
[broke]: https://developers.logitech.com/circle/reference/notification-events?enableNewMarkdown=true
