### PR TITLE
fix: use TLS for npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   "homepage": "https://rdmd.readme.io",
   "repository": "https://github.com/readmeio/markdown",
   "publishConfig": {
-    "registry": "http://registry.npmjs.org",
+    "registry": "https://registry.npmjs.org",
     "access": "public"
   },
   "prettier": "@readme/eslint-config/prettier",

--- a/package.json
+++ b/package.json
@@ -110,10 +110,6 @@
   "license": "MIT",
   "homepage": "https://rdmd.readme.io",
   "repository": "https://github.com/readmeio/markdown",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org",
-    "access": "public"
-  },
   "prettier": "@readme/eslint-config/prettier",
   "bundlewatch": {
     "files": [


### PR DESCRIPTION
## 🧰 Changes

Update the npm registry URL to use TLS.
