### PR TITLE
docs: updating the pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
-[<img height=20 src=https://readme.com/static/favicon.ico align=center>][demo] | Fixes LINEAR_ID
-:---:|:---:
+[![PR App][icn]][demo] | Fix RM-XYZ
+:-------------------:|:----------:
 
 ## 🧰 Changes
 
@@ -13,3 +13,4 @@ Describe your changes in detail.
 
 [demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
 [prod]: https://SUBDOMAIN.readme.io
+[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

Updates the PR template to match what we're using in our other repos now and also to mainly fix the broken icon image.

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg