### PR TITLE
fix(seo): add href to TOC

### DIFF
--- a/__tests__/components/TableOfContents.test.jsx
+++ b/__tests__/components/TableOfContents.test.jsx
@@ -33,7 +33,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(toc);
 
-    expect(container.querySelectorAll('li > a[href]')).toHaveLength(2);
+    expect(container.querySelectorAll('li > a[href]:not([href="#"])')).toHaveLength(2);
   });
 
   it('includes two heading levels', () => {
@@ -42,7 +42,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(toc);
 
-    expect(container.querySelectorAll('li > a[href]')).toHaveLength(2);
+    expect(container.querySelectorAll('li > a[href]:not([href="#"])')).toHaveLength(2);
     expect(container.innerHTML).toMatchSnapshot();
   });
 
@@ -52,7 +52,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(toc);
 
-    expect(container.querySelectorAll('li > a[href]')).toHaveLength(2);
+    expect(container.querySelectorAll('li > a[href]:not([href="#"])')).toHaveLength(2);
   });
 
   it('includes variables', () => {
@@ -61,7 +61,7 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(<VariablesContext.Provider value={variables}>{toc}</VariablesContext.Provider>);
 
-    expect(container.querySelector('li > a[href]')).toHaveTextContent(`Heading ${variables.user.test}`);
+    expect(container.querySelector('li > a[href]:not([href="#"])')).toHaveTextContent(`Heading ${variables.user.test}`);
   });
 
   it('includes glossary items', () => {
@@ -70,6 +70,8 @@ describe('Table of Contents', () => {
     const toc = markdown.reactTOC(ast);
     const { container } = render(<GlossaryContext.Provider value={glossaryTerms}>{toc}</GlossaryContext.Provider>);
 
-    expect(container.querySelector('li > a[href]')).toHaveTextContent(`Heading ${glossaryTerms[0].term}`);
+    expect(container.querySelector('li > a[href]:not([href="#"])')).toHaveTextContent(
+      `Heading ${glossaryTerms[0].term}`
+    );
   });
 });

--- a/__tests__/components/__snapshots__/TableOfContents.test.jsx.snap
+++ b/__tests__/components/__snapshots__/TableOfContents.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Table of Contents includes two heading levels 1`] = `
-"<nav><ul class=\\"toc-list\\"><li><a class=\\"tocHeader\\"><i class=\\"icon icon-text-align-left\\"></i>Table of Contents</a></li><li class=\\"toc-children\\"><ul>
+"<nav><ul class=\\"toc-list\\"><li><a class=\\"tocHeader\\" href=\\"#\\"><i class=\\"icon icon-text-align-left\\"></i>Table of Contents</a></li><li class=\\"toc-children\\"><ul>
 <li>
 <a href=\\"#heading-zed\\">Heading Zed</a>
 <ul>

--- a/components/TableOfContents/index.jsx
+++ b/components/TableOfContents/index.jsx
@@ -7,7 +7,7 @@ function TableOfContents({ children }) {
       <ul className="toc-list">
         <li>
           {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-          <a className="tocHeader">
+          <a className="tocHeader" href="#">
             <i className="icon icon-text-align-left"></i>
             Table of Contents
           </a>


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] |
:---:|

## 🧰 Changes

This is a redo of https://github.com/readmeio/markdown/pull/447... turns out removing the `href` attribute entirely is just as problematic in the eyes of Lighthouse as have an empty one 🤦🏽 

## 🧬 QA & Testing

I ran a Lighthouse SEO test against [this page](https://kanad-reference-redesign.readme.io/docs/asdf), which has both an `<a href="#">` tag and an `<a>` tag (i.e. one that doesn't have an `href`). Feel free to run one yourself! Lighthouse only flags the latter.

If this change looks good and tests pass, we should be good to go!


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
