### PR TITLE
fix(table): correctly save magic block

### DIFF
--- a/__tests__/__snapshots__/flavored-compilers.test.js.snap
+++ b/__tests__/__snapshots__/flavored-compilers.test.js.snap
@@ -98,16 +98,18 @@ exports[`ReadMe Magic Blocks Tables 1`] = `
 exports[`ReadMe Magic Blocks Tables with breaks 1`] = `
 "[block:parameters]
 {
+  \\"data\\": {
+    \\"h-0\\": \\"th 1\\",
+    \\"h-1\\": \\"th 2\\",
+    \\"0-0\\": \\"cell 1  \\\\nafter the break\\",
+    \\"0-1\\": \\"cell 2\\"
+  },
+  \\"cols\\": 2,
+  \\"rows\\": 1,
   \\"align\\": [
     \\"center\\",
     \\"center\\"
-  ],
-  \\"cols\\": 2,
-  \\"rows\\": 2,
-  \\"h-0\\": \\"th 1\\",
-  \\"h-1\\": \\"th 2\\",
-  \\"0-0\\": \\"cell 1  \\\\nafter the break\\",
-  \\"0-1\\": \\"cell 2\\"
+  ]
 }
 [/block]
 "

--- a/__tests__/flavored-compilers/tables.test.js
+++ b/__tests__/flavored-compilers/tables.test.js
@@ -1,0 +1,99 @@
+import { mdast, md } from '../../index';
+
+describe('table compiler', () => {
+  it('converts to markdown syntax', () => {
+    const markdown = `
+[block:parameters]
+{
+  "data": {
+    "h-0": "th 1",
+    "h-1": "th 2",
+    "0-0": "cell 1",
+    "0-1": "cell 2"
+  },
+  "cols": 2,
+  "rows": 1,
+  "align": [
+    "center",
+    "center"
+  ]
+}
+[/block]
+`;
+
+    expect(md(mdast(markdown))).toBe(
+      `|  th 1  |  th 2  |
+| :----: | :----: |
+| cell 1 | cell 2 |
+`
+    );
+  });
+
+  it('saves to magic block syntax if there are breaks', () => {
+    const markdown = `
+[block:parameters]
+{
+  "data": {
+    "h-0": "th 1",
+    "h-1": "th 2",
+    "0-0": "cell 1\\nextra line",
+    "0-1": "cell 2"
+  },
+  "cols": 2,
+  "rows": 1,
+  "align": [
+    "center",
+    "center"
+  ]
+}
+[/block]
+`;
+
+    expect(md(mdast(markdown))).toBe(`[block:parameters]
+{
+  "data": {
+    "h-0": "th 1",
+    "h-1": "th 2",
+    "0-0": "cell 1  \\nextra line",
+    "0-1": "cell 2"
+  },
+  "cols": 2,
+  "rows": 1,
+  "align": [
+    "center",
+    "center"
+  ]
+}
+[/block]
+`);
+  });
+
+  it('converts to magic block syntax if there are breaks', () => {
+    const markdown = `
+|  th 1  |  th 2  |
+| :----: | :----: |
+| cell 1 | cell 2 |
+`;
+    const nodes = mdast(markdown);
+    const cell = nodes.children[0].children[1].children[0];
+    cell.children = [...cell.children, { type: 'break' }, { type: 'text', value: 'extra line' }];
+
+    expect(md(nodes)).toBe(`[block:parameters]
+{
+  "data": {
+    "h-0": "th 1",
+    "h-1": "th 2",
+    "0-0": "cell 1  \\nextra line",
+    "0-1": "cell 2"
+  },
+  "cols": 2,
+  "rows": 1,
+  "align": [
+    "center",
+    "center"
+  ]
+}
+[/block]
+`);
+  });
+});

--- a/processor/compile/table.js
+++ b/processor/compile/table.js
@@ -17,9 +17,10 @@ module.exports = function TableCompiler() {
     }
 
     const data = {
-      align: [...node.align],
+      data: {},
       cols: node.children[0]?.children?.length || 0,
-      rows: node.children.length,
+      rows: node.children.length - 1,
+      align: [...node.align],
     };
 
     node.children.forEach((row, i) => {
@@ -27,7 +28,7 @@ module.exports = function TableCompiler() {
         const col = i === 0 ? 'h' : i - 1;
         const string = this.all(cell).join('').replace(/\\\n/g, '  \n');
 
-        data[`${col}-${j}`] = string;
+        data.data[`${col}-${j}`] = string;
       });
     });
 


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4309
:-------------------:|:----------:

## 🧰 Changes

The custom table compiler was not correctly saving back to magic block :(.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
