### PR TITLE
fix: page crashing on invalid url in embed block

### DIFF
--- a/__tests__/__snapshots__/magic-block-parser.test.js.snap
+++ b/__tests__/__snapshots__/magic-block-parser.test.js.snap
@@ -297,6 +297,42 @@ Object {
 }
 `;
 
+exports[`Parse Magic Blocks Embed Blocks with invalid URL 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": null,
+            },
+          ],
+          "title": "www.youtu.be/J3-uKv1DShQ",
+          "type": "link",
+          "url": "www.youtu.be/J3-uKv1DShQ",
+        },
+      ],
+      "data": Object {
+        "hName": "rdme-embed",
+        "hProperties": Object {
+          "favicon": "https://youtu.be/favicon.ico",
+          "href": "www.youtu.be/J3-uKv1DShQ",
+          "html": false,
+          "iframe": false,
+          "provider": "www.youtu.be/J3-uKv1DShQ",
+          "title": null,
+          "url": "www.youtu.be/J3-uKv1DShQ",
+        },
+      },
+      "type": "embed",
+    },
+  ],
+  "type": "root",
+}
+`;
+
 exports[`Parse Magic Blocks Heading Blocks 1`] = `
 Object {
   "children": Array [

--- a/__tests__/magic-block-parser.test.js
+++ b/__tests__/magic-block-parser.test.js
@@ -190,6 +190,19 @@ describe('Parse Magic Blocks', () => {
     expect(process(text)).toMatchSnapshot();
   });
 
+  it('Embed Blocks with invalid URL', () => {
+    const text = `[block:embed]
+    {
+      "html": false,
+      "url": "www.youtu.be/J3-uKv1DShQ",
+      "title": null,
+      "favicon": "https://youtu.be/favicon.ico",
+      "iframe": false
+    }
+    [/block]`;
+    expect(process(text)).toMatchSnapshot();
+  });
+
   it('Callout Blocks', () => {
     const text = `[block:callout]
     {

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -201,10 +201,14 @@ function tokenize(eat, value) {
     }
     case 'embed': {
       const { title, url, html } = json;
-      json.provider = new URL(url).hostname
-        .split(/(?:www)?\./)
-        .filter(i => i)
-        .join('.');
+      try {
+        json.provider = new URL(url).hostname
+          .split(/(?:www)?\./)
+          .filter(i => i)
+          .join('.');
+      } catch {
+        json.provider = url;
+      }
       const data = {
         ...json,
         url,


### PR DESCRIPTION
(relates to [RM-74](https://linear.app/readme-io/issue/RM-74))

## 🧰 Changes

We're seeing an issue in the new embed block where the page crashes when trying to render a populated embed. Here's a video of me having a lovely time with it, entering the (valid) YouTube URL https://www.youtube.com/watch?v=tE0wh-RKhR0:

https://user-images.githubusercontent.com/48635728/158707361-47e3342f-eb71-4c65-9109-f3f68ce1a135.mov

The error returned is this one:
![Screen Shot 2022-03-15 at 4 12 32 PM](https://user-images.githubusercontent.com/48635728/158705386-b422c8c6-5b08-45ed-bbfd-d0a898b90176.png)

We've tracked this down to [the switch statement inside magic-block-parser,](https://github.com/readmeio/markdown/blob/b0e98ac373d3985ac9eaa40bff3fde2cb93c38a9/processor/parse/magic-block-parser.js#L202), where we assign a value to `json.provider`.

We go on to use this `json.provider` as a title [here](https://github.com/readmeio/markdown/blob/b0e98ac373d3985ac9eaa40bff3fde2cb93c38a9/processor/parse/magic-block-parser.js#L226).

By wrapping this assignment in a try catch statement, we avoid the page crashing entirely and instead assign an empty string as the provider. If anyone sees a problem with this please shout!

In the new embed block we are validating the URL entered before we try to render the block, so honestly it's still a bit of a mystery why this is happening at all... I'm still not sure how we're hitting this point of the switch statement inside the parser. I wonder if perhaps we're starting to render the block before embedly returns all the data, but if that were the case I'd expect us to return at the top of the switch statement in the magic block parser and never hit this line of code. 🤷‍♀️ 

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
