### PR TITLE
feat: add safeMode flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Each processor method takes an options object which you can use to adjust the ou
 - **`copyButtons`** — Automatically insert a button to copy a block of text to the clipboard. Currently used on `<code>` elements.
 - **`correctnewlines`** — Render new line delimeters as `<br>` tags.
 - **`markdownOptions`** — Remark [parser options](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#processorusestringify-options).
+- **`safeMode`** — Render html blocks as `<pre>` elements. We normally allow all manner of html attributes that could potentially execute JavaScript. 
 
 ## Flavored Syntax
 

--- a/__tests__/__snapshots__/magic-block-parser.test.js.snap
+++ b/__tests__/__snapshots__/magic-block-parser.test.js.snap
@@ -252,6 +252,7 @@ Object {
   <a class=\\"button\\">Go</a>
 </form>",
           "runScripts": undefined,
+          "safeMode": undefined,
         },
       },
       "type": "html-block",

--- a/__tests__/components/HTMLBlock.test.jsx
+++ b/__tests__/components/HTMLBlock.test.jsx
@@ -3,7 +3,8 @@ const React = require('react');
 const { renderToString } = require('react-dom/server');
 
 const sanitize = require('../../sanitize.schema');
-const HTMLBlock = require('../../components/HTMLBlock')(sanitize);
+const HTMLBlock = require('../../components/HTMLBlock')(sanitize, {});
+const { react } = require('../../index');
 
 describe('HTML Block', () => {
   beforeEach(() => {
@@ -31,5 +32,19 @@ describe('HTML Block', () => {
     expect(elem.props.runScripts).toBe(true);
     expect(view.indexOf('<script>')).toBeLessThan(0);
     expect(view.indexOf('<h1>')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('renders in the html in a `<pre>` tag if safeMode={true}', () => {
+    const md = `
+[block:html]
+${JSON.stringify({
+  html: '<button onload="alert(\'gotcha!\')"/>',
+})}
+[/block]
+    `;
+
+    expect(renderToString(react(md, { safeMode: true }))).toMatchInlineSnapshot(
+      `"<pre class=\\"html-unsafe\\" data-reactroot=\\"\\"><code>&lt;button onload=&quot;alert(&#x27;gotcha!&#x27;)&quot;/&gt;</code></pre>"`
+    );
   });
 });

--- a/__tests__/components/HTMLBlock.test.jsx
+++ b/__tests__/components/HTMLBlock.test.jsx
@@ -34,7 +34,7 @@ describe('HTML Block', () => {
     expect(view.indexOf('<h1>')).toBeGreaterThanOrEqual(0);
   });
 
-  it('renders in the html in a `<pre>` tag if safeMode={true}', () => {
+  it('renders the html in a `<pre>` tag if safeMode={true}', () => {
     const md = `
 [block:html]
 ${JSON.stringify({

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -26,6 +26,7 @@ test('it should have the proper utils exports', () => {
       setext: true,
     },
     normalize: true,
+    safeMode: false,
     settings: { position: false },
     theme: 'light',
   });

--- a/components/HTMLBlock/index.jsx
+++ b/components/HTMLBlock/index.jsx
@@ -3,7 +3,7 @@
 const React = require('react');
 const PropTypes = require('prop-types');
 
-const MATCH_SCRIPT_TAGS = /<script\b[^>]*>([\s\S]*?)<\/script>\n?/gim;
+const MATCH_SCRIPT_TAGS = /<script\b[^>]*>([\s\S]*?)<\/script *>\n?/gim;
 
 const extractScripts = (html = '') => {
   const scripts = [];

--- a/components/HTMLBlock/index.jsx
+++ b/components/HTMLBlock/index.jsx
@@ -27,21 +27,40 @@ class HTMLBlock extends React.Component {
   }
 
   render() {
+    const { html, safeMode } = this.props;
+
+    if (safeMode) {
+      return (
+        <pre className="html-unsafe">
+          <code>{html}</code>
+        </pre>
+      );
+    }
+
     return <div className="rdmd-html" dangerouslySetInnerHTML={{ __html: this.html }} />;
   }
 }
 
 HTMLBlock.defaultProps = {
   runScripts: false,
+  safeMode: false,
 };
 
 HTMLBlock.propTypes = {
   html: PropTypes.string,
   runScripts: PropTypes.any,
+  safeMode: PropTypes.bool,
 };
 
-module.exports = sanitize => {
+const CreateHtmlBlock =
+  ({ safeMode }) =>
+  // eslint-disable-next-line react/display-name
+  props =>
+    <HTMLBlock {...props} safeMode={safeMode} />;
+
+module.exports = (sanitize, opts) => {
   sanitize.tagNames.push('html-block');
   sanitize.attributes['html-block'] = ['html', 'runScripts'];
-  return HTMLBlock;
+
+  return CreateHtmlBlock(opts);
 };

--- a/components/HTMLBlock/style.scss
+++ b/components/HTMLBlock/style.scss
@@ -1,0 +1,5 @@
+.markdown-body {
+  pre.html-unsafe {
+    background-color: #fdd;
+  }
+}

--- a/components/index.js
+++ b/components/index.js
@@ -1,13 +1,11 @@
-export { default as GlossaryItem } from './GlossaryItem';
-export { default as Code } from './Code';
-export { default as Table } from './Table';
 export { default as Anchor } from './Anchor';
-export { default as Heading } from './Heading';
 export { default as Callout } from './Callout';
+export { default as Code } from './Code';
 export { default as CodeTabs } from './CodeTabs';
-export { default as Image } from './Image';
 export { default as Embed } from './Embed';
-
+export { default as GlossaryItem } from './GlossaryItem';
 export { default as HTMLBlock } from './HTMLBlock';
-
+export { default as Heading } from './Heading';
+export { default as Image } from './Image';
+export { default as Table } from './Table';
 export { default as TableOfContents } from './TableOfContents';

--- a/example/Demo.jsx
+++ b/example/Demo.jsx
@@ -69,7 +69,7 @@ function Demo({ opts }) {
                 <Fixtures
                   ci={ci}
                   getRoute={getRoute}
-                  render={props => <DemoContent {...props} ci={ci} opts={opts} />}
+                  render={({ options, ...props }) => <DemoContent {...props} ci={ci} opts={{ ...opts, ...options }} />}
                   selected={route}
                 />
               );

--- a/example/Fixtures/docs.js
+++ b/example/Fixtures/docs.js
@@ -2,6 +2,7 @@ import callouts from '../../docs/callouts.md';
 import codeBlocks from '../../docs/code-blocks.md';
 import embeds from '../../docs/embeds.md';
 import features from '../../docs/features.md';
+import gettingStarted from '../../docs/getting-started.md';
 import headings from '../../docs/headings.md';
 import images from '../../docs/images.md';
 import lists from '../../docs/lists.md';
@@ -15,17 +16,18 @@ import varsTest from '../../docs/variable-tests.md';
 const lowerCase = str => str.replaceAll(/([a-z])([A-Z])/g, (_, p1, p2) => `${p1} ${p2.toLowerCase()}`);
 
 const fixtureMap = Object.entries({
-  codeBlocks,
+  calloutTests,
   callouts,
+  codeBlockTests,
+  codeBlocks,
   embeds,
-  tables,
-  lists,
+  features,
+  gettingStarted,
   headings,
   images,
-  features,
-  calloutTests,
-  codeBlockTests,
+  lists,
   tableOfContentsTests,
+  tables,
   varsTest,
 }).reduce((memo, [sym, doc]) => {
   const name = lowerCase(sym);

--- a/example/Fixtures/index.jsx
+++ b/example/Fixtures/index.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import syntaxFixtures from './docs';
 
 const Fixtures = ({ render, selected, getRoute }) => {
   const [edited, setEdited] = useState(null);
+  const [options, setOptions] = useState({ safeMode: false });
 
   const handleSelect = event => {
     getRoute(event.target.value);
@@ -13,6 +14,12 @@ const Fixtures = ({ render, selected, getRoute }) => {
     setEdited(event.target.value);
     getRoute('edited');
   };
+  const onChangeSafeMode = useCallback(() => {
+    setOptions({
+      ...options,
+      safeMode: !options.safeMode,
+    });
+  }, [options]);
 
   let fixture;
   let name;
@@ -24,24 +31,31 @@ const Fixtures = ({ render, selected, getRoute }) => {
   }
 
   const fields = (
-    <fieldset className="rdmd-demo--fixture-select">
-      <label className="rdmd-demo--label" htmlFor="fixture-select">
-        fixture
-      </label>
-      <select className="rdmd-demo--select" id="fixture-select" onChange={handleSelect} value={selected}>
-        {edited && <option value={'edited'}>** modified **</option>}
-        {Object.entries(syntaxFixtures).map(([sym, { name: _name }]) => {
-          return (
-            <option key={sym} value={sym}>
-              {_name}
-            </option>
-          );
-        })}
-      </select>
-    </fieldset>
+    <>
+      <fieldset className="rdmd-demo--fieldset rdmd-demo--options">
+        <legend>Options</legend>
+        <div>
+          <label htmlFor="safe-mode">Safe Mode</label>
+          <input id="safe-mode" onChange={onChangeSafeMode} type="checkbox" value={options.safeMode} />
+        </div>
+      </fieldset>
+      <fieldset className="rdmd-demo--fieldset">
+        <legend>Fixture</legend>
+        <select id="fixture-select" onChange={handleSelect} value={selected}>
+          {edited && <option value={'edited'}>** modified **</option>}
+          {Object.entries(syntaxFixtures).map(([sym, { name: _name }]) => {
+            return (
+              <option key={sym} value={sym}>
+                {_name}
+              </option>
+            );
+          })}
+        </select>
+      </fieldset>
+    </>
   );
 
-  return render({ children: fields, name, fixture, onChange });
+  return render({ children: fields, name, fixture, onChange, options });
 };
 
 Fixtures.propTypes = {

--- a/example/demo.scss
+++ b/example/demo.scss
@@ -86,23 +86,28 @@
     flex-direction: row;
   }
 
-  .rdmd-demo--fixture-select {
-    padding: 0 0 1em;
+  .rdmd-demo--fieldset {
+    padding: 1em 0;
     border: none;
     border-top: 1px solid #eee;
     display: flex;
-    justify-content: space-between;
-  }
+    justify-content: flex-end;
 
-  .rdmd-demo--label {
-    text-transform: uppercase;
-    color: #bbb;
-  }
+    legend {
+      text-transform: uppercase;
+      color: #bbb;
+    }
 
-  .rdmd-demo--select {
-    min-width: 50%;
-    color: #555;
-    margin-top: 1em;
+    select {
+      min-width: 50%;
+      color: #555;
+    }
+
+    div {
+      width: 33%;
+      display: flex;
+      justify-content: space-between;
+    }
   }
 
   [name='demo-editor'] {

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ export function reactProcessor(opts = {}, components = {}) {
       Fragment: React.Fragment,
       components: {
         'code-tabs': CodeTabs(sanitize, opts),
-        'html-block': HTMLBlock(sanitize),
+        'html-block': HTMLBlock(sanitize, opts),
         'rdme-callout': Callout(sanitize),
         'readme-variable': Variable,
         'readme-glossary-item': GlossaryItem,

--- a/options.js
+++ b/options.js
@@ -13,6 +13,7 @@ const options = {
     setext: true,
   },
   normalize: true,
+  safeMode: false,
   settings: {
     position: false,
   },

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -2,6 +2,7 @@
 const RGXP = /^\[block:(.*)\]([^]+?)\[\/block\]/;
 
 let compatibilityMode;
+let safeMode;
 
 const WrapPinnedBlocks = (node, json) => {
   if (!json.sidebar) return node;
@@ -249,6 +250,7 @@ function tokenize(eat, value) {
               hProperties: {
                 html: json.html,
                 runScripts: compatibilityMode,
+                safeMode,
               },
             },
           },
@@ -281,6 +283,7 @@ function parser() {
   const methods = Parser.prototype.blockMethods;
 
   if (this.data('compatibilityMode')) compatibilityMode = true;
+  if (this.data('safeMode')) safeMode = true;
 
   tokenizers.magicBlocks = tokenize;
   methods.splice(methods.indexOf('newline'), 0, 'magicBlocks');

--- a/styles/components.scss
+++ b/styles/components.scss
@@ -1,15 +1,9 @@
 @import '../components/Image/style.scss';
-
 @import '../components/Table/style.scss';
-
 @import '../components/TableOfContents/style.scss';
-
 @import '../components/Code/style.scss';
-
 @import '../components/CodeTabs/style.scss';
-
 @import '../components/Callout/style.scss';
-
 @import '../components/Heading/style.scss';
-
+@import '../components/HTMLBlock/style.scss';
 @import '../components/Embed/style.scss';


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4509
:-------------------:|:----------:

## 🧰 Changes

Adds a `safeMode` flag. When run with `safeMode: true`, we no longer render html blocks. This is to prevent a wide range of vulnerabilities that are available via iframes, script tags, and attributes that allow javascript.

There are cases where we want to render 'untrusted' markdown (via suggested edits). Since we want to still allow the full range of html within html blocks, but we also need to be able to render untrusted changes, this seemed like a good compromise.

## 🧬 QA & Testing

You can try it out in the [PR app][demo]. The 'getting started' page has a short html block at the bottom. If you enable the `safeMode` flag, you should be able to see it render as a `<pre>` element.

![image](https://user-images.githubusercontent.com/451488/173458145-83b3fbe5-7d3e-443a-9b17-8591f786e038.png)

![image](https://user-images.githubusercontent.com/451488/173458179-1cc18091-007b-49f0-9992-bca2ad3122ad.png)

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-517.herokuapp.com/#getting-started
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
