### PR TITLE
fix: serializing images 😬

### DIFF
--- a/__tests__/flavored-compilers/images.test.js
+++ b/__tests__/flavored-compilers/images.test.js
@@ -1,0 +1,9 @@
+import { mdast, md } from '../../index';
+
+describe('image compiler', () => {
+  it('correctly serializes an image back to markdown', () => {
+    const txt = `![alt text](/path/to/image.png)`;
+
+    expect(md(mdast(txt))).toMatch(txt);
+  });
+});

--- a/processor/compile/image.js
+++ b/processor/compile/image.js
@@ -7,7 +7,7 @@ module.exports = function ImageCompiler() {
   visitors.image = function compile(node, ...args) {
     if (node.data?.hProperties?.className === 'emoji') return node.title;
 
-    if (node.data.hProperties.width) return visitors.figure.call(this, node, ...args);
+    if (node.data?.hProperties?.width) return visitors.figure.call(this, node, ...args);
 
     return originalImageCompiler.call(this, node, ...args);
   };


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4329
:-------------------:|:----------:

## 🧰 Changes

Saving images in tables was busted. The compiler needed some null checks. It looks like the editor was nicely inserting the `hProperties` when it had a 'full' image, but not when it was in a table.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
