### PR TITLE
test: add additional script sanitizing tests

### DIFF
--- a/__tests__/components/HTMLBlock.test.jsx
+++ b/__tests__/components/HTMLBlock.test.jsx
@@ -1,4 +1,4 @@
-const { render } = require('@testing-library/react');
+const { render, screen } = require('@testing-library/react');
 const React = require('react');
 const { renderToString } = require('react-dom/server');
 
@@ -20,6 +20,24 @@ describe('HTML Block', () => {
   it("doesn't run user scripts by default", () => {
     render(<HTMLBlock html="<script>mockFn()</script>" runScripts={false} />);
     expect(global.mockFn).toHaveBeenCalledTimes(0);
+  });
+
+  it("doesn't render user scripts by default", () => {
+    render(<HTMLBlock html="<script>mockFn()</script>" runScripts={false} />);
+
+    expect(screen.queryByText('mockFn()')).not.toBeInTheDocument();
+  });
+
+  it("doesn't render user scripts with weird endings", () => {
+    render(<HTMLBlock html="<script>mockFn()</script foo='bar'>" runScripts={false} />);
+
+    expect(screen.queryByText('mockFn()')).not.toBeInTheDocument();
+  });
+
+  it("doesn't render user scripts with a malicious string", () => {
+    render(<HTMLBlock html="<scrip<script></script>t>mockFn()</s<script></script>cript>" runScripts={false} />);
+
+    expect(screen.queryByText('mockFn()')).not.toBeInTheDocument();
   });
 
   it("doesn't run scripts on the server (even in compat mode)", () => {


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4673
:-------------------:|:----------:

## 🧰 Changes

This PR adds some additional tests for executing scripts within html blocks. Github had flagged the regex we use to extract scripts as a potential vulnerability. It pointed out two things:

1. Html closing tags will happily render with arbitrary attributes, so trying to match something simple like `/</script>/` is insufficient.
2. That there are so many edge cases, that it's safer to rely on well tested libraries for parsing html.

In testing these assertions, our code appears to be safe since `innerHtml` no longer will execute `script` tags. Presumably since it was such a common attack vector. In any event, I thought it'd be good to keep the tests around.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
