### PR TITLE
feat: more compiler updates

### DIFF
--- a/__tests__/flavored-compilers.test.js
+++ b/__tests__/flavored-compilers.test.js
@@ -47,7 +47,7 @@ describe('ReadMe Flavored Blocks', () => {
     `);
   });
 
-  it.only('Html Block', () => {
+  it('Html Block', () => {
     const text = `
 [block:html]
 {

--- a/__tests__/flavored-compilers.test.js
+++ b/__tests__/flavored-compilers.test.js
@@ -33,11 +33,40 @@ describe('ReadMe Flavored Blocks', () => {
     `);
   });
 
+  it('Glossary Items', () => {
+    expect(compile(parse('<<glossary:owl>>'))).toMatchInlineSnapshot(`
+      "<<glossary:owl>>
+      "
+    `);
+  });
+
   it('Emojis', () => {
     expect(compile(parse(':smiley:'))).toMatchInlineSnapshot(`
       ":smiley:
       "
     `);
+  });
+
+  it.only('Html Block', () => {
+    const text = `
+[block:html]
+{
+  "html": ${JSON.stringify(
+    '<style>\n  summary {\n    padding-top: 8px;\n    outline: none !important;\n    user-select: none;\n  }\n  details[open] + details > summary {\n    padding-top: 0;\n  }\n  details > summary + hr {\n    opacity: .66;\n  }\n</style>'
+  )}
+}
+[/block]
+`;
+    const ast = parse(text);
+
+    expect(compile(ast)).toMatchInlineSnapshot(`
+"[block:html]
+{
+  \\"html\\": \\"<style>\\\\n  summary {\\\\n    padding-top: 8px;\\\\n    outline: none !important;\\\\n    user-select: none;\\\\n  }\\\\n  details[open] + details > summary {\\\\n    padding-top: 0;\\\\n  }\\\\n  details > summary + hr {\\\\n    opacity: .66;\\\\n  }\\\\n</style>\\"
+}
+[/block]
+"
+`);
   });
 });
 

--- a/processor/compile/glossary.js
+++ b/processor/compile/glossary.js
@@ -1,0 +1,6 @@
+module.exports = function RdmeGlossaryCompiler() {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+
+  visitors['readme-glossary-item'] = node => `<<glossary:${node.data.hProperties.term}>>`;
+};

--- a/processor/compile/html-block.js
+++ b/processor/compile/html-block.js
@@ -1,0 +1,9 @@
+module.exports = function () {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+
+  visitors['html-block'] = node => {
+    const html = node.data.hProperties.html;
+    return `[block:html]\n${JSON.stringify({ html }, null, 2)}\n[/block]`;
+  };
+};

--- a/processor/compile/index.js
+++ b/processor/compile/index.js
@@ -5,6 +5,8 @@ export { default as figureCompiler } from './figure';
 export { default as codeTabsCompiler } from './code-tabs';
 export { default as rdmeEmbedCompiler } from './embed';
 export { default as rdmeVarCompiler } from './var';
+export { default as rdmeGlossaryCompiler } from './glossary';
 export { default as rdmeCalloutCompiler } from './callout';
 export { default as rdmePinCompiler } from './pin';
 export { default as imageCompiler } from './image';
+export { default as htmlBlockCompiler } from './html-block';


### PR DESCRIPTION
## 🧰 Changes

Adds compilers for `html-block` and `readme-glossary-item`.

## 🧬 QA & Testing

- [ ] tests pass?
