### PR TITLE
fix(deps): revert actions/checkout@v3

### DIFF
--- a/.github/workflows/bundlewatch.yml
+++ b/.github/workflows/bundlewatch.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'SKIP CI')"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2.3.4
       - uses: actions/setup-node@v3
         with:
           node-version: 14.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         node-version: [14.x, 16.x]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2.3.4
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       # Setup the git repo & Node environemnt.
       #
       - name: Checkout branch (${{ github.ref }})
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2.3.4
         with:
           persist-credentials: false # install breaks with persistant creds!
 


### PR DESCRIPTION
## 🧰 Changes

It appears that [the release CI has been failing](https://github.com/readmeio/markdown/runs/5452345503?check_suite_focus=true) since https://github.com/readmeio/markdown/pull/442. Not sure what exactly is causing the issues, but I figured we should just revert the bump to `v3` in the meantime.
