### PR TITLE
feat: save newlines with spaces

### DIFF
--- a/__tests__/flavored-compilers/break.test.js
+++ b/__tests__/flavored-compilers/break.test.js
@@ -1,0 +1,17 @@
+import { mdast, md } from '../..';
+
+describe('break compiler', () => {
+  it('uses two spaces with `correctnewlines: false`', () => {
+    const txt = `line\nbreak`;
+    const opts = { correctnewlines: false };
+
+    expect(md(mdast(txt, opts), opts)).toBe(`line  \nbreak\n`);
+  });
+
+  it('uses two spaces with `correctnewlines: true`', () => {
+    const txt = `line\\\nbreak`;
+    const opts = { correctnewlines: true };
+
+    expect(md(mdast(txt, opts), opts)).toBe(`line  \nbreak\n`);
+  });
+});

--- a/processor/compile/break.js
+++ b/processor/compile/break.js
@@ -1,0 +1,10 @@
+module.exports = function BreakCompiler() {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+
+  // @note: We could save this as just '\n' when `correctnewlines: false`, but
+  // this is more portable.
+  visitors.break = function compile() {
+    return '  \n';
+  };
+};

--- a/processor/compile/index.js
+++ b/processor/compile/index.js
@@ -1,3 +1,4 @@
+export { default as breakCompiler } from './break';
 export { default as codeTabsCompiler } from './code-tabs';
 export { default as divCompiler } from './div';
 export { default as figureCompiler } from './figure';


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4096
:-------------------:|:----------:

## 🧰 Changes

Override the `break` compiler to save as "&blank;&blank;\n" instead of "\\\n".

The MarkdownEditor doesn't use the `escape` parser, so that the backslashes are preserved in the editor. For some reason `remark-parse` doesn't consume the backslash of "\\\n" when parsing the break. (I believe this is technically incorrect, but :shrug:) This means that if you enter a newline in the editor, it gets saves as "\\\n" and then loaded as the same.

We can't turn the `escape` parser on, as we'd lose escapes. And, we could save as "\n" when `correctnewlines: false`, but that's not portable to other markdown parsers. So this seems like a reasonable workaround.

## 🧬 QA & Testing

- [Working in this PR app][demo].


[demo]: https://markdown-pr-471.herokuapp.com
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
