### PR TITLE
fix(SEO): add href to TOC

### DIFF
--- a/__tests__/components/TableOfContents.test.jsx
+++ b/__tests__/components/TableOfContents.test.jsx
@@ -33,7 +33,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(toc);
 
-    expect(container.querySelectorAll('li > a[href]:not([href=""])')).toHaveLength(2);
+    expect(container.querySelectorAll('li > a[href]:not([href="#"])')).toHaveLength(2);
   });
 
   it('includes two heading levels', () => {
@@ -42,7 +42,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(toc);
 
-    expect(container.querySelectorAll('li > a[href]:not([href=""])')).toHaveLength(2);
+    expect(container.querySelectorAll('li > a[href]:not([href="#"])')).toHaveLength(2);
     expect(container.innerHTML).toMatchSnapshot();
   });
 
@@ -52,7 +52,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(toc);
 
-    expect(container.querySelectorAll('li > a[href]:not([href=""])')).toHaveLength(2);
+    expect(container.querySelectorAll('li > a[href]:not([href="#"])')).toHaveLength(2);
   });
 
   it('includes variables', () => {
@@ -61,7 +61,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(<VariablesContext.Provider value={variables}>{toc}</VariablesContext.Provider>);
 
-    expect(container.querySelector('li > a[href]:not([href=""])')).toHaveTextContent(`Heading ${variables.user.test}`);
+    expect(container.querySelector('li > a[href]:not([href="#"])')).toHaveTextContent(`Heading ${variables.user.test}`);
   });
 
   it('includes glossary items', () => {
@@ -70,7 +70,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(<GlossaryContext.Provider value={glossaryTerms}>{toc}</GlossaryContext.Provider>);
 
-    expect(container.querySelector('li > a[href]:not([href=""])')).toHaveTextContent(
+    expect(container.querySelector('li > a[href]:not([href="#"])')).toHaveTextContent(
       `Heading ${glossaryTerms[0].term}`
     );
   });

--- a/__tests__/components/TableOfContents.test.jsx
+++ b/__tests__/components/TableOfContents.test.jsx
@@ -33,7 +33,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(toc);
 
-    expect(container.querySelectorAll('li > a[href]:not([href="#"])')).toHaveLength(2);
+    expect(container.querySelectorAll('li > a[href]')).toHaveLength(2);
   });
 
   it('includes two heading levels', () => {
@@ -42,7 +42,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(toc);
 
-    expect(container.querySelectorAll('li > a[href]:not([href="#"])')).toHaveLength(2);
+    expect(container.querySelectorAll('li > a[href]')).toHaveLength(2);
     expect(container.innerHTML).toMatchSnapshot();
   });
 
@@ -52,7 +52,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(toc);
 
-    expect(container.querySelectorAll('li > a[href]:not([href="#"])')).toHaveLength(2);
+    expect(container.querySelectorAll('li > a[href]')).toHaveLength(2);
   });
 
   it('includes variables', () => {
@@ -61,7 +61,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(<VariablesContext.Provider value={variables}>{toc}</VariablesContext.Provider>);
 
-    expect(container.querySelector('li > a[href]:not([href="#"])')).toHaveTextContent(`Heading ${variables.user.test}`);
+    expect(container.querySelector('li > a[href]')).toHaveTextContent(`Heading ${variables.user.test}`);
   });
 
   it('includes glossary items', () => {
@@ -70,8 +70,6 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(<GlossaryContext.Provider value={glossaryTerms}>{toc}</GlossaryContext.Provider>);
 
-    expect(container.querySelector('li > a[href]:not([href="#"])')).toHaveTextContent(
-      `Heading ${glossaryTerms[0].term}`
-    );
+    expect(container.querySelector('li > a[href]')).toHaveTextContent(`Heading ${glossaryTerms[0].term}`);
   });
 });

--- a/__tests__/components/__snapshots__/TableOfContents.test.jsx.snap
+++ b/__tests__/components/__snapshots__/TableOfContents.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table of Contents includes two heading levels 1`] = `
-"<nav><ul class=\\"toc-list\\"><li><a class=\\"tocHeader\\" href=\\"#\\"><i class=\\"icon icon-text-align-left\\"></i>Table of Contents</a></li><li class=\\"toc-children\\"><ul>
+"<nav><ul class=\\"toc-list\\"><li><a class=\\"tocHeader\\"><i class=\\"icon icon-text-align-left\\"></i>Table of Contents</a></li><li class=\\"toc-children\\"><ul>
 <li>
 <a href=\\"#heading-zed\\">Heading Zed</a>
 <ul>

--- a/__tests__/components/__snapshots__/TableOfContents.test.jsx.snap
+++ b/__tests__/components/__snapshots__/TableOfContents.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table of Contents includes two heading levels 1`] = `
-"<nav><ul class=\\"toc-list\\"><li><a class=\\"tocHeader\\" href=\\"\\"><i class=\\"icon icon-text-align-left\\"></i>Table of Contents</a></li><li class=\\"toc-children\\"><ul>
+"<nav><ul class=\\"toc-list\\"><li><a class=\\"tocHeader\\" href=\\"#\\"><i class=\\"icon icon-text-align-left\\"></i>Table of Contents</a></li><li class=\\"toc-children\\"><ul>
 <li>
 <a href=\\"#heading-zed\\">Heading Zed</a>
 <ul>

--- a/components/TableOfContents/index.jsx
+++ b/components/TableOfContents/index.jsx
@@ -7,7 +7,7 @@ function TableOfContents({ children }) {
       <ul className="toc-list">
         <li>
           {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-          <a className="tocHeader" href="#">
+          <a className="tocHeader">
             <i className="icon icon-text-align-left"></i>
             Table of Contents
           </a>

--- a/components/TableOfContents/index.jsx
+++ b/components/TableOfContents/index.jsx
@@ -7,7 +7,7 @@ function TableOfContents({ children }) {
       <ul className="toc-list">
         <li>
           {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-          <a className="tocHeader" href="">
+          <a className="tocHeader" href="#">
             <i className="icon icon-text-align-left"></i>
             Table of Contents
           </a>


### PR DESCRIPTION
## 🧰 Changes

Makes a tiny markup change to our TOC so we can address this issue that's getting flagged in our Lighthouse SEO score:
<img width="721" alt="Screen Shot 2022-03-16 at 9 57 40 AM" src="https://user-images.githubusercontent.com/8854718/158620701-a0621ca0-1b5a-491c-9093-875f80369370.png">


## 🧬 QA & Testing

Do tests pass?
