### PR TITLE
fix: allow indented code on first line

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -31,6 +31,20 @@ exports[`check list items 1`] = `
 </ul>"
 `;
 
+exports[`code samples should parse indented code on the first line 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "lang": null,
+      "meta": null,
+      "type": "code",
+      "value": "const code = true;",
+    },
+  ],
+  "type": "root",
+}
+`;
+
 exports[`emojis 1`] = `
 "<p><img src=\\"/img/emojis/joy.png\\" alt=\\":joy:\\" title=\\":joy:\\" class=\\"emoji\\" align=\\"absmiddle\\" height=\\"20\\" width=\\"20\\" caption=\\"\\" loading=\\"lazy\\"><br>
 <i class=\\"fa fa-lock\\"></i><br>

--- a/__tests__/flavored-parsers/callouts.test.js
+++ b/__tests__/flavored-parsers/callouts.test.js
@@ -16,7 +16,8 @@ describe('Parse RDMD Callouts', () => {
 > ℹ️ Info Callout
 >
 > <span>With html!</span>
-      `;
+`;
+
       expect(mdast(text)).toMatchSnapshot();
     });
   });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -201,6 +201,11 @@ describe('code samples', () => {
       expect(elem.find('button')).toHaveLength(0);
     });
   });
+
+  it('should parse indented code on the first line', () => {
+    const md = '    const code = true;';
+    expect(markdown.mdast(md)).toMatchSnapshot();
+  });
 });
 
 test('should render nothing if nothing passed in', () => {
@@ -253,15 +258,17 @@ describe('tree flattening', () => {
   it('should bring nested mdast data up to the top child level', () => {
     const text = `
 
-    |  | Col. B  |
-    |:-------:|:-------:|
-    | Cell A1 | Cell B1 |
-    | Cell A2 | Cell B2 |
-    | Cell A3 | |
+|  | Col. B  |
+|:-------:|:-------:|
+| Cell A1 | Cell B1 |
+| Cell A2 | Cell B2 |
+| Cell A3 | |
 
     `;
 
-    const table = markdown.hast(text).children[1];
+    const hast = markdown.hast(text);
+    const table = hast.children[1];
+
     expect(table.children).toHaveLength(2);
     expect(table.children[0].value).toStrictEqual('Col. B');
     expect(table.children[1].value).toStrictEqual('Cell A1 Cell B1 Cell A2 Cell B2 Cell A3');

--- a/__tests__/table-flattening/index.test.js
+++ b/__tests__/table-flattening/index.test.js
@@ -18,10 +18,10 @@ describe('astToPlainText with tables', () => {
 
   it('includes formatted text', () => {
     const text = `
-      | *Col. A*  | Col. *B*  |
-      |:---------:|:---------:|
-      | Cell *A1* | *Cell B1* |
-      | *Cell* A2 | *Cell* B2 |`;
+| *Col. A*  | Col. *B*  |
+|:---------:|:---------:|
+| Cell *A1* | *Cell B1* |
+| *Cell* A2 | *Cell* B2 |`;
 
     expect(astToPlainText(hast(text))).toMatchInlineSnapshot(`
       "

--- a/index.js
+++ b/index.js
@@ -71,10 +71,7 @@ export function setup(blocks, opts = {}) {
 
   // normalize magic block linebreaks
   if (opts.normalize && blocks) {
-    blocks = blocks
-      .replace(/\[block:/g, '\n\n[block:')
-      .replace(/\[\/block\]/g, '[/block]\n')
-      .trim();
+    blocks = blocks.replace(/\[block:/g, '\n\n[block:').replace(/\[\/block\]/g, '[/block]\n');
   }
 
   return [`${blocks}\n\n `, opts];


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] |
:---:|

## 🧰 Changes

Allows starting a markdown doc with indented code. It looks like we were trimming off all whitespace, which mess with leading indented code blocks.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-362.herokuapp.com
[prod]: https://kjp-examples.readme.io/docs/leading-code-indentation