### PR TITLE
feat: add width support to image compiler

### DIFF
--- a/__tests__/__snapshots__/flavored-compilers.test.js.snap
+++ b/__tests__/__snapshots__/flavored-compilers.test.js.snap
@@ -57,8 +57,41 @@ exports[`ReadMe Magic Blocks Figure 1`] = `
         \\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\",
         \\"rdme-blue.svg\\"
       ],
-      \\"caption\\": \\"Ok, **pizza** man.\\",
-      \\"sizing\\": \\"80\\"
+      \\"sizing\\": \\"80\\",
+      \\"caption\\": \\"Ok, **pizza** man.\\"
+    }
+  ]
+}
+[/block]
+"
+`;
+
+exports[`ReadMe Magic Blocks Image 1`] = `
+"[block:image]
+{
+  \\"images\\": [
+    {
+      \\"image\\": [
+        \\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\",
+        \\"rdme-blue.svg\\"
+      ]
+    }
+  ]
+}
+[/block]
+"
+`;
+
+exports[`ReadMe Magic Blocks Image with sizing 1`] = `
+"[block:image]
+{
+  \\"images\\": [
+    {
+      \\"image\\": [
+        \\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\",
+        \\"rdme-blue.svg\\"
+      ],
+      \\"sizing\\": \\"80px\\"
     }
   ]
 }

--- a/__tests__/flavored-compilers.test.js
+++ b/__tests__/flavored-compilers.test.js
@@ -60,13 +60,13 @@ describe('ReadMe Flavored Blocks', () => {
     const ast = parse(text);
 
     expect(compile(ast)).toMatchInlineSnapshot(`
-"[block:html]
-{
-  \\"html\\": \\"<style>\\\\n  summary {\\\\n    padding-top: 8px;\\\\n    outline: none !important;\\\\n    user-select: none;\\\\n  }\\\\n  details[open] + details > summary {\\\\n    padding-top: 0;\\\\n  }\\\\n  details > summary + hr {\\\\n    opacity: .66;\\\\n  }\\\\n</style>\\"
-}
-[/block]
-"
-`);
+      "[block:html]
+      {
+        \\"html\\": \\"<style>\\\\n  summary {\\\\n    padding-top: 8px;\\\\n    outline: none !important;\\\\n    user-select: none;\\\\n  }\\\\n  details[open] + details > summary {\\\\n    padding-top: 0;\\\\n  }\\\\n  details > summary + hr {\\\\n    opacity: .66;\\\\n  }\\\\n</style>\\"
+      }
+      [/block]
+      "
+    `);
   });
 });
 
@@ -140,6 +140,41 @@ describe('ReadMe Magic Blocks', () => {
     [/block]`;
     const ast = parse(txt);
     const out = compile(ast);
+    expect(out).toMatchSnapshot();
+  });
+
+  it('Image', () => {
+    const txt = `[block:image]
+    {
+       "images": [{
+          "image": [
+            "https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg",
+            "rdme-blue.svg"
+          ]
+       }]
+    }
+    [/block]`;
+    const ast = parse(txt);
+    const out = compile(ast);
+
+    expect(out).toMatchSnapshot();
+  });
+
+  it('Image with sizing', () => {
+    const txt = `[block:image]
+    {
+       "images": [{
+          "image": [
+            "https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg",
+            "rdme-blue.svg"
+          ],
+          "sizing": "80px"
+       }]
+    }
+    [/block]`;
+    const ast = parse(txt);
+    const out = compile(ast);
+
     expect(out).toMatchSnapshot();
   });
 

--- a/processor/compile/figure.js
+++ b/processor/compile/figure.js
@@ -1,19 +1,31 @@
 const { imgSizeByWidth } = require('../parse/magic-block-parser');
 
+const compileImage = image => {
+  const img = {
+    image: [image.url, image.title],
+    ...(image.data.hProperties.width && { sizing: imgSizeByWidth[image.data.hProperties.width] }),
+    ...(image.border && { border: image.border }),
+  };
+
+  return img;
+};
+
 module.exports = function FigureCompiler() {
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
 
   visitors.figure = function figureCompiler(node) {
-    const [image, caption] = node.children;
+    let image;
+    let caption;
 
-    const img = {
-      image: [image.url, image.title],
-      caption: this.block(caption),
-      sizing: imgSizeByWidth[image.data.hProperties.width ?? 'auto'],
-    };
+    if (node.children) {
+      [image, caption] = node.children;
+    } else {
+      image = node;
+    }
 
-    if (image.border) img.border = image.border;
+    const img = compileImage(image);
+    if (caption) img.caption = this.block(caption);
 
     const block = {
       images: [img],

--- a/processor/compile/image.js
+++ b/processor/compile/image.js
@@ -1,9 +1,10 @@
 module.exports = function ImageCompiler() {
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
-  const { image: original } = visitors;
 
   visitors.image = function compile(node, ...args) {
-    return node.data?.hProperties?.className === 'emoji' ? node.title : original.call(this, node, ...args);
+    if (node.data?.hProperties?.className === 'emoji') return node.title;
+
+    return visitors.figure.call(this, node, ...args);
   };
 };

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -108,7 +108,7 @@ function tokenize(eat, value) {
             data: {
               hProperties: {
                 className: img.border ? 'border' : '',
-                width: imgWidthBySize[img.sizing ?? 'original'],
+                ...(img.sizing && { width: imgWidthBySize[img.sizing] }),
               },
             },
           };


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] |
:---:|

## 🧰 Changes

Adds support for saving images without captions but with widths.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
