### PR TITLE
fix(a11y): making copy code button accessible

### DIFF
--- a/components/Code/index.jsx
+++ b/components/Code/index.jsx
@@ -21,7 +21,7 @@ function CopyCode({ codeRef, rootClass = 'rdmd-code-copy', className = '' }) {
       setTimeout(() => $el.classList.remove(copyClass), 1500);
     }
   };
-  return <button ref={button} className={`${rootClass} ${className}`} onClick={copier} />;
+  return <button ref={button} aria-label="Copy Code" className={`${rootClass} ${className}`} onClick={copier} />;
 }
 
 CopyCode.propTypes = {


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] | Fixes RM-1535
:---:|:---:

## 🧰 Changes

Added `aria-label` to button.rdme-code-copy.fa to make it accessible. Follow the links below and go to Lighthouse under dev tools, run the accessibility check, and you'll see that the buttons is now passing accessibility check!

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-228.herokuapp.com
[prod]: https://docs.readme.io/docs/custom-login-with-readme
