### PR TITLE
fix: images to plain text at the root

### DIFF
--- a/__tests__/astToPlainText.test.js
+++ b/__tests__/astToPlainText.test.js
@@ -1,5 +1,14 @@
 import { hast, astToPlainText } from '../index';
 
+const find = (node, matcher) => {
+  if (matcher(node)) return node;
+  if (node.children) {
+    return node.children.find(child => find(child, matcher));
+  }
+
+  return null;
+};
+
 describe('astToPlainText()', () => {
   it("converts br's to ''", () => {
     const txt = '<br>';
@@ -54,7 +63,7 @@ ${JSON.stringify(
 [/block]
     `;
 
-    expect(astToPlainText(hast(txt))).toBe('Header 1 Header 2 Cell 1 Cell 2  \nCell 2.1');
+    expect(astToPlainText(hast(txt))).toBe('Header 1 Header 2 Cell 1 Cell 2 \nCell 2.1');
   });
 
   it('converts images', () => {
@@ -63,5 +72,14 @@ ${JSON.stringify(
     `;
 
     expect(astToPlainText(hast(txt))).toBe('entitled kittens');
+  });
+
+  it('converts a single image', () => {
+    const txt = `
+![image **label**](http://placekitten.com/600/600 "entitled kittens")
+    `;
+    const ast = hast(txt);
+
+    expect(astToPlainText(find(ast, n => n.tagName === 'img'))).toBe('entitled kittens');
   });
 });

--- a/__tests__/table-flattening/index.test.js
+++ b/__tests__/table-flattening/index.test.js
@@ -21,6 +21,6 @@ describe('astToPlainText with tables', () => {
 | Cell *A1* | *Cell B1* |
 | *Cell* A2 | *Cell* B2 |`;
 
-    expect(astToPlainText(hast(text))).toMatchInlineSnapshot('"Col. A Col. B Cell A1 Cell B1 Cell A2 Cell B2"');
+    expect(astToPlainText(hast(text))).toMatchInlineSnapshot('"Col. A Col.  B Cell  A1 Cell B1 Cell  A2 Cell  B2"');
   });
 });

--- a/processor/plugin/plain-text.js
+++ b/processor/plugin/plain-text.js
@@ -1,12 +1,8 @@
 /* @note: copied from https://github.com/rehypejs/rehype-minify/blob/main/packages/hast-util-to-string/index.js
  */
 function toString(node) {
-  if ('children' in node) {
-    // eslint-disable-next-line no-use-before-define
-    return all(node);
-  }
-
-  return 'value' in node ? node.value : ' ';
+  // eslint-disable-next-line no-use-before-define
+  return 'children' in node ? all(node) : one(node);
 }
 
 function one(node) {
@@ -15,6 +11,10 @@ function one(node) {
   }
 
   if (node.type === 'text') {
+    return node.value;
+  }
+
+  if ('value' in node) {
     return node.value;
   }
 


### PR DESCRIPTION
[![PR App][icn]][demo] |
:-------------------:|

## 🧰 Changes

Fixes images to plain text when they are the only node passed to `astToPlainText`

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
