### PR TITLE
chore: auto-deploy changes to Heroku (markdown-demo)

### DIFF
--- a/.github/workflows/autodeploy.yaml
+++ b/.github/workflows/autodeploy.yaml
@@ -1,0 +1,17 @@
+name: Auto-deploy to Heroku
+
+on: push
+
+jobs:
+  deploy-to-production:
+    name: Deploy next to markdown-demo
+    if: github.event_name == 'push' && github.event.ref == 'refs/heads/next'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_email: ${{secrets.HEROKU_EMAIL}}
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: 'markdown-demo'
+          dontautocreate: true


### PR DESCRIPTION
This configures a GitHub Action to automatically deploy the Heroku app `markdown-demo` whenever changes are pushed to the `next` branch of this (`readmeio/markdown`) repo. This essentially restores the auto-deploy feature that we lost in the Great Heroku Security Mess! But it doesn't bring back automatic PR review apps just yet.

@erunion @domharrington @rafegoldberg @kellyjosephprice (Y'all seem to be active in this repo) Heads up that this will change the behavior of this repo, and will start publishing `main` commits directly to production again. You can see the status of the deploy on [the "Actions" tab of this repo](https://github.com/readmeio/markdown/actions), and also in [the "Activity" tab of the Heroku app](https://dashboard.heroku.com/apps/markdown-demo/activity).