### PR TITLE
docs(code blocks): add graphql, separate JSX

### DIFF
--- a/docs/code-blocks.md
+++ b/docs/code-blocks.md
@@ -88,12 +88,14 @@ We support syntax highlighting on a number of languages:
 | Docker | `dockerfile` |
 | Erlang | `erl`, `erlang` |
 | Go | `go` |
+| GraphQL | `gql`, `graphql` |
 | Groovy | `gradle`, `groovy` |
 | Handlebars | `handlebars`, `hbs` |
 | HTML/XML | `html`, `xhtml`, `xml` |
 | HTTP | `http` |
 | Java | `java` |
-| JavaScript | `coffeescript`, `ecmascript`, `javascript`, `js`, `jsx`, `node` |
+| JavaScript | `coffeescript`, `ecmascript`, `javascript`, `js`, `node` |
+| JSX | `jsx` |
 | JSON | `json` |
 | Julia | `jl`, `julia` |
 | Kotlin | `kotlin`, `kt` |


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] |
:---:|:---:

## 🧰 Changes

Was looking at https://github.com/readmeio/readme/pull/6305 and noticed we hadn't updated the docs to reflect the changes in https://github.com/readmeio/syntax-highlighter/pull/173. This takes care of that!

I also separated out JSX into its own line since it feels like a superset of JavaScript (and evidently [uses an entirely different engine than `javascript`](https://github.com/readmeio/syntax-highlighter/blob/e4bd011661ac7c2c19346144da71ef56d8342138/src/utils/modes.js#L41)), but I'm willing to be challenged on that.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
