### PR TITLE
feat: throw when parsing invalid magic block json

### DIFF
--- a/__tests__/__snapshots__/magic-block-parser.test.js.snap
+++ b/__tests__/__snapshots__/magic-block-parser.test.js.snap
@@ -38,6 +38,13 @@ Object {
 }
 `;
 
+exports[`Parse Magic Blocks Block with invalid JSON 1`] = `
+Object {
+  "children": Array [],
+  "type": "root",
+}
+`;
+
 exports[`Parse Magic Blocks Callout Blocks 1`] = `
 Object {
   "children": Array [
@@ -616,6 +623,31 @@ Object {
       "type": "div",
     },
   ],
+  "type": "root",
+}
+`;
+
+exports[`Parse Magic Blocks does not throw error when flag alwaysThrow is true and block has valid JSON 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Ooh I'm valid 💅",
+        },
+      ],
+      "depth": 2,
+      "type": "heading",
+    },
+  ],
+  "type": "root",
+}
+`;
+
+exports[`Parse Magic Blocks throws error when flag alwaysThrow is true and block has invalid JSON 1`] = `
+Object {
+  "children": Array [],
   "type": "root",
 }
 `;

--- a/__tests__/__snapshots__/magic-block-parser.test.js.snap
+++ b/__tests__/__snapshots__/magic-block-parser.test.js.snap
@@ -627,31 +627,6 @@ Object {
 }
 `;
 
-exports[`Parse Magic Blocks does not throw error when flag alwaysThrow is true and block has valid JSON 1`] = `
-Object {
-  "children": Array [
-    Object {
-      "children": Array [
-        Object {
-          "type": "text",
-          "value": "Ooh I'm valid 💅",
-        },
-      ],
-      "depth": 2,
-      "type": "heading",
-    },
-  ],
-  "type": "root",
-}
-`;
-
-exports[`Parse Magic Blocks throws error when flag alwaysThrow is true and block has invalid JSON 1`] = `
-Object {
-  "children": Array [],
-  "type": "root",
-}
-`;
-
 exports[`Sanitize Schema 1`] = `
 Object {
   "attributes": Array [],

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -233,6 +233,22 @@ test('`correctnewlines` option', () => {
   expect(container).toContainHTML('<p>test<br>\ntest<br>\ntest</p>');
 });
 
+test('`alwaysThrow` option', () => {
+  const { container } = render(
+    markdown.default(
+      `[block:api-header]
+    {,
+      "title": "Uh-oh, I'm invalid",
+      "level": 2
+    }
+    [/block]`,
+      { alwaysThrow: true }
+    )
+  );
+
+  expect(() => container).toThrow('Invalid Magic Block JSON');
+});
+
 // TODO not sure if this needs to work or not?
 // Isn't it a good thing to always strip HTML?
 describe('`stripHtml` option', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -12,6 +12,7 @@ test('it should have the proper utils exports', () => {
   expect(typeof markdown.utils.VariablesContext).toBe('object');
 
   expect(markdown.utils.options).toStrictEqual({
+    alwaysThrow: false,
     compatibilityMode: false,
     copyButtons: true,
     correctnewlines: false,

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -233,20 +233,40 @@ test('`correctnewlines` option', () => {
   expect(container).toContainHTML('<p>test<br>\ntest<br>\ntest</p>');
 });
 
-test('`alwaysThrow` option', () => {
-  const { container } = render(
-    markdown.default(
-      `[block:api-header]
+describe('`alwaysThrow` option', () => {
+  it('should throw if `alwaysThrow` is true and magic block has invalid JSON', () => {
+    const shouldThrow = () =>
+      render(
+        markdown.default(
+          `[block:api-header]
     {,
       "title": "Uh-oh, I'm invalid",
       "level": 2
     }
     [/block]`,
-      { alwaysThrow: true }
-    )
-  );
+          { alwaysThrow: true }
+        )
+      );
 
-  expect(() => container).toThrow('Invalid Magic Block JSON');
+    expect(() => shouldThrow()).toThrow('Invalid Magic Block JSON');
+  });
+
+  it('should not throw if `alwaysThrow` is true but magic block has valid JSON', () => {
+    const shouldThrow = () =>
+      render(
+        markdown.default(
+          `[block:api-header]
+    {
+      "title": "Ooh I'm valid 💅",
+      "level": 2
+    }
+    [/block]`,
+          { alwaysThrow: true }
+        )
+      );
+
+    expect(() => shouldThrow()).not.toThrow('Invalid Magic Block JSON');
+  });
 });
 
 // TODO not sure if this needs to work or not?

--- a/__tests__/magic-block-parser.test.js
+++ b/__tests__/magic-block-parser.test.js
@@ -270,4 +270,14 @@ describe('Parse Magic Blocks', () => {
     [/block]`;
     expect(process(text)).toMatchSnapshot();
   });
+
+  it('Block with invalid JSON', () => {
+    const text = `[block:api-header]
+    {,
+      "title": "Uh-oh, I'm invalid",
+      "level": 2
+    }
+    [/block]`;
+    expect(process(text)).toMatchSnapshot();
+  });
 });

--- a/index.js
+++ b/index.js
@@ -136,6 +136,7 @@ export function processor(opts = {}) {
     .use(remarkFrontmatter, ['yaml', 'toml'])
     .data('settings', opts.settings)
     .data('compatibilityMode', opts.compatibilityMode)
+    .data('alwaysThrow', opts.alwaysThrow)
     .use(!opts.correctnewlines ? remarkBreaks : () => {})
     .use(CustomParsers.map(parser => parser.sanitize(sanitize)))
     .use(remarkSlug)

--- a/options.js
+++ b/options.js
@@ -1,4 +1,5 @@
 const options = {
+  alwaysThrow: false,
   compatibilityMode: false,
   copyButtons: true,
   correctnewlines: false,

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -45,6 +45,8 @@ function tokenize(eat, value) {
     json = JSON.parse(json);
   } catch (err) {
     json = {};
+    // eslint-disable-next-line no-console
+    console.error('Invalid Magic Block JSON:', err);
     if (alwaysThrow) {
       throw new Error('Invalid Magic Block JSON:', { cause: err });
     }

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -48,7 +48,7 @@ function tokenize(eat, value) {
     // eslint-disable-next-line no-console
     console.error('Invalid Magic Block JSON:', err);
     if (alwaysThrow) {
-      throw new Error('Invalid Magic Block JSON:', { cause: err });
+      throw new Error('Invalid Magic Block JSON');
     }
   }
 

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -3,6 +3,7 @@ const RGXP = /^\[block:(.*)\]([^]+?)\[\/block\]/;
 
 let compatibilityMode;
 let safeMode;
+let alwaysThrow;
 
 const WrapPinnedBlocks = (node, json) => {
   if (!json.sidebar) return node;
@@ -44,8 +45,9 @@ function tokenize(eat, value) {
     json = JSON.parse(json);
   } catch (err) {
     json = {};
-    // eslint-disable-next-line no-console
-    console.error('Invalid Magic Block JSON:', err);
+    if (alwaysThrow) {
+      throw new Error('Invalid Magic Block JSON:', { cause: err });
+    }
   }
 
   if (Object.keys(json).length < 1) return eat(match);
@@ -284,6 +286,7 @@ function parser() {
 
   if (this.data('compatibilityMode')) compatibilityMode = true;
   if (this.data('safeMode')) safeMode = true;
+  if (this.data('alwaysThrow')) alwaysThrow = true;
 
   tokenizers.magicBlocks = tokenize;
   methods.splice(methods.indexOf('newline'), 0, 'magicBlocks');


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-4798
:-------------------:|:----------:

## 🧰 Changes

We want to better handle errors when trying to parse magic blocks; previously we were failing more or less silently (apart from an error in the console) and disappearing magic blocks with invalid JSON. We're not keen on the disappearing act when toggling from raw mode to the new editor, so this PR:
1. adds a flag called `alwaysThrow`, set to `false` by default
2. when this flag is set to true, throw a new error when failing to parse the json in a magic block
We'll still log out to the console in both cases- this ensures we aren't changing the behavior of the old editor and continues to provide extra context for the user if they want it/know it's there.
 
This is PR 1/3 for this ticket. 
PR 2/3 will be updating the markdown version in our main readme repo and PR 3/3 will be adding the `alwaysThrow: true` flag to the new editor's deserializer.

## 🧬 QA & Testing

There should be no change to the behavior in the [demo], but pulling this branch and running readme locally with the `alwaysThrow` flag set to true [here](https://github.com/readmeio/readme/blob/7b2c60c763873024f9e7829080ac13acbbac299e/packages/react/src/ui/MarkdownEditor/editor/parser.js#L60), we throw an error and pop up the Error Modal. Shout out to Kelly for his work on that modal! 🌟 

Demo video:


https://user-images.githubusercontent.com/48635728/182705393-8e45f8d6-cb98-498d-b68d-0f1bf17088e5.mov



- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
