### PR TITLE
fix: allow undefined code children

### DIFF
--- a/__tests__/components/Code.test.jsx
+++ b/__tests__/components/Code.test.jsx
@@ -24,4 +24,10 @@ describe('Code', () => {
 
     expect(copy).toHaveBeenCalledWith(expect.stringMatching(/VARIABLE_SUBSTITUTED/));
   });
+
+  it('allows undefined children?!', () => {
+    const code = mount(<Code />);
+
+    expect(code.text()).toBe('');
+  });
 });

--- a/components/Code/index.jsx
+++ b/components/Code/index.jsx
@@ -49,7 +49,9 @@ function Code(props) {
     tokenizeVariables: true,
     dark: theme === 'dark',
   };
-  const codeContent = syntaxHighlighter ? syntaxHighlighter(children[0], language, codeOpts) : children[0];
+
+  const codeContent =
+    syntaxHighlighter && children ? syntaxHighlighter(children[0], language, codeOpts) : children?.[0] || '';
 
   return (
     <React.Fragment>
@@ -76,7 +78,7 @@ function CreateCode(sanitizeSchema, { copyButtons, theme }) {
 }
 
 Code.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.string).isRequired,
+  children: PropTypes.arrayOf(PropTypes.string),
   className: PropTypes.string,
   copyButtons: PropTypes.bool,
   lang: PropTypes.string,

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "node-sass": "^6.0.1",
         "prettier": "^2.5.0",
         "puppeteer": "^12.0.1",
-        "rdme": "^6.0.0",
+        "rdme": "^6.0.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
         "react-hot-loader": "^4.13.0",
@@ -3646,35 +3646,53 @@
         "prettier": "^2.0.2"
       }
     },
-    "node_modules/@readme/openapi-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.0.tgz",
-      "integrity": "sha512-pa5zWTU6Xp3TOI6fMDtbmEv5bF3w8ThFNtvMROiQyIMFAfge4q6QTLU6KiGLOjfW/QcuHV6reRApmAyyY0cjFw==",
+    "node_modules/@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
       "dev": true,
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@readme/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/@readme/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@readme/openapi-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
+      "dev": true,
+      "dependencies": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
         "ajv": "^8.6.3",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
       "peerDependencies": {
         "openapi-types": ">=7"
-      }
-    },
-    "node_modules/@readme/openapi-parser/node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "0.0.0-dev",
-      "resolved": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/ajv": {
@@ -3705,24 +3723,6 @@
         "ajv": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@readme/openapi-parser/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/@readme/openapi-parser/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@readme/openapi-parser/node_modules/json-schema-traverse": {
@@ -19326,9 +19326,9 @@
       "dev": true
     },
     "node_modules/oas": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.0.tgz",
-      "integrity": "sha512-IOIN50QINeTaTvJjtYPxI8YUmTVCZ7Ex6VTsYZM/yopqnEQoY80KSKAgkQjRSGxG9DYFr5i7GHT6oFYhyYPU8Q==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.1.tgz",
+      "integrity": "sha512-Txvl22IoYdtseZc7UXfL36/wcnb2YlQqoDtu+ksODKpcjR6qLlfsZOxlenhT2Lfqu5epxndL4IqrRy+0dmKMmw==",
       "dev": true,
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
@@ -19342,7 +19342,7 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.0.1",
+        "oas-normalize": "^5.0.5",
         "openapi-types": "^9.3.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^5.0.2"
@@ -19378,12 +19378,12 @@
       }
     },
     "node_modules/oas-normalize": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.3.tgz",
-      "integrity": "sha512-9LTMftmjA1YI2I8L1liwkW276zUoyyRTBOBxA1Q9iOiIiHwXtU65nIe6zsNVzwCYWA1NQdEjpEnagSVN+ZHwng==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
+      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
       "dev": true,
       "dependencies": {
-        "@readme/openapi-parser": "^1.1.0",
+        "@readme/openapi-parser": "^1.2.1",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -20911,9 +20911,9 @@
       }
     },
     "node_modules/rdme": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rdme/-/rdme-6.0.0.tgz",
-      "integrity": "sha512-CZSr2kUTj9xJhW6Ax2FGUE0khHMM7PyXNXHLAa869rCnKrkRLwi32I/E2j9mOICytq07RNTKc8Q8iqyV6ImvOg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rdme/-/rdme-6.0.1.tgz",
+      "integrity": "sha512-pua/8lHeEB4TwaUm4SjQXr0MfYAbw+ByNfjV7KSptO0bixIAoDAF7XHlHjc49KnXkHYk2NpDiPRCZ00pZI9b2w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -20928,8 +20928,8 @@
         "gray-matter": "^4.0.1",
         "isemail": "^3.1.3",
         "node-fetch": "^2.6.1",
-        "oas": "^17.2.0",
-        "oas-normalize": "^5.0.3",
+        "oas": "^17.3.1",
+        "oas-normalize": "^5.0.5",
         "open": "^8.2.1",
         "parse-link-header": "^1.0.1",
         "read": "^1.0.7",
@@ -27949,33 +27949,51 @@
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       }
     },
-    "@readme/openapi-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.0.tgz",
-      "integrity": "sha512-pa5zWTU6Xp3TOI6fMDtbmEv5bF3w8ThFNtvMROiQyIMFAfge4q6QTLU6KiGLOjfW/QcuHV6reRApmAyyY0cjFw==",
+    "@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
       "dev": true,
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
+      }
+    },
+    "@readme/openapi-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
+      "dev": true,
+      "requires": {
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
         "ajv": "^8.6.3",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
       },
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": {
-          "version": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-          "dev": true,
-          "from": "@apidevtools/json-schema-ref-parser@github:erunion/json-schema-ref-parser#fix/dates-as-strings",
-          "requires": {
-            "@jsdevtools/ono": "^7.1.3",
-            "@types/json-schema": "^7.0.6",
-            "call-me-maybe": "^1.0.1",
-            "js-yaml": "^4.1.0"
-          }
-        },
         "ajv": {
           "version": "8.8.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
@@ -27994,21 +28012,6 @@
           "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
           "dev": true,
           "requires": {}
-        },
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "dev": true,
-          "requires": {
-            "argparse": "^2.0.1"
-          }
         },
         "json-schema-traverse": {
           "version": "1.0.0",
@@ -40081,9 +40084,9 @@
       "dev": true
     },
     "oas": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.0.tgz",
-      "integrity": "sha512-IOIN50QINeTaTvJjtYPxI8YUmTVCZ7Ex6VTsYZM/yopqnEQoY80KSKAgkQjRSGxG9DYFr5i7GHT6oFYhyYPU8Q==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/oas/-/oas-17.3.1.tgz",
+      "integrity": "sha512-Txvl22IoYdtseZc7UXfL36/wcnb2YlQqoDtu+ksODKpcjR6qLlfsZOxlenhT2Lfqu5epxndL4IqrRy+0dmKMmw==",
       "dev": true,
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^9.0.6",
@@ -40097,7 +40100,7 @@
         "jsonpointer": "^5.0.0",
         "memoizee": "^0.4.14",
         "minimist": "^1.2.0",
-        "oas-normalize": "^5.0.1",
+        "oas-normalize": "^5.0.5",
         "openapi-types": "^9.3.0",
         "path-to-regexp": "^6.2.0",
         "swagger-inline": "^5.0.2"
@@ -40181,12 +40184,12 @@
       }
     },
     "oas-normalize": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.3.tgz",
-      "integrity": "sha512-9LTMftmjA1YI2I8L1liwkW276zUoyyRTBOBxA1Q9iOiIiHwXtU65nIe6zsNVzwCYWA1NQdEjpEnagSVN+ZHwng==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/oas-normalize/-/oas-normalize-5.0.5.tgz",
+      "integrity": "sha512-Ob+yK3Xh3fJn15rg7iu9ib+hHoHMwmIR0WBfhzX17eJU+LWEYMtaiYes3080ic4QE4O36FkIwuUMIyDCNv0OuQ==",
       "dev": true,
       "requires": {
-        "@readme/openapi-parser": "^1.1.0",
+        "@readme/openapi-parser": "^1.2.1",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "swagger2openapi": "^7.0.8"
@@ -41293,9 +41296,9 @@
       }
     },
     "rdme": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rdme/-/rdme-6.0.0.tgz",
-      "integrity": "sha512-CZSr2kUTj9xJhW6Ax2FGUE0khHMM7PyXNXHLAa869rCnKrkRLwi32I/E2j9mOICytq07RNTKc8Q8iqyV6ImvOg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rdme/-/rdme-6.0.1.tgz",
+      "integrity": "sha512-pua/8lHeEB4TwaUm4SjQXr0MfYAbw+ByNfjV7KSptO0bixIAoDAF7XHlHjc49KnXkHYk2NpDiPRCZ00pZI9b2w==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
@@ -41310,8 +41313,8 @@
         "gray-matter": "^4.0.1",
         "isemail": "^3.1.3",
         "node-fetch": "^2.6.1",
-        "oas": "^17.2.0",
-        "oas-normalize": "^5.0.3",
+        "oas": "^17.3.1",
+        "oas-normalize": "^5.0.5",
         "open": "^8.2.1",
         "parse-link-header": "^1.0.1",
         "read": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "node-sass": "^6.0.1",
     "prettier": "^2.5.0",
     "puppeteer": "^12.0.1",
-    "rdme": "^6.0.0",
+    "rdme": "^6.0.1",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-hot-loader": "^4.13.0",


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] |
:---:|

## 🧰 Changes

It's possible to generate a react tree with an empty code block. This adds checks to the Code component to allow this.

Example:
```
<code></code>
```

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://dash.readme.com/project/kjp/v1.0/docs/empty-code-block
