### PR TITLE
fix escaping again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 ===
 
+## Version 6.43.2
+
+### 🛠 Fixes & Updates
+
+* support safeMode in node ([#520](https://github.com/readmeio/markdown/issues/520)) ([e5f7a74](https://github.com/readmeio/markdown/commit/e5f7a746ea80d53e15e95491e3b00fcd470d80de))
+
 ## Version 6.43.1
 
 ### 🛠 Fixes & Updates

--- a/__tests__/components/HTMLBlock.test.jsx
+++ b/__tests__/components/HTMLBlock.test.jsx
@@ -44,7 +44,7 @@ ${JSON.stringify({
     `;
 
     expect(renderToString(react(md, { safeMode: true }))).toMatchInlineSnapshot(
-      `"<pre class=\\"html-unsafe\\" data-reactroot=\\"\\"><code>&amp;lt;button onload=&amp;quot;alert(&amp;#39;gotcha!&amp;#39;)&amp;quot;/&amp;gt;</code></pre>"`
+      `"<pre class=\\"html-unsafe\\" data-reactroot=\\"\\"><code>&lt;button onload=&quot;alert(&#39;gotcha!&#39;)&quot;/&gt;</code></pre>"`
     );
   });
 });

--- a/components/HTMLBlock/index.jsx
+++ b/components/HTMLBlock/index.jsx
@@ -33,7 +33,7 @@ class HTMLBlock extends React.Component {
     if (safeMode) {
       return (
         <pre className="html-unsafe">
-          <code>{escape(html)}</code>
+          <code dangerouslySetInnerHTML={{ __html: escape(html) }} />
         </pre>
       );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@readme/markdown",
-  "version": "6.43.1",
+  "version": "6.43.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@readme/markdown",
-      "version": "6.43.1",
+      "version": "6.43.2",
       "license": "MIT",
       "dependencies": {
         "@readme/emojis": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@readme/markdown",
   "description": "ReadMe's React-based Markdown parser",
   "author": "Rafe Goldberg <rafe@readme.io>",
-  "version": "6.43.1",
+  "version": "6.43.2",
   "main": "dist/main.node.js",
   "browser": "dist/main.js",
   "files": [


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4509
:-------------------:|:----------:

## 🧰 Changes

Ugh. Correctly render escaped html by setting it via `dangerouslySetInnerHtml`.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
