### PR TITLE
docs: add category to each page

### DIFF
--- a/docs/callouts.md
+++ b/docs/callouts.md
@@ -1,5 +1,6 @@
 ---
 title: "Callouts"
+category: 5fdf7610134322007389a6ed
 slug: "callouts"
 hidden: false
 metadata: 

--- a/docs/code-block-tests.md
+++ b/docs/code-block-tests.md
@@ -1,5 +1,6 @@
 ---
 title: "Code Block Tests"
+category: 5fdf9fc9c2a7ef443e937315
 slug: "code-block-tests"
 hidden: true
 ---

--- a/docs/code-blocks.md
+++ b/docs/code-blocks.md
@@ -1,5 +1,6 @@
 ---
 title: "Code Blocks"
+category: 5fdf7610134322007389a6ed
 slug: "code-blocks"
 hidden: false
 ---

--- a/docs/custom-css.md
+++ b/docs/custom-css.md
@@ -1,5 +1,6 @@
 ---
 title: "Custom Styling"
+category: 5fdf7610134322007389a6ec
 slug: "custom-css"
 excerpt: "Styling best-practices and CSS selector references."
 hidden: false

--- a/docs/embeds.md
+++ b/docs/embeds.md
@@ -1,5 +1,6 @@
 ---
 title: "Embeds"
+category: 5fdf7610134322007389a6ed
 slug: "embeds"
 hidden: false
 ---

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,5 +1,6 @@
 ---
 title: "And more..."
+category: 5fdf7610134322007389a6ed
 slug: "features"
 excerpt: "Additional Markdown features of the ReadMe platform implementation."
 hidden: false

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+category: 5fdf7610134322007389a6ec
 slug: "getting-started"
 excerpt: "ReadMe's Markdown engine, with notes of GitHub, modern styles, and a hint of magic."
 hidden: false

--- a/docs/headings.md
+++ b/docs/headings.md
@@ -1,5 +1,6 @@
 ---
 title: "Headings"
+category: 5fdf7610134322007389a6ed
 slug: "headings"
 hidden: false
 ---

--- a/docs/images.md
+++ b/docs/images.md
@@ -1,5 +1,6 @@
 ---
 title: "Images"
+category: 5fdf7610134322007389a6ed
 slug: "images"
 hidden: false
 ---

--- a/docs/lists.md
+++ b/docs/lists.md
@@ -1,5 +1,6 @@
 ---
 title: "Lists"
+category: 5fdf7610134322007389a6ed
 slug: "lists"
 hidden: false
 ---

--- a/docs/syntax-extensions.md
+++ b/docs/syntax-extensions.md
@@ -1,5 +1,6 @@
 ---
 title: "Flavored Syntax"
+category: 5fdf7610134322007389a6ec
 slug: "syntax-extensions"
 excerpt: "Specs and examples of ReadMe's (restrained) Markdown syntax extensions."
 hidden: false

--- a/docs/table-of-contents-tests.md
+++ b/docs/table-of-contents-tests.md
@@ -1,5 +1,6 @@
 ---
 title: "Table Of Contents Tests"
+category: 5fdf9fc9c2a7ef443e937315
 slug: "table-of-contents-tests"
 hidden: true
 ---

--- a/docs/tables.md
+++ b/docs/tables.md
@@ -1,5 +1,6 @@
 ---
 title: "Tables"
+category: 5fdf7610134322007389a6ed
 slug: "tables"
 hidden: false
 ---

--- a/docs/variable-tests.md
+++ b/docs/variable-tests.md
@@ -1,5 +1,6 @@
 ---
 title: "Variable Tests"
+category: 5fdf9fc9c2a7ef443e937315
 slug: "variable-tests"
 hidden: true
 ---


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] |
:---:|

## 🧰 Changes

It appears that the rdme docs sync step of our release CI is failing: https://github.com/readmeio/markdown/runs/2833856744

```
Error: We couldn't save this doc (Path `category` is required.).
```
This commit adds the category in the front-matter of each page we're syncing! I have some doc updates in the pipeline (will open a separate PR for them!) but wanted to make sure this was resolved first.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-171.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
