### PR TITLE
feat: add yaml compiler

### DIFF
--- a/__tests__/flavored-compilers/yaml.test.js
+++ b/__tests__/flavored-compilers/yaml.test.js
@@ -1,0 +1,22 @@
+import { mdast, md } from '../../index';
+
+describe('yaml compiler', () => {
+  it('correctly writes out yaml', () => {
+    const txt = `
+---
+title: This is test
+author: A frontmatter test
+---
+
+Document content!
+    `;
+
+    expect(md(mdast(txt))).toBe(`---
+title: This is test
+author: A frontmatter test
+---
+
+Document content!
+`);
+  });
+});

--- a/processor/compile/index.js
+++ b/processor/compile/index.js
@@ -13,3 +13,4 @@ export { default as rdmePinCompiler } from './pin';
 export { default as rdmeVarCompiler } from './var';
 export { default as tableCompiler } from './table';
 export { default as tableHeadCompiler } from './table-head';
+export { default as yamlCompiler } from './yaml';

--- a/processor/compile/yaml.js
+++ b/processor/compile/yaml.js
@@ -1,0 +1,8 @@
+module.exports = function YamlCompiler() {
+  const { Compiler } = this;
+  const { visitors } = Compiler.prototype;
+
+  visitors.yaml = function compile(node) {
+    return `---\n${node.value}\n---`;
+  };
+};


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4430
:-------------------:|:----------:

## 🧰 Changes

Adds a compiler for frontmatter.

If you try to save a doc in the editor with frontmatter, the save currently fails! Something like the following:

```
---
title: Getting started
---

Coming content
```

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-509.herokuapp.com
[prod]: https://dash.readme.com/project/pismo-docs/v1.0/docs/old-draft-authentication-with-openid-connect-for-servers
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
