### PR TITLE
fix: add protocol to links

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -1030,6 +1030,6 @@ exports[`magic image 1`] = `"<figure><span aria-label=\\"A guy. Eating pizza. An
 
 exports[`prefix anchors with "section-" should add a section- prefix to heading anchors 1`] = `"<h1 id=\\"heading\\">heading</h1>"`;
 
-exports[`protocol should be added to links 1`] = `"<p><a href=\\"http://www.example.com\\" target=\\"\\" title=\\"\\">link without protocol</a></p>"`;
+exports[`protocol should be added to links 1`] = `"<p><a href=\\"https://www.example.com\\" target=\\"\\" title=\\"\\">link without protocol</a></p>"`;
 
 exports[`tables 1`] = `"<div class=\\"rdmd-table\\"><div class=\\"rdmd-table-inner\\"><table><thead><tr><th>Tables</th><th style=\\"text-align: center;\\">Are</th><th style=\\"text-align: right;\\">Cool</th></tr></thead><tbody><tr><td>col 3 is</td><td style=\\"text-align: center;\\">right-aligned</td><td style=\\"text-align: right;\\">$1600</td></tr><tr><td>col 2 is</td><td style=\\"text-align: center;\\">centered</td><td style=\\"text-align: right;\\">$12</td></tr><tr><td>zebra stripes</td><td style=\\"text-align: center;\\">are neat</td><td style=\\"text-align: right;\\">$1</td></tr></tbody></table></div></div>"`;

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -1030,4 +1030,6 @@ exports[`magic image 1`] = `"<figure><span aria-label=\\"A guy. Eating pizza. An
 
 exports[`prefix anchors with "section-" should add a section- prefix to heading anchors 1`] = `"<h1 id=\\"heading\\">heading</h1>"`;
 
+exports[`protocol should be added to links 1`] = `"<p><a href=\\"http://www.example.com\\" target=\\"\\" title=\\"\\">link without protocol</a></p>"`;
+
 exports[`tables 1`] = `"<div class=\\"rdmd-table\\"><div class=\\"rdmd-table-inner\\"><table><thead><tr><th>Tables</th><th style=\\"text-align: center;\\">Are</th><th style=\\"text-align: right;\\">Cool</th></tr></thead><tbody><tr><td>col 3 is</td><td style=\\"text-align: center;\\">right-aligned</td><td style=\\"text-align: right;\\">$1600</td></tr><tr><td>col 2 is</td><td style=\\"text-align: center;\\">centered</td><td style=\\"text-align: right;\\">$12</td></tr><tr><td>zebra stripes</td><td style=\\"text-align: center;\\">are neat</td><td style=\\"text-align: right;\\">$1</td></tr></tbody></table></div></div>"`;

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -132,6 +132,16 @@ test('anchors', () => {
   expect(container.innerHTML).toMatchSnapshot();
 });
 
+test('protocol should be added to links', () => {
+  const { container } = render(
+    markdown.default(`
+[link without protocol](www.example.com)
+`)
+  );
+
+  expect(container.innerHTML).toMatchSnapshot();
+});
+
 test('anchor target: should default to _self', () => {
   const { container } = render(markdown.default('[test](https://example.com)'));
   expect(container.innerHTML).toMatchSnapshot();

--- a/components/Anchor.jsx
+++ b/components/Anchor.jsx
@@ -34,7 +34,7 @@ function getHref(href, baseUrl) {
   const regex = /^(www.)+/;
   if (!regex.test(href)) return href;
 
-  const hrefWithAddedProtocol = 'http://'.concat(href);
+  const hrefWithAddedProtocol = 'https://'.concat(href);
   return hrefWithAddedProtocol;
 }
 

--- a/components/Anchor.jsx
+++ b/components/Anchor.jsx
@@ -31,7 +31,11 @@ function getHref(href, baseUrl) {
     return `${base}/page/${custompage[1]}`;
   }
 
-  return href;
+  const regex = /^(www.)+/;
+  if (!regex.test(href)) return href;
+
+  const hrefWithAddedProtocol = 'http://'.concat(href);
+  return hrefWithAddedProtocol;
 }
 
 function docLink(href) {


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4169
:-------------------:|:----------:

## 🧰 Changes

Describe your changes in detail.

This fix doesn't work for links like 'bbc.co.uk', but maybe that's okay? It also doesn't address [this other backlog ticket](https://linear.app/readme-io/issue/RM-1193/insert-link-protocols-when-obvious).

## 🧬 QA & Testing

Test with the following:
```
[link to docs](doc:hello)
[link without protocol](www.bbc.co.uk)
[link with protocol](http://www.bbc.co.uk)
[link with secure protocol](https://www.bbc.co.uk)
```

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
