### PR TITLE
ci: add another missing page category to get our docs syncing

### DIFF
--- a/docs/callout-tests.md
+++ b/docs/callout-tests.md
@@ -1,5 +1,6 @@
 ---
 title: "Callouts Tests"
+category: 5fdf9fc9c2a7ef443e937315
 slug: "callouts-tests"
 hidden: true
 ---

--- a/docs/callout-tests.md
+++ b/docs/callout-tests.md
@@ -1,7 +1,7 @@
 ---
 title: "Callouts Tests"
 category: 5fdf9fc9c2a7ef443e937315
-slug: "callouts-tests"
+slug: "callout-tests"
 hidden: true
 ---
 


### PR DESCRIPTION
## 🧰 Changes

So it looks like the sync step was _**partiallly**_ fixed in #171 (see [this page](https://rdmd.readme.io/docs/custom-css), which successfully updated!), but there was one page that I overlooked which ultimately [caused the workflow to fail](https://github.com/readmeio/markdown/runs/2896825988?check_suite_focus=true#step:8). Since this is a simple test page, I'm just backfilling the category for this page with our existing catch-all "Tests" category.

## 🧬 QA & Testing

I actually ran the `rdme` command locally this time and confirmed that the script ran successfully 🎉  If I am not crazy and you can in fact see [this page](https://rdmd.readme.io/docs/callouts-tests) in ReadMe, we should be good to go! See below for the full output when I ran the command locally:
![image](https://user-images.githubusercontent.com/8854718/123134484-70b1c680-d416-11eb-9bbc-064593b21d95.png)
