### PR TITLE
fix: callout warning icon

### DIFF
--- a/__tests__/flavored-parsers/callouts.test.js
+++ b/__tests__/flavored-parsers/callouts.test.js
@@ -40,7 +40,7 @@ describe('Parse RDMD Callouts', () => {
 });
 
 describe('emoji modifier support', () => {
-  const emojis = ['📘', '⚠️', '🚧', '👍', '✅', '❗', '❗️', '🛑', '⁉️', '‼️', 'ℹ️', '⚠'];
+  const emojis = ['📘', '🚧', '⚠️', '👍', '✅', '❗', '❗️', '🛑', '⁉️', '‼️', 'ℹ️', '⚠'];
 
   emojis.forEach(emoji => {
     it(`render a callout for ${emoji}`, () => {

--- a/processor/parse/flavored/callout.js
+++ b/processor/parse/flavored/callout.js
@@ -4,8 +4,8 @@ const rgx = new RegExp(`^> ?(${emojiRegex().source})(?: +(.+)?)?\n((?:>(?: .*)?\
 
 const themes = {
   '\uD83D\uDCD8': 'info',
-  '\u26A0\uFE0F': 'warn',
   '\uD83D\uDEA7': 'warn',
+  '\u26A0\uFE0F': 'warn',
   '\uD83D\uDC4D': 'okay',
   '\u2705': 'okay',
   '\u2757': 'error',


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes
- Switch order of callout warning icons (🚧 <-> ⚠️)
- Based off the [docs](https://rdmd.readme.io/docs/callouts), the default should be 🚧 instead of ⚠️

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
