### PR TITLE
style: add class for blank-line

### DIFF
--- a/styles/gfm.scss
+++ b/styles/gfm.scss
@@ -324,6 +324,9 @@
     vertical-align: middle
   }
 
+  p.blank-line {
+    height: 1.5em;
+  }
 }
 
 @mixin markdownOverrides {


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] | Fixes RM-1395 | RM-6415
:---:|:---:|:---:

## 🧰 Changes

Adds a class for when we start inserting blank lines.

## 🧬 QA & Testing

You can try inserting the following markdown:

```
One line

<p class="blank-line"></p>

Another line
```

And you should see 3 paragraphs of similar heights.

- [Working in this PR app][demo].


[demo]: https://markdown-pr-457.herokuapp.com
