### PR TITLE
style(demo): polish sticky scrolling

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -71,6 +71,6 @@ The `utils` export gives you access to various tools and configuration settings:
   React provider and consumer wrappers for [user data injection](doc:features#section-data-injection).
 [block:html]
 {
-  "html": "<style>\n  .markdown-body .callout.callout_default[theme=🧙‍]{\n    --background: #fffae7;\n    --border: #e6b8086e;\n    --title: #e0b400;\n  }\n</style>"
+  "html": "<style>\n  .markdown-body .callout.callout_default[theme=🧙] {\n    --background: #fffae7;\n    --border: #e6b8086e;\n    --title: #e0b400;\n  }\n</style>"
 }
 [/block]

--- a/example/Fixtures/index.jsx
+++ b/example/Fixtures/index.jsx
@@ -32,13 +32,6 @@ const Fixtures = ({ render, selected, getRoute }) => {
 
   const fields = (
     <>
-      <fieldset className="rdmd-demo--fieldset rdmd-demo--options">
-        <legend>Options</legend>
-        <div>
-          <label htmlFor="safe-mode">Safe Mode</label>
-          <input id="safe-mode" onChange={onChangeSafeMode} type="checkbox" value={options.safeMode} />
-        </div>
-      </fieldset>
       <fieldset className="rdmd-demo--fieldset">
         <legend>Fixture</legend>
         <select id="fixture-select" onChange={handleSelect} value={selected}>
@@ -51,6 +44,13 @@ const Fixtures = ({ render, selected, getRoute }) => {
             );
           })}
         </select>
+      </fieldset>
+      <fieldset className="rdmd-demo--fieldset rdmd-demo--options">
+        <legend>Options</legend>
+        <div>
+          <label htmlFor="safe-mode">Safe Mode</label>
+          <input id="safe-mode" onChange={onChangeSafeMode} type="checkbox" value={options.safeMode} />
+        </div>
       </fieldset>
     </>
   );

--- a/example/demo.scss
+++ b/example/demo.scss
@@ -93,20 +93,34 @@
     display: flex;
     justify-content: flex-end;
 
+    &:first-child {
+      position: sticky;
+      top: -3em;
+      background: white;
+      box-shadow: 0 -0.5em white;
+      z-index: 9999999;
+    }
+
     legend {
       text-transform: uppercase;
       color: #bbb;
     }
 
     select {
-      min-width: 50%;
+      border-color: #ccc;
+      border-radius: 3px;
       color: #555;
+      font: inherit;
+      min-width: 50%;
+      padding: 0.2em;
     }
 
     div {
-      width: 33%;
+      max-width: 33%;
       display: flex;
-      justify-content: space-between;
+      align-items: center;
+      gap: 0.2em;
+      padding: 0.2em 0.4em;
     }
   }
 
@@ -139,10 +153,17 @@
 
   .rdmd-demo--editor-container {
     position: sticky;
-    top: -1px;
+    top: 0;
     height: 100vh;
+    overflow: scroll;
     display: flex;
     flex-flow: nowrap column;
+    & {
+      // pop the editor container to its parent's padding box so
+      // it scrolls to the very top and bottom of the page.
+      margin: -2em 0;
+      padding: 2em 0;
+    }
     > [name='demo-editor'] {
       flex: 1;
     }


### PR DESCRIPTION
 [![PR App][icn]][demo] | [PR App][demo] 
:----------------------:|:--------------:

## 🧰 Changes
- [x] Polish the `sticky` positioning layout.
- [x] Flip the *Fixture* and *Options* bars.

## 🧬 QA & Testing
Open up the [demo app for this PR][demo], resize your browser so it's very short, and then try scrolling the left hand content panel. Only the top-most *Fixture* section should stick to the top!


[demo]: https://markdown-pr-523.herokuapp.com
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
