### PR TITLE
chore(compatMode): normalize compact header spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,8 +65,12 @@ export function setup(blocks, opts = {}) {
   // merge default and user options
   opts = parseOptions(opts);
 
-  // normalize magic block linebreaks
   if (opts.normalize && blocks) {
+    if (opts.compatibilityMode) {
+      // Add spaces to "compact" heading syntax.
+      blocks = blocks.replace(/([^\n]\n#+)(\s?)(.*)/gm, '$1 $3');
+    }
+    // Normalize magic block linebreaks.
     blocks = blocks
       .replace(/\[block:/g, '\n\n[block:')
       .replace(/\[\/block\]/g, '[/block]\n')

--- a/processor/parse/compact-headings.js
+++ b/processor/parse/compact-headings.js
@@ -1,4 +1,4 @@
-const rgx = /^(#+)([^\n]+)\n{1,}/;
+const rgx = /^(#+)([^\n]+)\n+/;
 
 function tokenizer(eat, value) {
   if (!rgx.test(value)) return true;


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] | Fixes RM-2327
:---:|:---:

## 🧰 Changes

- [x] Add `compatibilityMode`-only logic to normalize the spacing between markdown heading prefixes and content when using the "compact" hash notation.

## 🧬 QA & Testing
Check out this branch, [turn on compat mode][compatmode], and `start` the local environment. Then paste **the following markdown** in to the editor on the left hand side of the playground. If all of the headings render correctly, this worked! :tada:

<details>
<summary><b>Test Markdown:</b></summary>

```markdown
[block:api-header]{
}[/block]
### [Blocks](doc:compose-build) 
Create and deploy your conversational messaging experiences across platforms. 
###[Reengagements](doc:reengagement) 
Send targeted and automated messages to users. 
###[Acquisition](doc:acquisition)
Grow and track your audience across a variety of sources. 

###[NLP](doc:nlp)
Build and train your bot's natural language understanding in order to respond to a diverse array of customer requests and inquiries.
### [Analytics](doc:content)
Analyze and track the most important metrics for your bot.

[block:api-header]{
}[/block]
```

</details>


[demo]: https://markdown-pr-326.herokuapp.com
[compatmode]: https://github.com/readmeio/markdown/blob/next/options.js#L2