### PR TITLE
feat: export callout icons

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,11 +87,14 @@ export function setup(blocks, opts = {}) {
   return [`${blocks}\n\n `, opts];
 }
 
+const { icons: calloutIcons } = require('./processor/parse/flavored/callout');
+
 export const utils = {
   BaseUrlContext,
   GlossaryContext: GlossaryItem.GlossaryContext,
   options,
   VariablesContext: Variable.VariablesContext,
+  calloutIcons,
 };
 
 /**

--- a/processor/parse/flavored/callout.js
+++ b/processor/parse/flavored/callout.js
@@ -1,5 +1,8 @@
+// @note: We'd like to allow any emoji to match, but included in the emoji
+// character set is [#*0-9].
+// https://www.unicode.org/Public/13.0.0/ucd/emoji/emoji-data.txt
 // eslint-disable-next-line unicorn/no-unsafe-regex
-const rgx = /^> ?(\p{Emoji})(?: {0,}(.+))?\n((?:>(?: .*)?\n)*)/u;
+const rgx = /^> ?((?![#*0-9])\p{Emoji})(?: {0,}(.+))?\n((?:>(?: .*)?\n)*)/u;
 
 const themes = {
   '\uD83D\uDCD8': 'info',

--- a/processor/parse/flavored/callout.js
+++ b/processor/parse/flavored/callout.js
@@ -1,5 +1,27 @@
 // eslint-disable-next-line unicorn/no-unsafe-regex
-const rgx = /^> ?((?:\u2139|\u2049|\u2757|\u203C|\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff])+)(?: {0,}(.+))?\n((?:>(?: .*)?\n)*)/;
+const rgx = /^> ?(\p{Emoji})(?: {0,}(.+))?\n((?:>(?: .*)?\n)*)/u;
+
+const themes = {
+  '\uD83D\uDCD8': 'info',
+  '\u26A0\uFE0F': 'warn',
+  '\uD83D\uDEA7': 'warn',
+  '\uD83D\uDC4D': 'okay',
+  '\u2705': 'okay',
+  '\u2757': 'error',
+  '\u2757\uFE0F': 'error',
+  '\uD83D\uDED1': 'error',
+  '\u2049\uFE0F': 'error',
+  '\u203C\uFE0F': 'error',
+  '\u2139\uFE0F': 'info',
+  '\u26A0': 'warn',
+};
+
+const icons = Object.entries(themes).reduce((acc, [icon, theme]) => {
+  if (!acc[theme]) acc[theme] = [];
+  acc[theme].push(icon);
+
+  return acc;
+}, {});
 
 function tokenizer(eat, value) {
   if (!rgx.test(value)) return true;
@@ -11,20 +33,7 @@ function tokenizer(eat, value) {
   text = text.replace(/^>(?:(\n)|(\s)?)/gm, '$1').trim();
   title = title.trim();
 
-  const style = {
-    '\uD83D\uDCD8': 'info',
-    '\u26A0\uFE0F': 'warn',
-    '\uD83D\uDEA7': 'warn',
-    '\uD83D\uDC4D': 'okay',
-    '\u2705': 'okay',
-    '\u2757': 'error',
-    '\u2757\uFE0F': 'error',
-    '\uD83D\uDED1': 'error',
-    '\u2049\uFE0F': 'error',
-    '\u203C\uFE0F': 'error',
-    '\u2139\uFE0F': 'info',
-    '\u26A0': 'warn',
-  }[icon];
+  const style = themes[icon];
 
   return eat(match)({
     type: 'rdme-callout',
@@ -51,6 +60,8 @@ function parser() {
 }
 
 module.exports = parser;
+
+module.exports.icons = icons;
 
 module.exports.sanitize = sanitizeSchema => {
   const tags = sanitizeSchema.tagNames;


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] |
:---:|

## 🧰 Changes

Export the callout emoji map so it can be consumed by the markdown editor.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-219.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io