### PR TITLE
fix: astToPlainText with lone image

### DIFF
--- a/__tests__/astToPlainText.test.js
+++ b/__tests__/astToPlainText.test.js
@@ -82,4 +82,37 @@ ${JSON.stringify(
 
     expect(astToPlainText(find(ast, n => n.tagName === 'img'))).toBe('entitled kittens');
   });
+
+  it('converts magic block images', () => {
+    const txt = `
+      [block:image]
+      {
+        "images": [
+          {
+            "image": ["https://files.readme.io/test.png", "Test Image Title", 100, 100, "#fff"]
+          }
+        ]
+      }
+      [/block]
+    `;
+
+    expect(astToPlainText(hast(txt))).toBe('Test Image Title');
+  });
+
+  it('converts a lone magic block image', () => {
+    const txt = `
+      [block:image]
+      {
+        "images": [
+          {
+            "image": ["https://files.readme.io/test.png", "Test Image Title", 100, 100, "#fff"]
+          }
+        ]
+      }
+      [/block]
+    `;
+    const img = find(hast(txt), n => n.tagName === 'img');
+
+    expect(astToPlainText(img)).toBe('Test Image Title');
+  });
 });

--- a/processor/plugin/plain-text.js
+++ b/processor/plugin/plain-text.js
@@ -2,7 +2,7 @@
  */
 function toString(node) {
   // eslint-disable-next-line no-use-before-define
-  return 'children' in node ? all(node) : one(node);
+  return 'children' in node ? all(node) || one(node) : one(node);
 }
 
 function one(node) {


### PR DESCRIPTION
[![PR App][icn]][demo] |
:-------------------:|

## 🧰 Changes

Yet another fix to `astToPlainText`, this time when there is a single image passed in, and that image has empty children. I'm not sure where the empty children are coming from, but this fix seems reasnable enough.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
