### PR TITLE
fix: escape html when rendering in safeMode

### DIFF
--- a/__tests__/components/HTMLBlock.test.jsx
+++ b/__tests__/components/HTMLBlock.test.jsx
@@ -44,7 +44,7 @@ ${JSON.stringify({
     `;
 
     expect(renderToString(react(md, { safeMode: true }))).toMatchInlineSnapshot(
-      `"<pre class=\\"html-unsafe\\" data-reactroot=\\"\\"><code>&lt;button onload=&quot;alert(&#x27;gotcha!&#x27;)&quot;/&gt;</code></pre>"`
+      `"<pre class=\\"html-unsafe\\" data-reactroot=\\"\\"><code>&amp;lt;button onload=&quot;alert(&#x27;gotcha!&#x27;)&quot;/&amp;gt;</code></pre>"`
     );
   });
 });

--- a/components/HTMLBlock/index.jsx
+++ b/components/HTMLBlock/index.jsx
@@ -15,6 +15,13 @@ const extractScripts = (html = '') => {
   return [cleaned, () => scripts.map(js => window.eval(js))];
 };
 
+/**
+ * @hack: https://stackoverflow.com/a/30930653/659661
+ */
+const escapeHTML = html => {
+  return document.createElement('div').appendChild(document.createTextNode(html)).parentNode.innerHTML;
+};
+
 class HTMLBlock extends React.Component {
   constructor(props) {
     super(props);
@@ -32,7 +39,7 @@ class HTMLBlock extends React.Component {
     if (safeMode) {
       return (
         <pre className="html-unsafe">
-          <code>{html}</code>
+          <code>{escapeHTML(html)}</code>
         </pre>
       );
     }


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4509
:-------------------:|:----------:

## 🧰 Changes

This actually escapes html characters when rendering them via `safeMode`. :grimacing:

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
