### PR TITLE
feat: add escape type

### DIFF
--- a/__tests__/flavored-compilers/escape.test.js
+++ b/__tests__/flavored-compilers/escape.test.js
@@ -1,0 +1,9 @@
+import { mdast, md } from '../../index';
+
+describe('escape compiler', () => {
+  it('handles escapes', () => {
+    const txt = `\\&para;`;
+
+    expect(md(mdast(txt))).toBe(`\\&para;\n`);
+  });
+});

--- a/__tests__/flavored-parsers/__snapshots__/escape.test.js.snap
+++ b/__tests__/flavored-parsers/__snapshots__/escape.test.js.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Escape uses the "escape" type 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 1,
+              "line": 1,
+              "offset": 0,
+            },
+          },
+          "type": "escape",
+          "value": "&",
+        },
+        Object {
+          "position": Position {
+            "end": Object {
+              "column": 8,
+              "line": 1,
+              "offset": 7,
+            },
+            "indent": Array [],
+            "start": Object {
+              "column": 3,
+              "line": 1,
+              "offset": 2,
+            },
+          },
+          "type": "text",
+          "value": "para;",
+        },
+      ],
+      "position": Position {
+        "end": Object {
+          "column": 8,
+          "line": 1,
+          "offset": 7,
+        },
+        "indent": Array [],
+        "start": Object {
+          "column": 1,
+          "line": 1,
+          "offset": 0,
+        },
+      },
+      "type": "paragraph",
+    },
+  ],
+  "position": Object {
+    "end": Object {
+      "column": 2,
+      "line": 3,
+      "offset": 10,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+      "offset": 0,
+    },
+  },
+  "type": "root",
+}
+`;

--- a/__tests__/flavored-parsers/escape.test.js
+++ b/__tests__/flavored-parsers/escape.test.js
@@ -1,0 +1,8 @@
+import { mdast } from '../../index';
+
+describe('Escape', () => {
+  it('uses the "escape" type', () => {
+    const md = `\\&para;`;
+    expect(mdast(md, { settings: { position: true } })).toMatchSnapshot();
+  });
+});

--- a/processor/compile/escape.js
+++ b/processor/compile/escape.js
@@ -1,0 +1,8 @@
+module.exports = function EscapeCompiler() {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+
+  visitors.escape = function compile(node) {
+    return `\\${node.value}`;
+  };
+};

--- a/processor/compile/index.js
+++ b/processor/compile/index.js
@@ -1,6 +1,7 @@
 export { default as breakCompiler } from './break';
 export { default as codeTabsCompiler } from './code-tabs';
 export { default as divCompiler } from './div';
+export { default as escapeCompiler } from './escape';
 export { default as figureCompiler } from './figure';
 export { default as htmlBlockCompiler } from './html-block';
 export { default as iconCompiler } from './i';

--- a/processor/parse/escape.js
+++ b/processor/parse/escape.js
@@ -1,0 +1,46 @@
+// @note: this is copied from https://github.com/remarkjs/remark/blob/remark-parse%407.0.2/packages/remark-parse/lib/tokenize/escape.js
+
+const lineFeed = '\n';
+const backslash = '\\';
+
+// eslint-disable-next-line consistent-return
+function escape(eat, value, silent) {
+  const self = this;
+  let character;
+  let node;
+
+  if (value.charAt(0) === backslash) {
+    character = value.charAt(1);
+
+    if (self.escape.indexOf(character) !== -1) {
+      if (silent) {
+        return true;
+      }
+
+      if (character === lineFeed) {
+        node = { type: 'break' };
+      } else {
+        node = { type: 'escape', value: character };
+      }
+
+      return eat(backslash + character)(node);
+    }
+  }
+}
+
+function locate(value, fromIndex) {
+  return value.indexOf('\\', fromIndex);
+}
+
+escape.locator = locate;
+
+function parser() {
+  const { Parser } = this;
+  const { inlineTokenizers } = Parser.prototype;
+
+  inlineTokenizers.escape = escape;
+}
+
+parser.sanitize = () => parser;
+
+export default parser;

--- a/processor/parse/index.js
+++ b/processor/parse/index.js
@@ -4,6 +4,7 @@ export { default as flavorCodeTabs } from './flavored/code-tabs';
 export { default as flavorCallout } from './flavored/callout';
 export { default as flavorEmbed } from './flavored/embed';
 
+export { default as escape } from './escape';
 export { default as compactHeadings } from './compact-headings';
 export { default as variableParser } from './variable-parser';
 export { default as gemojiParser } from './gemoji-parser';


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4340
:-------------------:|:----------:

## 🧰 Changes

Adds an 'escape' type.

Our markdown editor has no way to discern if an element has been escaped or not. Consider the markdown:
```
\&para;
```

This will be represented in `mdast` roughly as:
```
{
  type: 'text',
  value: '&',
}, {
  type: 'text',
  value: 'para;'
}
```

This PR changes that to:
```
{
  type: 'escape',
  value: '&',
}, {
  type: 'text',
  value: 'para;'
}
```

This will enable our editor to re-add the necessary backslash.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
