### PR TITLE
chore: auto-open Markdown review apps on Heroku

### DIFF
--- a/.github/workflows/review-app.yaml
+++ b/.github/workflows/review-app.yaml
@@ -1,0 +1,20 @@
+name: Heroku Review App
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Update Heroku
+        uses: readmeio/heroku-review-app-action@main
+        with:
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}
+          heroku_api_key: ${{ secrets.HEROKU_API_KEY }}
+          pipeline_name: markdown


### PR DESCRIPTION
This uses [our new GitHub Action for managing Heroku review apps](https://github.com/readmeio/heroku-review-app-action) to deploy review apps for Markdown, just like it worked before April 15.

* When a Pull Request is opened or reopened, a review app is created in the [`markdown` pipeline](https://dashboard.heroku.com/pipelines/ab10f22a-8076-49ce-8e4f-5968280b2e59) on Heroku
* When a Pull Request is [synchronized](https://github.community/t/what-is-a-pull-request-synchronize-event/14784), the review app is rebuilt with the latest source
* When a Pull Request is closed, the review app is deleted

For more information, check out the GitHub Action repo linked above.