### PR TITLE
Glossary fixes

### DIFF
--- a/__tests__/GlossaryItem.test.jsx
+++ b/__tests__/GlossaryItem.test.jsx
@@ -12,7 +12,19 @@ test('should output a glossary item if the term exists', () => {
   expect(container.querySelector('.tooltip-content-body')).toHaveTextContent(`${term} - ${definition}`);
 });
 
-test('should output nothing if the term does not exist', () => {
-  const { container } = render(<GlossaryItem term="something" terms={[]} />);
-  expect(container).toBeEmptyDOMElement();
+test('should be case insensitive', () => {
+  const term = 'aCme';
+  const definition = 'This is a definition';
+  const { container } = render(<GlossaryItem term="acme" terms={[{ term, definition }]} />);
+
+  expect(container.querySelector('.glossary-item.highlight')).toHaveTextContent('acme');
+  expect(container.querySelector('.tooltip-content-body')).toHaveTextContent(`${term} - ${definition}`);
+});
+
+test('should output the term if the term does not exist', () => {
+  const term = 'something';
+  const { container } = render(<GlossaryItem term={term} terms={[]} />);
+
+  expect(container.querySelector('.glossary-item.highlight')).not.toBeInTheDocument();
+  expect(container.querySelector('span')).toHaveTextContent(term);
 });

--- a/components/GlossaryItem.jsx
+++ b/components/GlossaryItem.jsx
@@ -5,13 +5,13 @@ const GlossaryContext = require('../contexts/GlossaryTerms');
 
 // https://github.com/readmeio/api-explorer/blob/0dedafcf71102feedaa4145040d3f57d79d95752/packages/api-explorer/src/lib/replace-vars.js#L8
 function GlossaryItem({ term, terms }) {
-  const foundTerm = terms.find(i => term === i.term);
+  const foundTerm = terms.find(i => term.toLowerCase() === i.term.toLowerCase());
 
   if (!foundTerm) return null;
 
   return (
     <span className="glossary-tooltip" v={foundTerm.term}>
-      <span className="glossary-item highlight">{foundTerm.term}</span>
+      <span className="glossary-item highlight">{term}</span>
       <span className="tooltip-content">
         <span className="tooltip-content-body">
           <strong className="term">{foundTerm.term}</strong> - {foundTerm.definition}

--- a/components/GlossaryItem.jsx
+++ b/components/GlossaryItem.jsx
@@ -7,7 +7,7 @@ const GlossaryContext = require('../contexts/GlossaryTerms');
 function GlossaryItem({ term, terms }) {
   const foundTerm = terms.find(i => term.toLowerCase() === i.term.toLowerCase());
 
-  if (!foundTerm) return null;
+  if (!foundTerm) return <span>{term}</span>;
 
   return (
     <span className="glossary-tooltip" v={foundTerm.term}>


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

This does a few things!
- [ ] Makes the glossary case-insensitive
- [ ] If no glossary term matches, it still returns the original word (rather than just nothing)

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
