### PR TITLE
fix: typos in variable subpackage exports

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -6,6 +6,34 @@ const markdown = require('../index');
 const { tableFlattening } = require('../processor/plugin/table-flattening');
 const { options } = require('../options.js');
 
+test('it should have the proper utils exports', () => {
+  expect(typeof markdown.utils.BaseUrlContext).toBe('object');
+  expect(typeof markdown.utils.GlossaryContext).toBe('object');
+  expect(typeof markdown.utils.OauthContext).toBe('object');
+  expect(typeof markdown.utils.SelectedAppContext).toBe('object');
+  expect(typeof markdown.utils.Variable).toBe('function');
+  expect(typeof markdown.utils.VariablesContext).toBe('object');
+
+  expect(markdown.utils.VARIABLE_REGEXP).toBe('(?:\\\\)?<<([-\\w:.\\s]+)(?:\\\\)?>>');
+  expect(markdown.utils.options).toStrictEqual({
+    compatibilityMode: false,
+    copyButtons: true,
+    correctnewlines: false,
+    markdownOptions: {
+      fences: true,
+      commonmark: true,
+      gfm: true,
+      ruleSpaces: false,
+      listItemIndent: '1',
+      spacedTable: true,
+      paddedTable: true,
+      setext: true,
+    },
+    normalize: true,
+    settings: { position: false },
+  });
+});
+
 test('image', () => {
   expect(mount(markdown.default('![Image](http://example.com/image.png)')).html()).toMatchSnapshot();
 });

--- a/index.js
+++ b/index.js
@@ -86,9 +86,9 @@ export function setup(blocks, opts = {}) {
 export const utils = {
   BaseUrlContext,
   GlossaryContext: GlossaryItem.GlossaryContext,
-  OuathContext: Variable.OuathContext,
+  OauthContext: Variable.OauthContext,
   SelectedAppContext: Variable.SelectedAppContext,
-  VARIABLE_REGEX: Variable.VARIABLE_REGEX,
+  VARIABLE_REGEXP: Variable.VARIABLE_REGEXP,
   Variable: Variable.Variable,
   VariablesContext: Variable.VariablesContext,
   options,

--- a/variable/index.jsx
+++ b/variable/index.jsx
@@ -156,10 +156,13 @@ module.exports.Variable = props => (
 );
 
 module.exports.VariableComponent = Variable;
+
 // Regex to match the following:
 // - \<<apiKey\>> - escaped variables
 // - <<apiKey>> - regular variables
 // - <<glossary:glossary items>> - glossary
 module.exports.VARIABLE_REGEXP = /(?:\\)?<<([-\w:.\s]+)(?:\\)?>>/.source;
-module.exports.VariablesContext = VariablesContext;
+
+module.exports.OauthContext = OauthContext;
 module.exports.SelectedAppContext = SelectedAppContext;
+module.exports.VariablesContext = VariablesContext;


### PR DESCRIPTION
## 🧰 Changes

* [x] `VARIABLE_REGEXP` was being exported as `VARIABLE_REGEX`
* [x] `OauthContext` wasn't being exported from `./variable`
* [x] `OauthContext`, which was already not being exported, was being re-exported from `./` as `OuathContext`.
* [x] Added some sanity checks for the `utils` export.

## 🧬 QA & Testing

* [ ] Tests pass?