### PR TITLE
fix(code): silence DOM errors for inline snippets in p tags

### DIFF
--- a/components/Code/index.jsx
+++ b/components/Code/index.jsx
@@ -38,9 +38,11 @@ function Code(props) {
   const language = canonicalLanguage(lang) || langClass;
 
   const codeRef = React.createRef();
-  const codeContent = syntaxHighlighter
-    ? syntaxHighlighter(children[0], language, { tokenizeVariables: true })
-    : children[0];
+  const codeOpts = {
+    inline: !lang,
+    tokenizeVariables: true,
+  };
+  const codeContent = syntaxHighlighter ? syntaxHighlighter(children[0], language, codeOpts) : children[0];
 
   return (
     <React.Fragment>


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] | See: [@readme/syntax-highlighter#94][94]
:---:|:---

## 🧰 Changes
If you write a code block, the RDMD engine will wrap the code contents with a `div`. Unfortunately, this holds true for inline code snippets as well, since they're represented by the same underlying MDAST. [Per the W3][w3], `<p>` tags may *only* contain other inline elements, which means the engine throws a warning whenever we render an inline code snippet within a paragraph. Which is, like, all the time...

To fix this, we added an `inline` toggle to our syntax highlighter ([#94][94]) to optionally use a `<span>` instead of a `<div>`. So here, we need to:

- [ ] ~Roll a release for the `@readme/syntax-highlighter`~ ([v10.5.0][syxh]) and bump the package here.
- [x] **Render code snippets without a specified lang as `inline`**.
   The existence of a custom `lang` attribute is a decent proxy for inline versus code blocks. (And even if we do errantly flip this option on a code *block*, our CSS is sturdy enough that it shouldn't have any visible effect.)

## 🧬 QA & Testing

- [Always `div`s in production][prod].
- [Either `span` or `div` in this PR app][demo].


[demo]: https://markdown-pr-140.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[w3]: https://www.w3.org/TR/html401/struct/text.html#h-9.3.1
[94]: https://github.com/readmeio/syntax-highlighter/pull/94
[syxh]: https://github.com/readmeio/syntax-highlighter/releases/tag/10.5.0