### PR TITLE
feat: fix plain string compiler

### DIFF
--- a/__tests__/astToPlainText.test.js
+++ b/__tests__/astToPlainText.test.js
@@ -1,0 +1,25 @@
+import { hast, mdast, astToPlainText } from '../index';
+
+describe('astToPlainText()', () => {
+  it("converts br's to ''", () => {
+    const txt = `<br>`;
+
+    expect(astToPlainText(hast(txt))).toBe('');
+  });
+
+  it("converts hr's to ''", () => {
+    const txt = `<hr>`;
+
+    expect(astToPlainText(hast(txt))).toBe('');
+  });
+
+  it('converts flavored callouts', () => {
+    const txt = `
+> 📘 Title
+> 
+> Some body
+    `;
+
+    expect(astToPlainText(mdast(txt))).toBe('Title Some body');
+  });
+});

--- a/__tests__/astToPlainText.test.js
+++ b/__tests__/astToPlainText.test.js
@@ -1,4 +1,4 @@
-import { hast, mdast, astToPlainText } from '../index';
+import { hast, astToPlainText } from '../index';
 
 describe('astToPlainText()', () => {
   it("converts br's to ''", () => {
@@ -20,6 +20,48 @@ describe('astToPlainText()', () => {
 > Some body
     `;
 
-    expect(astToPlainText(mdast(txt))).toBe('Title Some body');
+    expect(astToPlainText(hast(txt))).toBe('Title Some body');
+  });
+
+  it('converts markdown tables', () => {
+    const txt = `
+| Header 1 | Header 2 |
+| :------- | :------- |
+| Cell 1   | Cell 2   |
+    `;
+
+    expect(astToPlainText(hast(txt))).toBe('Header 1 Header 2 Cell 1 Cell 2');
+  });
+
+  it('converts magic block tables', () => {
+    const txt = `
+[block:parameters]
+${JSON.stringify(
+  {
+    data: {
+      'h-0': 'Header 1',
+      'h-1': 'Header 2',
+      '0-0': 'Cell 1',
+      '0-1': 'Cell 2  \nCell 2.1',
+    },
+    cols: 2,
+    rows: 1,
+    align: ['left', 'left', 'left'],
+  },
+  null,
+  2
+)}
+[/block]
+    `;
+
+    expect(astToPlainText(hast(txt))).toBe('Header 1 Header 2 Cell 1 Cell 2  \nCell 2.1');
+  });
+
+  it('converts images', () => {
+    const txt = `
+![image **label**](http://placekitten.com/600/600)
+    `;
+
+    expect(astToPlainText(hast(txt))).toBe('');
   });
 });

--- a/__tests__/table-flattening/index.test.js
+++ b/__tests__/table-flattening/index.test.js
@@ -9,11 +9,9 @@ describe('astToPlainText with tables', () => {
   | Cell A2 | Cell B2 | Cell C2 |
   | Cell A3 | Cell B3 | Cell C3 |`;
 
-    expect(astToPlainText(hast(text))).toMatchInlineSnapshot(`
-      "
-
-      Col. A Col. B Col. CCell A1 Cell B1 Cell C1 Cell A2 Cell B2 Cell C2 Cell A3 Cell B3 Cell C3"
-    `);
+    expect(astToPlainText(hast(text))).toMatchInlineSnapshot(
+      `"Col. A Col. B Col. C Cell A1 Cell B1 Cell C1 Cell A2 Cell B2 Cell C2 Cell A3 Cell B3 Cell C3"`
+    );
   });
 
   it('includes formatted text', () => {
@@ -23,10 +21,6 @@ describe('astToPlainText with tables', () => {
 | Cell *A1* | *Cell B1* |
 | *Cell* A2 | *Cell* B2 |`;
 
-    expect(astToPlainText(hast(text))).toMatchInlineSnapshot(`
-      "
-
-      Col. A Col.  BCell  A1 Cell B1 Cell  A2 Cell  B2"
-    `);
+    expect(astToPlainText(hast(text))).toMatchInlineSnapshot(`"Col. A Col. B Cell A1 Cell B1 Cell A2 Cell B2"`);
   });
 });

--- a/index.js
+++ b/index.js
@@ -249,7 +249,9 @@ export function astToPlainText(node, opts = {}) {
   if (!node) return '';
   [, opts] = setup('', opts);
 
-  return processor(opts).use(toPlainText).runSync(node);
+  console.log(JSON.stringify({ node }, null, 2));
+
+  return processor(opts).use(toPlainText).stringify(node);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -249,8 +249,6 @@ export function astToPlainText(node, opts = {}) {
   if (!node) return '';
   [, opts] = setup('', opts);
 
-  console.log(JSON.stringify({ node }, null, 2));
-
   return processor(opts).use(toPlainText).stringify(node);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@readme/syntax-highlighter": "^11.0.0",
         "copy-to-clipboard": "^3.3.1",
         "hast-util-sanitize": "^4.0.0",
-        "hast-util-to-string": "^1.0.4",
         "lodash.escape": "^4.0.1",
         "lodash.kebabcase": "^4.1.1",
         "mdast-util-toc": "^5.1.0",
@@ -10715,11 +10714,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
-    },
-    "node_modules/hast-util-to-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz",
-      "integrity": "sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w=="
     },
     "node_modules/hast-util-whitespace": {
       "version": "1.0.4",
@@ -31113,11 +31107,6 @@
         "xtend": "^4.0.0",
         "zwitch": "^1.0.0"
       }
-    },
-    "hast-util-to-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-1.0.4.tgz",
-      "integrity": "sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w=="
     },
     "hast-util-whitespace": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@readme/syntax-highlighter": "^11.0.0",
     "copy-to-clipboard": "^3.3.1",
     "hast-util-sanitize": "^4.0.0",
-    "hast-util-to-string": "^1.0.4",
     "lodash.escape": "^4.0.1",
     "lodash.kebabcase": "^4.1.1",
     "mdast-util-toc": "^5.1.0",

--- a/processor/plugin/plain-text.js
+++ b/processor/plugin/plain-text.js
@@ -1,7 +1,36 @@
-const toString = require('hast-util-to-string');
+/* @note: copied from https://github.com/rehypejs/rehype-minify/blob/main/packages/hast-util-to-string/index.js
+ */
+function toString(node) {
+  if ('children' in node) {
+    // eslint-disable-next-line no-use-before-define
+    return all(node);
+  }
+
+  return 'value' in node ? node.value : ' ';
+}
+
+function one(node) {
+  if (node.type === 'text') {
+    return node.value;
+  }
+
+  // eslint-disable-next-line no-use-before-define
+  return 'children' in node ? all(node) : ' ';
+}
+
+function all(node) {
+  let index = -1;
+  const result = [];
+
+  // eslint-disable-next-line no-plusplus
+  while (++index < node.children.length) {
+    result[index] = one(node.children[index]);
+  }
+
+  return result.join(' ').trim().replace(/ +/, ' ');
+}
 
 const Compiler = node => {
-  console.log(JSON.stringify({ node }, null, 2));
   return toString(node);
 };
 

--- a/processor/plugin/plain-text.js
+++ b/processor/plugin/plain-text.js
@@ -1,7 +1,12 @@
 const toString = require('hast-util-to-string');
 
-module.exports = () => {
-  return function compile(node) {
-    return toString(node);
-  };
+const Compiler = node => {
+  console.log(JSON.stringify({ node }, null, 2));
+  return toString(node);
 };
+
+const toPlainText = function () {
+  Object.assign(this, { Compiler });
+};
+
+module.exports = toPlainText;


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-3436
:-------------------:|:----------:

## 🧰 Changes

Fixes the `astToPlainText` compiler.

I'm not sure how this working at all before, sometimes it returns a string, and sometimes it returns the passed in node?! Prior to this, it was calling `.runSync(ast)` which only [runs the `run` step](https://github.com/unifiedjs/unified#overview) and only calls `transformers` on the passed in `ast`. Theoretically, the correct call should be `.stringify(ast)`, which calls the `compile` step. 

This PR reworks `astToPlainText()` to make the 'correct' call to `.stringify(ast)`. It also copies in the `hast-util-to-string` library so that it will use a space (` `) to join all the strings together.


## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
