### PR TITLE
chore(deps): bumping syntax-highlighter to support graphql

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,11 @@
   "packages": {
     "": {
       "name": "@readme/markdown",
-      "version": "6.30.6-next.2",
+      "version": "6.30.6-next.3",
       "license": "MIT",
       "dependencies": {
         "@readme/emojis": "^3.0.0",
-        "@readme/syntax-highlighter": "^10.12.0",
+        "@readme/syntax-highlighter": "^10.13.0",
         "copy-to-clipboard": "^3.3.1",
         "hast-util-sanitize": "^4.0.0",
         "hast-util-to-string": "^1.0.4",
@@ -3485,11 +3485,12 @@
       }
     },
     "node_modules/@readme/syntax-highlighter": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.12.0.tgz",
-      "integrity": "sha512-aJ9/jPOd7gDYYaSuZHJhHBOZGBtWF5AiM1CYKXWxZeNTb0rlYJOKJS+QMztGRrt1O+oqn72HIUVFbm2v7dJfcA==",
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.13.0.tgz",
+      "integrity": "sha512-1Sq7cxk72aSE+//9D1XEkRnQsn84RTAW25//ajwpFki2PK7RZL/CcQ7ZUABbqOktSuUCIOA48gJHbBdMNVtYVw==",
       "dependencies": {
         "codemirror": "^5.48.2",
+        "codemirror-graphql": "^1.0.2",
         "prop-types": "^15.7.2",
         "react-codemirror2": "^7.2.1"
       },
@@ -5949,6 +5950,19 @@
       "version": "5.62.3",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.3.tgz",
       "integrity": "sha512-zZAyOfN8TU67ngqrxhOgtkSAGV9jSpN1snbl8elPtnh9Z5A11daR405+dhLzLnuXrwX0WCShWlybxPN3QC/9Pg=="
+    },
+    "node_modules/codemirror-graphql": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-1.0.2.tgz",
+      "integrity": "sha512-D4+BdYa6iQnDlio4mBk1Yap5ROCqEWapSFLkiKGatx/I0dF6euzdwd0um3Ndudw6rFQbNuT7hpcH8tnBO6VOfQ==",
+      "dependencies": {
+        "graphql-language-service-interface": "^2.8.2",
+        "graphql-language-service-parser": "^1.9.0"
+      },
+      "peerDependencies": {
+        "codemirror": "^5.54.0",
+        "graphql": ">= v14.5.0 <= 15.5.0"
+      }
     },
     "node_modules/collapse-white-space": {
       "version": "1.0.6",
@@ -10017,6 +10031,60 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
+    },
+    "node_modules/graphql": {
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-language-service-interface": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-2.8.4.tgz",
+      "integrity": "sha512-myW8z7HOZkYfhYGKDc0URFkTZChp41Po890W92zuBIhGccckgtiWSJGXaLX+r9QAwVIeZhKaNgEacsyvQb1f/g==",
+      "dependencies": {
+        "graphql-language-service-parser": "^1.9.0",
+        "graphql-language-service-types": "^1.8.0",
+        "graphql-language-service-utils": "^2.5.1",
+        "vscode-languageserver-types": "^3.15.1"
+      },
+      "peerDependencies": {
+        "graphql": ">= v14.5.0 <= 15.5.0"
+      }
+    },
+    "node_modules/graphql-language-service-parser": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.9.2.tgz",
+      "integrity": "sha512-3txms73cJsXDfJQdR5hI83N2rpTuq9FD6aijdrXAeSuI5B60g32DxjelUkt4Ge+2BvBEDLn5ppXlpVYDC9UQHQ==",
+      "dependencies": {
+        "graphql-language-service-types": "^1.8.0"
+      },
+      "peerDependencies": {
+        "graphql": ">= v14.5.0 <= 15.5.0"
+      }
+    },
+    "node_modules/graphql-language-service-types": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.8.2.tgz",
+      "integrity": "sha512-Sj07RHnMwAhEvAt7Jdt1l/x56ZpoNh+V6g+T58CF6GiYqI5l4vXqqRB4d4xHDcNQX98GpJfnf3o8BqPgP3C5Sw==",
+      "peerDependencies": {
+        "graphql": ">= v14.5.0 <= 15.5.0"
+      }
+    },
+    "node_modules/graphql-language-service-utils": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-2.5.3.tgz",
+      "integrity": "sha512-ydevEZ0AgzEKQF3hiCbLXuS0o7189Ww/T30WtCKCLaRHDYk9Yyb2PZWdhSTWLxYZTaX2TccV6NtFWvzIC7UP3g==",
+      "dependencies": {
+        "graphql-language-service-types": "^1.8.0",
+        "nullthrows": "^1.0.0"
+      },
+      "peerDependencies": {
+        "graphql": ">= v14.5.0 <= 15.5.0"
+      }
     },
     "node_modules/gray-matter": {
       "version": "4.0.2",
@@ -20478,6 +20546,11 @@
         "boolbase": "~1.0.0"
       }
     },
+    "node_modules/nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
+    },
     "node_modules/number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -25518,6 +25591,11 @@
         "unist-util-stringify-position": "^2.0.0"
       }
     },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -28945,11 +29023,12 @@
       }
     },
     "@readme/syntax-highlighter": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.12.0.tgz",
-      "integrity": "sha512-aJ9/jPOd7gDYYaSuZHJhHBOZGBtWF5AiM1CYKXWxZeNTb0rlYJOKJS+QMztGRrt1O+oqn72HIUVFbm2v7dJfcA==",
+      "version": "10.13.0",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.13.0.tgz",
+      "integrity": "sha512-1Sq7cxk72aSE+//9D1XEkRnQsn84RTAW25//ajwpFki2PK7RZL/CcQ7ZUABbqOktSuUCIOA48gJHbBdMNVtYVw==",
       "requires": {
         "codemirror": "^5.48.2",
+        "codemirror-graphql": "^1.0.2",
         "prop-types": "^15.7.2",
         "react-codemirror2": "^7.2.1"
       }
@@ -30941,6 +31020,15 @@
       "version": "5.62.3",
       "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.3.tgz",
       "integrity": "sha512-zZAyOfN8TU67ngqrxhOgtkSAGV9jSpN1snbl8elPtnh9Z5A11daR405+dhLzLnuXrwX0WCShWlybxPN3QC/9Pg=="
+    },
+    "codemirror-graphql": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-1.0.2.tgz",
+      "integrity": "sha512-D4+BdYa6iQnDlio4mBk1Yap5ROCqEWapSFLkiKGatx/I0dF6euzdwd0um3Ndudw6rFQbNuT7hpcH8tnBO6VOfQ==",
+      "requires": {
+        "graphql-language-service-interface": "^2.8.2",
+        "graphql-language-service-parser": "^1.9.0"
+      }
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -34246,6 +34334,46 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
+    },
+    "graphql": {
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "peer": true
+    },
+    "graphql-language-service-interface": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-2.8.4.tgz",
+      "integrity": "sha512-myW8z7HOZkYfhYGKDc0URFkTZChp41Po890W92zuBIhGccckgtiWSJGXaLX+r9QAwVIeZhKaNgEacsyvQb1f/g==",
+      "requires": {
+        "graphql-language-service-parser": "^1.9.0",
+        "graphql-language-service-types": "^1.8.0",
+        "graphql-language-service-utils": "^2.5.1",
+        "vscode-languageserver-types": "^3.15.1"
+      }
+    },
+    "graphql-language-service-parser": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.9.2.tgz",
+      "integrity": "sha512-3txms73cJsXDfJQdR5hI83N2rpTuq9FD6aijdrXAeSuI5B60g32DxjelUkt4Ge+2BvBEDLn5ppXlpVYDC9UQHQ==",
+      "requires": {
+        "graphql-language-service-types": "^1.8.0"
+      }
+    },
+    "graphql-language-service-types": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.8.2.tgz",
+      "integrity": "sha512-Sj07RHnMwAhEvAt7Jdt1l/x56ZpoNh+V6g+T58CF6GiYqI5l4vXqqRB4d4xHDcNQX98GpJfnf3o8BqPgP3C5Sw==",
+      "requires": {}
+    },
+    "graphql-language-service-utils": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-2.5.3.tgz",
+      "integrity": "sha512-ydevEZ0AgzEKQF3hiCbLXuS0o7189Ww/T30WtCKCLaRHDYk9Yyb2PZWdhSTWLxYZTaX2TccV6NtFWvzIC7UP3g==",
+      "requires": {
+        "graphql-language-service-types": "^1.8.0",
+        "nullthrows": "^1.0.0"
+      }
     },
     "gray-matter": {
       "version": "4.0.2",
@@ -42283,6 +42411,11 @@
         "boolbase": "~1.0.0"
       }
     },
+    "nullthrows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
+      "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw=="
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -46395,6 +46528,11 @@
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
       }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@readme/emojis": "^3.0.0",
-    "@readme/syntax-highlighter": "^10.12.0",
+    "@readme/syntax-highlighter": "^10.13.0",
     "copy-to-clipboard": "^3.3.1",
     "hast-util-sanitize": "^4.0.0",
     "hast-util-to-string": "^1.0.4",


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] |
:---:|

## 🧰 Changes

This bumps `@readme/syntax-highlighter` to allow for us to start highlighting GraphQL code. Available code language modes (the language that comes after the 3 backticks) that we'll support are `graphql` and `gql`.

## 📚 Release Notes
### 10.13.0 (2021-09-17)

* docs: adding a code of conduct ([41d91b5](https://github.com/readmeio/syntax-highlighter/commit/41d91b5))
* feat: adding highlight support for graphql (#173) ([8ffcb52](https://github.com/readmeio/syntax-highlighter/commit/8ffcb52)), closes [#173](https://github.com/readmeio/syntax-highlighter/issues/173)


[demo]: https://markdown-pr-309.herokuapp.com
[prod]: https://rdme.readme.io
