### PR TITLE
fix(gemoji): add compiler for font-awesome emojis

### DIFF
--- a/__tests__/flavored-compilers.test.js
+++ b/__tests__/flavored-compilers.test.js
@@ -199,4 +199,15 @@ ${JSON.stringify(
     const out = compile(ast);
     expect(out).toMatchSnapshot();
   });
+
+  it('font-awesome emojis', () => {
+    const txt = `:fa-rss-square:`;
+
+    const ast = parse(txt);
+    const out = compile(ast);
+    expect(out).toMatchInlineSnapshot(`
+      ":fa-rss-square:
+      "
+    `);
+  });
 });

--- a/processor/compile/i.js
+++ b/processor/compile/i.js
@@ -1,0 +1,8 @@
+module.exports = function FaEmojiCompiler() {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+
+  visitors.i = function compile(node) {
+    return `:${node.data.hProperties.className[1]}:`;
+  };
+};

--- a/processor/compile/index.js
+++ b/processor/compile/index.js
@@ -9,4 +9,5 @@ export { default as rdmeGlossaryCompiler } from './glossary';
 export { default as rdmeCalloutCompiler } from './callout';
 export { default as rdmePinCompiler } from './pin';
 export { default as imageCompiler } from './image';
+export { default as iconCompiler } from './i';
 export { default as htmlBlockCompiler } from './html-block';


### PR DESCRIPTION
[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] | Fixes RM-3937
:---:|:---:

## 🧰 Changes

Adds a compiler for the `i` type, font-awesome emojis. This is so the editor can save back out when loading, for instance: `:fa-rss-square:`.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
