### PR TITLE
fix(recipes): add 'slug' to whitelist

### DIFF
--- a/sanitize.schema.js
+++ b/sanitize.schema.js
@@ -11,7 +11,7 @@ sanitize.attributes['*'].push('class', 'className', 'align', 'style');
  *       within the engine!
  * @todo change `link` to `href`
  */
-sanitize.attributes['tutorial-tile'] = ['backgroundColor', 'emoji', 'link'];
+sanitize.attributes['tutorial-tile'] = ['backgroundColor', 'emoji', 'link', 'slug'];
 
 sanitize.tagNames.push('rdme-pin');
 


### PR DESCRIPTION
<img height=20 src=https://readme.com/static/favicon.ico align=center> [Demo][demo] | 🎫 [Ticket][ticket]
:---:|:---:

### 🧰  Changes

Per some of the changes I'm working on to how our recipes embeds work in the guides section, I need to add `slug` to the attribute whitelist!


[demo]: #demo-app-link-to-come
[ticket]: https://linear.app/readme-io/issue/RM-23/guides-embed-should-open-modal-directly
