### PR TITLE
fix: correct first line spacing in code blocks

### DIFF
--- a/__tests__/__snapshots__/flavored-parsers.test.js.snap
+++ b/__tests__/__snapshots__/flavored-parsers.test.js.snap
@@ -1,5 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Parse RDMD Syntax Code Blocks Edge Cases Code blocks should keep spaces entered at start of first line 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "className": "tab-panel",
+          "data": Object {
+            "hName": "code",
+            "hProperties": Object {
+              "lang": "javascript",
+              "meta": "tab/a.js",
+            },
+          },
+          "lang": "javascript",
+          "meta": "tab/a.js",
+          "type": "code",
+          "value": "  function sayHello (state) {
+    console.log(state);
+  }
+
+export default sayHello;",
+        },
+        Object {
+          "className": "tab-panel",
+          "data": Object {
+            "hName": "code",
+            "hProperties": Object {
+              "lang": "javascript",
+              "meta": "tab/b.js",
+            },
+          },
+          "lang": "javascript",
+          "meta": "tab/b.js",
+          "type": "code",
+          "value": "import A from './a.js';
+
+A('Hello world!');",
+        },
+      ],
+      "className": "tabs",
+      "data": Object {
+        "hName": "code-tabs",
+      },
+      "type": "code-tabs",
+    },
+  ],
+  "type": "root",
+}
+`;
+
 exports[`Parse RDMD Syntax Code Blocks Single Code Block 1`] = `
 Object {
   "children": Array [

--- a/__tests__/flavored-parsers.test.js
+++ b/__tests__/flavored-parsers.test.js
@@ -68,6 +68,14 @@ describe('Parse RDMD Syntax', () => {
         expect(codeBlock.lang).toBe('js');
       });
 
+      it('Code blocks should keep spaces entered at start of first line', () => {
+        const mdx =
+          "```javascript tab/a.js\n  function sayHello (state) {\n    console.log(state);\n  }\n\nexport default sayHello;\n```\n```javascript tab/b.js\nimport A from './a.js';\n\nA('Hello world!');\n```\n\n";
+        const ast = process(mdx);
+
+        expect(ast).toMatchSnapshot();
+      });
+
       it('Code blocks should use a "smart" terminating delimiter', () => {
         /**
          * https://github.com/readmeio/api-explorer/issues/724

--- a/processor/parse/flavored/code-tabs.js
+++ b/processor/parse/flavored/code-tabs.js
@@ -25,7 +25,7 @@ function tokenizer(eat, value) {
     kids.push({
       type: 'code',
       className: 'tab-panel',
-      value: code.trim(),
+      value: code.replace(/^\n/, ''),
       meta,
       lang,
       data: {


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4689
:-------------------:|:----------:

## 🧰 Changes

We were trimming the leading whitespace from code blocks, which offsets indentations for lines when leading whitespace is intended on the first line of a code block. This PR resolves that by replacing the trim() method with the replace() to specifically target a remove new lines at the start of a code block as opposed to removing all leading whitespace.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-552.herokuapp.com/
[prod]: http://project-display.next.readme.ninja/docs/code-indentation
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
