### PR TITLE
chore: loosening up our @readme/variable peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "unist-util-select": "^3.0.4"
   },
   "peerDependencies": {
-    "@readme/variable": "^11.0.0",
+    "@readme/variable": "*",
     "react": "^16.14.0",
     "react-dom": "^16.14.0"
   },


### PR DESCRIPTION
## 🧰 Changes

This loosens up the version constraints on our `@readme/variable` peerDep as right now that package is the API Explorer repo and occasionally receives a version bump when we update dev dependencies, and right now when that happens we receive this error on npm@7 when doing installs:

```
$ npm i
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: @readme/explorer@0.0.0
npm ERR! Found: @readme/variable@12.0.0
npm ERR! node_modules/@readme/variable
npm ERR!   dev @readme/variable@"^12.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @readme/variable@"^11.0.0" from @readme/markdown@6.26.0
npm ERR! node_modules/@readme/markdown
npm ERR!   dev @readme/markdown@"^6.21.0" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /Users/jon/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jon/.npm/_logs/2021-02-24T01_11_35_822Z-debug.log
```
