### PR TITLE
escapes support node

### DIFF
--- a/__tests__/components/HTMLBlock.test.jsx
+++ b/__tests__/components/HTMLBlock.test.jsx
@@ -44,7 +44,7 @@ ${JSON.stringify({
     `;
 
     expect(renderToString(react(md, { safeMode: true }))).toMatchInlineSnapshot(
-      `"<pre class=\\"html-unsafe\\" data-reactroot=\\"\\"><code>&amp;lt;button onload=&quot;alert(&#x27;gotcha!&#x27;)&quot;/&amp;gt;</code></pre>"`
+      `"<pre class=\\"html-unsafe\\" data-reactroot=\\"\\"><code>&amp;lt;button onload=&amp;quot;alert(&amp;#39;gotcha!&amp;#39;)&amp;quot;/&amp;gt;</code></pre>"`
     );
   });
 });

--- a/components/HTMLBlock/index.jsx
+++ b/components/HTMLBlock/index.jsx
@@ -2,6 +2,7 @@
  */
 const React = require('react');
 const PropTypes = require('prop-types');
+const escape = require('lodash.escape');
 
 const MATCH_SCRIPT_TAGS = /<script\b[^>]*>([\s\S]*?)<\/script *>\n?/gim;
 
@@ -13,13 +14,6 @@ const extractScripts = (html = '') => {
   }
   const cleaned = html.replace(MATCH_SCRIPT_TAGS, '');
   return [cleaned, () => scripts.map(js => window.eval(js))];
-};
-
-/**
- * @hack: https://stackoverflow.com/a/30930653/659661
- */
-const escapeHTML = html => {
-  return document.createElement('div').appendChild(document.createTextNode(html)).parentNode.innerHTML;
 };
 
 class HTMLBlock extends React.Component {
@@ -39,7 +33,7 @@ class HTMLBlock extends React.Component {
     if (safeMode) {
       return (
         <pre className="html-unsafe">
-          <code>{escapeHTML(html)}</code>
+          <code>{escape(html)}</code>
         </pre>
       );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "copy-to-clipboard": "^3.3.1",
         "hast-util-sanitize": "^4.0.0",
         "hast-util-to-string": "^1.0.4",
+        "lodash.escape": "^4.0.1",
         "lodash.kebabcase": "^4.1.1",
         "mdast-util-toc": "^5.1.0",
         "path-browserify": "^1.0.1",
@@ -14611,6 +14612,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
+    },
+    "node_modules/lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
     },
     "node_modules/lodash.escaperegexp": {
       "version": "4.1.2",
@@ -34063,6 +34069,11 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
+    },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw=="
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "copy-to-clipboard": "^3.3.1",
     "hast-util-sanitize": "^4.0.0",
     "hast-util-to-string": "^1.0.4",
+    "lodash.escape": "^4.0.1",
     "lodash.kebabcase": "^4.1.1",
     "mdast-util-toc": "^5.1.0",
     "path-browserify": "^1.0.1",


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4509
:-------------------:|:----------:

## 🧰 Changes

Uses an escape function that works in node, for when rendering html via `safeMode`.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
