### PR TITLE
feat: less lossy md()

### DIFF
--- a/__tests__/__snapshots__/flavored-compilers.test.js.snap
+++ b/__tests__/__snapshots__/flavored-compilers.test.js.snap
@@ -1,12 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ReadMe Flavored Blocks Embed 1`] = `
-"[Embedded meta links.](https://nyti.me/s/gzoa2xb2v3 \\"@nyt\\")
 "
-`;
-
-exports[`ReadMe Flavored Blocks Emojis 1`] = `
-"![:smiley:](/img/emojis/smiley.png \\":smiley:\\")
+[block:embed]
+{
+  \\"title\\": \\"Embedded meta links.\\",
+  \\"url\\": \\"https://nyti.me/s/gzoa2xb2v3\\",
+  \\"provider\\": \\"nyt\\"
+}
+[/block]
 "
 `;
 
@@ -32,20 +34,34 @@ console.log('an unnamed sample snippet');
 `;
 
 exports[`ReadMe Magic Blocks Embed 1`] = `
-"[](https://youtu.be/J3-uKv1DShQ \\"@youtu.be\\")
+"
+[block:embed]
+{
+  \\"html\\": false,
+  \\"url\\": \\"https://youtu.be/J3-uKv1DShQ\\",
+  \\"title\\": null,
+  \\"favicon\\": \\"https://youtu.be/favicon.ico\\",
+  \\"provider\\": \\"youtu.be\\",
+  \\"href\\": \\"https://youtu.be/J3-uKv1DShQ\\"
+}
+[/block]
 "
 `;
 
 exports[`ReadMe Magic Blocks Figure 1`] = `
-"<div class=\\"rdmd-pinned\\">
-
-<figure>
-
-![Ok, pizza man.](https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg \\"rdme-blue.svg\\")
-
-<figcaption>Ok, pizza man.</figcaption>
-</figure>
-
-</div>
+"[block:image]
+{
+  \\"images\\": [
+    {
+      \\"image\\": [
+        \\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\",
+        \\"rdme-blue.svg\\"
+      ],
+      \\"caption\\": \\"Ok, pizza man.\\",
+      \\"sizing\\": \\"80\\"
+    }
+  ]
+}
+[/block]
 "
 `;

--- a/__tests__/__snapshots__/flavored-compilers.test.js.snap
+++ b/__tests__/__snapshots__/flavored-compilers.test.js.snap
@@ -57,7 +57,7 @@ exports[`ReadMe Magic Blocks Figure 1`] = `
         \\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\",
         \\"rdme-blue.svg\\"
       ],
-      \\"caption\\": \\"Ok, pizza man.\\",
+      \\"caption\\": \\"Ok, **pizza** man.\\",
       \\"sizing\\": \\"80\\"
     }
   ]

--- a/__tests__/__snapshots__/flavored-compilers.test.js.snap
+++ b/__tests__/__snapshots__/flavored-compilers.test.js.snap
@@ -5,6 +5,11 @@ exports[`ReadMe Flavored Blocks Embed 1`] = `
 "
 `;
 
+exports[`ReadMe Flavored Blocks Emojis 1`] = `
+"![:smiley:](/img/emojis/smiley.png \\":smiley:\\")
+"
+`;
+
 exports[`ReadMe Magic Blocks Callouts 1`] = `
 "> 👍 Success
 > 

--- a/__tests__/flavored-compilers.test.js
+++ b/__tests__/flavored-compilers.test.js
@@ -32,6 +32,13 @@ describe('ReadMe Flavored Blocks', () => {
       "
     `);
   });
+
+  it('Emojis', () => {
+    expect(compile(parse(':smiley:'))).toMatchInlineSnapshot(`
+      ":smiley:
+      "
+    `);
+  });
 });
 
 describe('ReadMe Magic Blocks', () => {

--- a/__tests__/flavored-compilers.test.js
+++ b/__tests__/flavored-compilers.test.js
@@ -101,15 +101,12 @@ describe('ReadMe Magic Blocks', () => {
         {
           "image": [
             "https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg",
-            "rdme-blue.svg",
-            300,
-            54,
-            "#000000"
+            "rdme-blue.svg"
           ],
-          "caption": "Ok, pizza man."
+          "caption": "Ok, pizza man.",
+          "sizing": "80"
         }
-      ],
-      "sidebar": true
+      ]
     }
     [/block]`;
     const ast = parse(txt);

--- a/__tests__/flavored-compilers.test.js
+++ b/__tests__/flavored-compilers.test.js
@@ -103,7 +103,7 @@ describe('ReadMe Magic Blocks', () => {
             "https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg",
             "rdme-blue.svg"
           ],
-          "caption": "Ok, pizza man.",
+          "caption": "Ok, __pizza__ man.",
           "sizing": "80"
         }
       ]

--- a/processor/compile/embed.js
+++ b/processor/compile/embed.js
@@ -1,10 +1,13 @@
 function EmbedCompiler(node) {
-  const { title, url } = node.data.hProperties;
+  const data = node.data.hProperties;
+  let { provider = 'embed' } = data;
+  provider = provider.replace(/^@/, '');
 
-  let { provider = '@embed' } = node.data.hProperties;
-  provider = provider[0] === '@' ? provider : `@${provider}`;
-
-  return `[${title || ''}](${url} "${provider}")`;
+  return `
+[block:embed]
+${JSON.stringify({ ...data, provider }, null, 2)}
+[/block]
+`;
 }
 
 module.exports = function () {

--- a/processor/compile/figure.js
+++ b/processor/compile/figure.js
@@ -1,21 +1,28 @@
 const nodeToString = require('hast-util-to-string');
 
+const { imgSizeByWidth } = require('../parse/magic-block-parser');
+
 module.exports = function FigureCompiler() {
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
 
-  visitors.figcaption = function figcaptionCompiler(node) {
-    const caption = nodeToString(node);
-    return `<figcaption>${caption}</figcaption>`;
-  };
-
   visitors.figure = function figureCompiler(node) {
     const [image, caption] = node.children;
-    return `<figure>
 
-${visitors.image.call(this, image)}
+    const img = {
+      image: [image.url, image.title],
+      caption: nodeToString(caption),
+      sizing: imgSizeByWidth[image.data.hProperties.width],
+    };
 
-${visitors.figcaption.call(this, caption)}
-</figure>`;
+    if (image.border) img.border = image.border;
+
+    const block = {
+      images: [img],
+    };
+
+    return `[block:image]
+${JSON.stringify(block, null, 2)}
+[/block]`;
   };
 };

--- a/processor/compile/figure.js
+++ b/processor/compile/figure.js
@@ -1,5 +1,3 @@
-const nodeToString = require('hast-util-to-string');
-
 const { imgSizeByWidth } = require('../parse/magic-block-parser');
 
 module.exports = function FigureCompiler() {
@@ -11,7 +9,7 @@ module.exports = function FigureCompiler() {
 
     const img = {
       image: [image.url, image.title],
-      caption: nodeToString(caption),
+      caption: this.block(caption),
       sizing: imgSizeByWidth[image.data.hProperties.width],
     };
 

--- a/processor/compile/image.js
+++ b/processor/compile/image.js
@@ -1,0 +1,9 @@
+module.exports = function ImageCompiler() {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+  const { image: original } = visitors;
+
+  visitors.image = function compile(node, ...args) {
+    return node.data.hProperties.className === 'emoji' ? node.title : original(node, ...args);
+  };
+};

--- a/processor/compile/image.js
+++ b/processor/compile/image.js
@@ -4,6 +4,6 @@ module.exports = function ImageCompiler() {
   const { image: original } = visitors;
 
   visitors.image = function compile(node, ...args) {
-    return node.data.hProperties.className === 'emoji' ? node.title : original(node, ...args);
+    return node.data.hProperties.className === 'emoji' ? node.title : original.call(this, node, ...args);
   };
 };

--- a/processor/compile/image.js
+++ b/processor/compile/image.js
@@ -4,6 +4,6 @@ module.exports = function ImageCompiler() {
   const { image: original } = visitors;
 
   visitors.image = function compile(node, ...args) {
-    return node.data.hProperties.className === 'emoji' ? node.title : original.call(this, node, ...args);
+    return node.data?.hProperties?.className === 'emoji' ? node.title : original.call(this, node, ...args);
   };
 };

--- a/processor/compile/index.js
+++ b/processor/compile/index.js
@@ -7,3 +7,4 @@ export { default as rdmeEmbedCompiler } from './embed';
 export { default as rdmeVarCompiler } from './var';
 export { default as rdmeCalloutCompiler } from './callout';
 export { default as rdmePinCompiler } from './pin';
+export { default as imageCompiler } from './image';


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] | Fixes RM-2780
:---:|:---:

## 🧰 Changes

Fixes converting mdast to md for some node types.

<dl>
  <dt>emojis</dt>
	<dd>Were saving as images, now they save in the short code format.</dd>
  <dt>embeds</dt>
	<dd>Were saving as links, now they save in magic block format. This decision was made for expediency. To eventually save them as links, we ought to update RDMD to parse link formatted embeds.</dd>
  <dt>figures</dt>
	<dd>Were saving as images, now they save in magic block format. Until we decide on a proper syntax for captions and sizing, we're forced to use magic block format.</dd>
</dl>

## 🧬 QA & Testing

- [ ] tests pass?

[demo]: https://markdown-pr-377.herokuapp.com