### PR TITLE
docs: add disable tokenizers

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,6 +66,7 @@ The `utils` export gives you access to various tools and configuration settings:
   - `markdownOptions`—configuration object passed to `remark`
   - `correctnewlines`—flag to toggle newline transformation.
   - `normalize`—auto-normalize magic blocks before processing.
+  - `disableTokenizers`—disable internal `block` or `inline` tokenizers.
 - **`<GlossaryContext/>`** and **`<VariablesContext/>`**
   React provider and consumer wrappers for [user data injection](doc:features#section-data-injection).
 [block:html]


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo]
:---:

## 🧰 Changes

- [ ] Update [the option name in the docs](https://github.com/readmeio/markdown/pull/129/commits/b2e45f4b251328a6c2a031f14ca1f00e7e0ed66c#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3R69) depending on the resolution of [**this question**](https://github.com/readmeio/markdown/pull/119#discussion_r574935420)...
- [x] Add disable tokenizer to [the options list in the intro](https://rdmd.readme.io/docs#utilities).

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
