### PR TITLE
fix: new editor magic block embed empty state

### DIFF
--- a/__tests__/__snapshots__/magic-block-parser.test.js.snap
+++ b/__tests__/__snapshots__/magic-block-parser.test.js.snap
@@ -297,6 +297,41 @@ Object {
 }
 `;
 
+exports[`Parse Magic Blocks Embed Blocks with empty URL 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": undefined,
+            },
+          ],
+          "title": "",
+          "type": "link",
+          "url": "",
+        },
+      ],
+      "data": Object {
+        "hName": "rdme-embed",
+        "hProperties": Object {
+          "href": "",
+          "html": undefined,
+          "provider": "",
+          "title": undefined,
+          "typeOfEmbed": "youtube",
+          "url": "",
+        },
+      },
+      "type": "embed",
+    },
+  ],
+  "type": "root",
+}
+`;
+
 exports[`Parse Magic Blocks Embed Blocks with invalid URL 1`] = `
 Object {
   "children": Array [

--- a/__tests__/magic-block-parser.test.js
+++ b/__tests__/magic-block-parser.test.js
@@ -203,6 +203,17 @@ describe('Parse Magic Blocks', () => {
     expect(process(text)).toMatchSnapshot();
   });
 
+  it('Embed Blocks with empty URL', () => {
+    const text = `[block:embed]
+    {
+      "url": "",
+      "typeOfEmbed": "youtube",
+      "provider": "embed"
+    }
+    [/block]`;
+    expect(process(text)).toMatchSnapshot();
+  });
+
   it('Callout Blocks', () => {
     const text = `[block:callout]
     {

--- a/components/Embed/index.jsx
+++ b/components/Embed/index.jsx
@@ -12,6 +12,10 @@ class Embed extends React.Component {
   render() {
     const { provider, url, title, html, iframe, image, favicon, ...attrs } = this.props;
 
+    if (!url) {
+      return <div />;
+    }
+
     if ('iframe' in this.props) {
       return <iframe {...attrs} border="none" src={url} style={{ border: 'none' }} />;
     }


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4083
:-------------------:|:----------:

## 🧰 Changes

The old editor used to produce empty embed magic blocks whose markdown looked like this:
```
[block:embed]
{}
[/block]
```

For the new editor's magic block embed, the empty state looks like this:
```
[block:embed]
{
  "url": "",
  "typeOfEmbed": "pdf",
  "provider": "embed"
}
[/block]
```
(for a PDF, for example).

Instead of disappearing the empty block, the new empty state was being rendered as the following in the hub:
<img width="465" alt="Screen Shot 2022-04-11 at 1 59 35 PM" src="https://user-images.githubusercontent.com/48635728/162831178-6a46cc91-9ad5-4162-816c-0b4e759bd4bf.png">

With this PR, we're back to disappearing the empty magic block.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
