### PR TITLE
fix: code block regex should allow empty tab contents

### DIFF
--- a/__tests__/flavored-parsers.test.js
+++ b/__tests__/flavored-parsers.test.js
@@ -104,6 +104,13 @@ describe('Parse RDMD Syntax', () => {
         const [codeTabs] = ast.children;
         expect(codeTabs.children).toHaveLength(2);
       });
+
+      it('Tabbed code blocks should not require any code', () => {
+        const mdx = '```c++ oh me\nsome code\n```\n```c++ a tab with no code\n```\n```c++ oh my\nsome more\n```';
+        const ast = process(mdx);
+        const [codeTabs] = ast.children;
+        expect(codeTabs.children).toHaveLength(3);
+      });
     });
   });
 

--- a/__tests__/flavored-parsers.test.js
+++ b/__tests__/flavored-parsers.test.js
@@ -111,6 +111,13 @@ describe('Parse RDMD Syntax', () => {
         const [codeTabs] = ast.children;
         expect(codeTabs.children).toHaveLength(3);
       });
+
+      it('Multiple empty code blocks tabs should render', () => {
+        const mdx = '```\n```\n```\n```';
+        const ast = process(mdx);
+        const [codeTabs] = ast.children;
+        expect(codeTabs.children).toHaveLength(2);
+      });
     });
   });
 

--- a/processor/parse/flavored/code-tabs.js
+++ b/processor/parse/flavored/code-tabs.js
@@ -16,7 +16,7 @@ function tokenizer(eat, value) {
    *    - [code] snippet text
    */
   // eslint-disable-next-line unicorn/no-unsafe-regex
-  const CODE_BLOCK_RGXP = /(?:^|\n)```[ \t]*(?<lang>[^\s]+)?(?: *(?<meta>[^\n]+))?\n(?<code>((?!\n```).)*)\n```/gs;
+  const CODE_BLOCK_RGXP = /(?:^|\n)```[ \t]*(?<lang>[^\s]+)?(?: *(?<meta>[^\n]+))?(?<code>((?!\n```).)*)?\n```/gs;
   while ((codeBlock = CODE_BLOCK_RGXP.exec(match)) !== null) {
     // eslint-disable-next-line prefer-const
     let { lang, meta = '', code = '' } = codeBlock.groups;


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] | Fixes (part of) 3457
:---:|:---:

## 🧰 Changes

We found that the code tabs parser would break if we had an empty tab. According to the tab's contents and the order it was added to the set of code blocks, it could be rendered with or without an empty line space.

This change to the regex allows the parser to understand that a tab without an empty line is still a tab. 

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
