### PR TITLE
fix: bumping @readme/syntax-highlighter to resolve upstram webpack issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@readme/emojis": "^4.0.0",
-        "@readme/syntax-highlighter": "^10.14.0",
+        "@readme/syntax-highlighter": "^10.14.1",
         "copy-to-clipboard": "^3.3.1",
         "hast-util-sanitize": "^4.0.0",
         "hast-util-to-string": "^1.0.4",
@@ -3732,12 +3732,12 @@
       "dev": true
     },
     "node_modules/@readme/syntax-highlighter": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.14.0.tgz",
-      "integrity": "sha512-E6itbZigYPNHY5/9t0uYL5VkgnWdXfEzJ4PnfhlsOP9ih/D8JL8ZfscijJmpumei/Cat457mOltZB27QFeiUhw==",
+      "version": "10.14.1",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.14.1.tgz",
+      "integrity": "sha512-Bk4WWJ6VRLnYp80IKGwKi8VIa0gjJiB+TbZ4Pn5F05De31VV+oYN9xxOmzyBlhQv9nXWGWL4mMFIKoUcGJD7pg==",
       "dependencies": {
-        "codemirror": "^5.48.2",
-        "codemirror-graphql": "^1.0.2",
+        "codemirror": "5.54.0",
+        "codemirror-graphql": "1.0.2",
         "prop-types": "^15.7.2",
         "react-codemirror2": "^7.2.1"
       },
@@ -3746,6 +3746,11 @@
         "react": "16.x",
         "react-dom": "16.x"
       }
+    },
+    "node_modules/@readme/syntax-highlighter/node_modules/codemirror": {
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.54.0.tgz",
+      "integrity": "sha512-Pgf3surv4zvw+KaW3doUU7pGjF0BPU8/sj7eglWJjzni46U/DDW8pu3nZY0QgQKUcICDXRkq8jZmq0y6KhxM3Q=="
     },
     "node_modules/@readme/variable": {
       "version": "13.6.0",
@@ -28022,14 +28027,21 @@
       }
     },
     "@readme/syntax-highlighter": {
-      "version": "10.14.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.14.0.tgz",
-      "integrity": "sha512-E6itbZigYPNHY5/9t0uYL5VkgnWdXfEzJ4PnfhlsOP9ih/D8JL8ZfscijJmpumei/Cat457mOltZB27QFeiUhw==",
+      "version": "10.14.1",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.14.1.tgz",
+      "integrity": "sha512-Bk4WWJ6VRLnYp80IKGwKi8VIa0gjJiB+TbZ4Pn5F05De31VV+oYN9xxOmzyBlhQv9nXWGWL4mMFIKoUcGJD7pg==",
       "requires": {
-        "codemirror": "^5.48.2",
-        "codemirror-graphql": "^1.0.2",
+        "codemirror": "5.54.0",
+        "codemirror-graphql": "1.0.2",
         "prop-types": "^15.7.2",
         "react-codemirror2": "^7.2.1"
+      },
+      "dependencies": {
+        "codemirror": {
+          "version": "5.54.0",
+          "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.54.0.tgz",
+          "integrity": "sha512-Pgf3surv4zvw+KaW3doUU7pGjF0BPU8/sj7eglWJjzni46U/DDW8pu3nZY0QgQKUcICDXRkq8jZmq0y6KhxM3Q=="
+        }
       }
     },
     "@readme/variable": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@readme/emojis": "^4.0.0",
-    "@readme/syntax-highlighter": "^10.14.0",
+    "@readme/syntax-highlighter": "^10.14.1",
     "copy-to-clipboard": "^3.3.1",
     "hast-util-sanitize": "^4.0.0",
     "hast-util-to-string": "^1.0.4",


### PR DESCRIPTION
## 🧰 Changes

Having issues upstream in ReadMe with the latest `@readme/syntax-highlighter` and its fresh release of `codemirror` so I bumped it back down.

See https://github.com/readmeio/syntax-highlighter/pull/222 for details.