### PR TITLE
fix: images to plain text

### DIFF
--- a/__tests__/astToPlainText.test.js
+++ b/__tests__/astToPlainText.test.js
@@ -59,9 +59,9 @@ ${JSON.stringify(
 
   it('converts images', () => {
     const txt = `
-![image **label**](http://placekitten.com/600/600)
+![image **label**](http://placekitten.com/600/600 "entitled kittens")
     `;
 
-    expect(astToPlainText(hast(txt))).toBe('');
+    expect(astToPlainText(hast(txt))).toBe('entitled kittens');
   });
 });

--- a/processor/plugin/plain-text.js
+++ b/processor/plugin/plain-text.js
@@ -10,6 +10,10 @@ function toString(node) {
 }
 
 function one(node) {
+  if (node.tagName === 'img') {
+    return node.properties?.title || '';
+  }
+
   if (node.type === 'text') {
     return node.value;
   }


### PR DESCRIPTION
[![PR App][icn]][demo] |
:-------------------:|

## 🧰 Changes

Use the images title when converting to plain text. This is useful for search indexing.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
