### PR TITLE
fix: swap out our custom heading tokenizer to more closely follow remark-parse

### DIFF
--- a/__tests__/__snapshots__/disabling-tokenizers.test.js.snap
+++ b/__tests__/__snapshots__/disabling-tokenizers.test.js.snap
@@ -7,7 +7,7 @@ Object {
       "children": Array [
         Object {
           "type": "text",
-          "value": "#  heading 1",
+          "value": "# heading 1",
         },
       ],
       "type": "paragraph",
@@ -75,7 +75,7 @@ Object {
       "children": Array [
         Object {
           "type": "text",
-          "value": "#  heading 1",
+          "value": "# heading 1",
         },
       ],
       "type": "paragraph",

--- a/__tests__/flavored-parsers/__snapshots__/compact-headings.test.js.snap
+++ b/__tests__/flavored-parsers/__snapshots__/compact-headings.test.js.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Compact headings can parse compact headings 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 33,
+              "line": 1,
+              "offset": 32,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 18,
+              "line": 1,
+              "offset": 17,
+            },
+          },
+          "type": "text",
+          "value": "Compact Heading",
+        },
+      ],
+      "depth": 1,
+      "position": Position {
+        "end": Object {
+          "column": 1,
+          "line": 2,
+          "offset": 17,
+        },
+        "indent": Array [
+          1,
+        ],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "heading",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 2,
+      "line": 3,
+      "offset": 19,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;
+
+exports[`Compact headings can parse headings that are not compact 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 22,
+              "line": 1,
+              "offset": 21,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+          },
+          "type": "text",
+          "value": "Non-compact Heading",
+        },
+      ],
+      "depth": 1,
+      "position": Position {
+        "end": Object {
+          "column": 22,
+          "line": 1,
+          "offset": 21,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "heading",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 2,
+      "line": 3,
+      "offset": 24,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/__tests__/flavored-parsers/compact-headings.test.js
+++ b/__tests__/flavored-parsers/compact-headings.test.js
@@ -1,0 +1,13 @@
+import { mdast } from '../../index';
+
+describe('Compact headings', () => {
+  it('can parse compact headings', () => {
+    const heading = `#Compact Heading`;
+    expect(mdast(heading, { settings: { position: true } })).toMatchSnapshot();
+  });
+
+  it('can parse headings that are not compact', () => {
+    const heading = `# Non-compact Heading`;
+    expect(mdast(heading, { settings: { position: true } })).toMatchSnapshot();
+  });
+});

--- a/processor/parse/compact-headings.js
+++ b/processor/parse/compact-headings.js
@@ -1,11 +1,19 @@
-const rgx = /^(#+)([^\n]+)\n{1,}/;
+const rgx = /^(#{1,6})(?!(?:#|\s))([^\n]+)\n/;
 
 function tokenizer(eat, value) {
   if (!rgx.test(value)) return true;
 
   const [match, hash, text] = rgx.exec(value);
-  const block = this.tokenizeBlock([hash, text].join(' '), eat.now());
-  return eat(match)(block[0]);
+
+  const now = eat.now();
+  now.column += match.length;
+  now.offset += match.length;
+
+  return eat(match)({
+    type: 'heading',
+    depth: hash.length,
+    children: this.tokenizeInline(text, now),
+  });
 }
 
 function parser() {


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4298
:-------------------:|:----------:

## 🧰 Changes

We used to have a custom tokenizer to allow headers without a space between the # char and the heading content. It was resulting in the position data being skewed, which then meant that when we tried to normalize links in headers in the editor ([over here in this file](https://github.com/readmeio/readme/blob/1a8da465ae7775d1e189fc060256edfcae7aa75c/packages/react/src/ui/MarkdownEditor/editor/blocks/Link/normalizeNode.ts)) we crashed the page.

We've now adapted our tokenizer to closely follow remark-parse's approach (as [defined here](https://github.com/remarkjs/remark/blob/remark-stringify%407.0.2/packages/remark-parse/lib/tokenize/heading-atx.js)) but adapted the regex we match against to allow those cases without a space between the # char and the content.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
