### PR TITLE
fix(tables): preserve breaks in tables

### DIFF
--- a/__tests__/__snapshots__/flavored-compilers.test.js.snap
+++ b/__tests__/__snapshots__/flavored-compilers.test.js.snap
@@ -99,6 +99,31 @@ exports[`ReadMe Magic Blocks Image with sizing 1`] = `
 "
 `;
 
+exports[`ReadMe Magic Blocks Tables 1`] = `
+"|  th 1  |  th 2  |
+| :----: | :----: |
+| cell 1 | cell 2 |
+"
+`;
+
+exports[`ReadMe Magic Blocks Tables with breaks 1`] = `
+"[block:parameters]
+{
+  \\"align\\": [
+    \\"center\\",
+    \\"center\\"
+  ],
+  \\"cols\\": 2,
+  \\"rows\\": 2,
+  \\"h-0\\": \\"th 1\\",
+  \\"h-1\\": \\"th 2\\",
+  \\"0-0\\": \\"cell 1  \\\\nafter the break\\",
+  \\"0-1\\": \\"cell 2\\"
+}
+[/block:parameters]
+"
+`;
+
 exports[`ReadMe Magic Blocks custom blocks 1`] = `
 "
 [block:tutorial-tile]

--- a/__tests__/__snapshots__/flavored-compilers.test.js.snap
+++ b/__tests__/__snapshots__/flavored-compilers.test.js.snap
@@ -120,7 +120,7 @@ exports[`ReadMe Magic Blocks Tables with breaks 1`] = `
   \\"0-0\\": \\"cell 1  \\\\nafter the break\\",
   \\"0-1\\": \\"cell 2\\"
 }
-[/block:parameters]
+[/block]
 "
 `;
 

--- a/__tests__/flavored-compilers.test.js
+++ b/__tests__/flavored-compilers.test.js
@@ -210,4 +210,44 @@ ${JSON.stringify(
       "
     `);
   });
+
+  it('Tables', () => {
+    const md = `
+[block:parameters]
+${JSON.stringify({
+  data: {
+    'h-0': 'th 1',
+    'h-1': 'th 2',
+    '0-0': 'cell 1',
+    '0-1': 'cell 2',
+  },
+  cols: 2,
+  rows: 1,
+  align: ['center', 'center'],
+})}
+[/block]
+    `;
+
+    expect(compile(parse(md))).toMatchSnapshot();
+  });
+
+  it('Tables with breaks', () => {
+    const md = `
+[block:parameters]
+${JSON.stringify({
+  data: {
+    'h-0': 'th 1',
+    'h-1': 'th 2',
+    '0-0': 'cell 1  \nafter the break',
+    '0-1': 'cell 2',
+  },
+  cols: 2,
+  rows: 1,
+  align: ['center', 'center'],
+})}
+[/block]
+    `;
+
+    expect(compile(parse(md))).toMatchSnapshot();
+  });
 });

--- a/processor/compile/index.js
+++ b/processor/compile/index.js
@@ -1,13 +1,13 @@
-export { default as divCompiler } from './div';
-export { default as tableHeadCompiler } from './table-head';
-export { default as figureCompiler } from './figure';
-
 export { default as codeTabsCompiler } from './code-tabs';
-export { default as rdmeEmbedCompiler } from './embed';
-export { default as rdmeVarCompiler } from './var';
-export { default as rdmeGlossaryCompiler } from './glossary';
-export { default as rdmeCalloutCompiler } from './callout';
-export { default as rdmePinCompiler } from './pin';
-export { default as imageCompiler } from './image';
-export { default as iconCompiler } from './i';
+export { default as divCompiler } from './div';
+export { default as figureCompiler } from './figure';
 export { default as htmlBlockCompiler } from './html-block';
+export { default as iconCompiler } from './i';
+export { default as imageCompiler } from './image';
+export { default as rdmeCalloutCompiler } from './callout';
+export { default as rdmeEmbedCompiler } from './embed';
+export { default as rdmeGlossaryCompiler } from './glossary';
+export { default as rdmePinCompiler } from './pin';
+export { default as rdmeVarCompiler } from './var';
+export { default as tableCompiler } from './table';
+export { default as tableHeadCompiler } from './table-head';

--- a/processor/compile/table.js
+++ b/processor/compile/table.js
@@ -31,6 +31,6 @@ module.exports = function TableCompiler() {
       });
     });
 
-    return `[block:parameters]\n${JSON.stringify(data, null, 2)}\n[/block:parameters]`;
+    return `[block:parameters]\n${JSON.stringify(data, null, 2)}\n[/block]`;
   };
 };

--- a/processor/compile/table.js
+++ b/processor/compile/table.js
@@ -1,0 +1,36 @@
+const find = (node, fn) => {
+  if (fn(node)) return node;
+  if (node.children) return node.children.find(n => find(n, fn));
+
+  return null;
+};
+
+module.exports = function TableCompiler() {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+
+  const { table: original } = visitors;
+
+  visitors.table = function (node) {
+    if (!find(node, n => n.type === 'break')) {
+      return original.call(this, node);
+    }
+
+    const data = {
+      align: [...node.align],
+      cols: node.children[0]?.children?.length || 0,
+      rows: node.children.length,
+    };
+
+    node.children.forEach((row, i) => {
+      row.children.forEach((cell, j) => {
+        const col = i === 0 ? 'h' : i - 1;
+        const string = this.all(cell).join('').replace(/\\\n/g, '  \n');
+
+        data[`${col}-${j}`] = string;
+      });
+    });
+
+    return `[block:parameters]\n${JSON.stringify(data, null, 2)}\n[/block:parameters]`;
+  };
+};


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4110
:-------------------:|:----------:

## 🧰 Changes

Magic block tables preserve breaks. Typically, RDMD writes tables to markdown as github flavored tables, which do not support any block content, including breaks.

This adds a custom compiler that checks if there are breaks in the table, in which case, it saves as a magic black table.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-467.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
