### PR TITLE
fix: upgrading syntax-highlighter to the latest release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@readme/emojis": "^4.0.0",
-        "@readme/syntax-highlighter": "^10.14.1",
+        "@readme/syntax-highlighter": "^10.14.3",
         "copy-to-clipboard": "^3.3.1",
         "hast-util-sanitize": "^4.0.0",
         "hast-util-to-string": "^1.0.4",
@@ -3732,9 +3732,9 @@
       "dev": true
     },
     "node_modules/@readme/syntax-highlighter": {
-      "version": "10.14.1",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.14.1.tgz",
-      "integrity": "sha512-Bk4WWJ6VRLnYp80IKGwKi8VIa0gjJiB+TbZ4Pn5F05De31VV+oYN9xxOmzyBlhQv9nXWGWL4mMFIKoUcGJD7pg==",
+      "version": "10.14.3",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.14.3.tgz",
+      "integrity": "sha512-hWBMH2aFVShdsq/E38zE6cCL36DV2i99BErmG013LvWRsHok50bGDffgKf2Z8wEP2QiGIH9Sjs7VGnyDSbvxBQ==",
       "dependencies": {
         "codemirror": "5.54.0",
         "codemirror-graphql": "1.0.2",
@@ -28027,9 +28027,9 @@
       }
     },
     "@readme/syntax-highlighter": {
-      "version": "10.14.1",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.14.1.tgz",
-      "integrity": "sha512-Bk4WWJ6VRLnYp80IKGwKi8VIa0gjJiB+TbZ4Pn5F05De31VV+oYN9xxOmzyBlhQv9nXWGWL4mMFIKoUcGJD7pg==",
+      "version": "10.14.3",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-10.14.3.tgz",
+      "integrity": "sha512-hWBMH2aFVShdsq/E38zE6cCL36DV2i99BErmG013LvWRsHok50bGDffgKf2Z8wEP2QiGIH9Sjs7VGnyDSbvxBQ==",
       "requires": {
         "codemirror": "5.54.0",
         "codemirror-graphql": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@readme/emojis": "^4.0.0",
-    "@readme/syntax-highlighter": "^10.14.1",
+    "@readme/syntax-highlighter": "^10.14.3",
     "copy-to-clipboard": "^3.3.1",
     "hast-util-sanitize": "^4.0.0",
     "hast-util-to-string": "^1.0.4",


### PR DESCRIPTION
## 🧰 Changes

The ongoing quest to get `@readme/syntax-highlighter` upgraded and working in the dash/hubs.