### PR TITLE
fix: save images in markdown format when they don't have a width

### DIFF
--- a/__tests__/__snapshots__/flavored-compilers.test.js.snap
+++ b/__tests__/__snapshots__/flavored-compilers.test.js.snap
@@ -67,18 +67,7 @@ exports[`ReadMe Magic Blocks Figure 1`] = `
 `;
 
 exports[`ReadMe Magic Blocks Image 1`] = `
-"[block:image]
-{
-  \\"images\\": [
-    {
-      \\"image\\": [
-        \\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\",
-        \\"rdme-blue.svg\\"
-      ]
-    }
-  ]
-}
-[/block]
+"![](https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg \\"rdme-blue.svg\\")
 "
 `;
 

--- a/processor/compile/image.js
+++ b/processor/compile/image.js
@@ -2,9 +2,13 @@ module.exports = function ImageCompiler() {
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
 
+  const originalImageCompiler = visitors.image;
+
   visitors.image = function compile(node, ...args) {
     if (node.data?.hProperties?.className === 'emoji') return node.title;
 
-    return visitors.figure.call(this, node, ...args);
+    if (node.data.hProperties.width) return visitors.figure.call(this, node, ...args);
+
+    return originalImageCompiler.call(this, node, ...args);
   };
 };


### PR DESCRIPTION
[![PR App][icn]][demo] | 
:-------------------:|

## 🧰 Changes

In order to allow images in tables, we're going to save them in markdown format when they don't have a width, so we don't try to nest magic blocks (images saved as figures) within magic blocks (tables).

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
