### PR TITLE
fix(image): filter null magic blocks

### DIFF
--- a/__tests__/magic-block-parser.test.js
+++ b/__tests__/magic-block-parser.test.js
@@ -72,6 +72,15 @@ test('Blank Magic Blocks', () => {
   }
   [/block]`;
   expect(process(emptyImage).children).toHaveLength(0);
+
+  const nullImage = `[block:image]
+  {
+    "images": [
+      {}
+    ]
+  }
+  [/block]`;
+  expect(process(nullImage).children).toHaveLength(0);
 });
 
 test('Sanitize Schema', () => {

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -120,7 +120,7 @@ function tokenize(eat, value) {
         .filter(e => e); // eslint-disable-line unicorn/prefer-array-find
       const img = imgs[0];
 
-      if (!img.url) return eat(match);
+      if (!img || !img.url) return eat(match);
       return eat(match)(WrapPinnedBlocks(img, json));
     }
     case 'callout': {

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -83,38 +83,41 @@ function tokenize(eat, value) {
       );
     }
     case 'image': {
-      const imgs = json.images.map(img => {
-        const [url, title] = img.image;
-        const size = img.sizing;
+      const imgs = json.images
+        .map(img => {
+          if (!('image' in img)) return null;
+          const [url, title] = img.image;
+          const size = img.sizing;
 
-        const block = {
-          type: 'image',
-          url,
-          title,
-          data: {
-            hProperties: {
-              className: img.border ? 'border' : '',
-              width: size && !size.match(/\D/) ? `${size}%` : imgSizeRemap[size] || size,
+          const block = {
+            type: 'image',
+            url,
+            title,
+            data: {
+              hProperties: {
+                className: img.border ? 'border' : '',
+                width: size && !size.match(/\D/) ? `${size}%` : imgSizeRemap[size] || size,
+              },
             },
-          },
-        };
+          };
 
-        if (!img.caption) return block;
+          if (!img.caption) return block;
 
-        return {
-          type: 'figure',
-          url,
-          data: { hName: 'figure' },
-          children: [
-            block,
-            {
-              type: 'figcaption',
-              data: { hName: 'figcaption' },
-              children: this.tokenizeBlock(img.caption, eat.now()),
-            },
-          ],
-        };
-      });
+          return {
+            type: 'figure',
+            url,
+            data: { hName: 'figure' },
+            children: [
+              block,
+              {
+                type: 'figcaption',
+                data: { hName: 'figcaption' },
+                children: this.tokenizeBlock(img.caption, eat.now()),
+              },
+            ],
+          };
+        })
+        .filter(e => e); // eslint-disable-line unicorn/prefer-array-find
       const img = imgs[0];
 
       if (!img.url) return eat(match);


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] | 💬  [Thread][thread]
:---:|:---:

## 🧰 Changes
In certain, very specific scenarios, empty magic image blocks would throw an error on parse:

- [x] Ignore + filter the `img` list for empty entries.
- [x] Add test case.

## 🧬 QA & Testing

- [Broken on production][prod].
- [~Working in this PR app~][demo].


[demo]: #tktktk "Pending an integration branch in ReadMe..."
[prod]: https://dev.kanad.dev/docs/empty-image-block
[thread]: https://readmeio.slack.com/archives/CC96MKA1E/p1620138248049400