### PR TITLE
fix(anchor): ignore anchor hash when parsing internal link syntax

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -24,6 +24,8 @@ exports[`anchors with baseUrl 1`] = `
 &lt;a href=\\"page:slug\\"&gt;page&lt;/a&gt;&lt;/p&gt;"
 `;
 
+exports[`anchors with baseUrl and special characters in url hash 1`] = `"<p><a href=\\"/reference-link/slug#%E6%95%B4\\" target=\\"\\" title=\\"\\">ref</a></p>"`;
+
 exports[`check list items 1`] = `
 "<ul class=\\"contains-task-list\\">
 <li class=\\"task-list-item\\"><input type=\\"checkbox\\" disabled=\\"\\"> checklistitem1</li>

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -171,6 +171,11 @@ test('anchors with baseUrl', () => {
   expect(container.innerHTML).toMatchSnapshot();
 });
 
+test('anchors with baseUrl and special characters in url hash', () => {
+  const { container } = render(markdown.default('[ref](ref:slug#整)'));
+  expect(container.innerHTML).toMatchSnapshot();
+});
+
 test('emojis', () => {
   const { container } = render(
     markdown.default(`

--- a/components/Anchor.jsx
+++ b/components/Anchor.jsx
@@ -6,29 +6,33 @@ const BaseUrlContext = require('../contexts/BaseUrl');
 // Nabbed from here:
 // https://github.com/readmeio/api-explorer/blob/0dedafcf71102feedaa4145040d3f57d79d95752/packages/api-explorer/src/lib/markdown/renderer.js#L52
 function getHref(href, baseUrl) {
+  const [path, hash] = href.split('#');
+  const hashStr = hash ? `#${hash}` : '';
+
   const base = baseUrl === '/' ? '' : baseUrl;
-  const doc = href.match(/^doc:([-_a-zA-Z0-9#]*)$/);
+  const doc = path.match(/^doc:([-_a-zA-Z0-9#]*)$/);
+
   if (doc) {
-    return `${base}/docs/${doc[1]}`;
+    return `${base}/docs/${doc[1]}${hashStr}`;
   }
 
-  const ref = href.match(/^ref:([-_a-zA-Z0-9#]*)$/);
+  const ref = path.match(/^ref:([-_a-zA-Z0-9#]*)$/);
   if (ref) {
-    return `${base}/reference-link/${ref[1]}`;
+    return `${base}/reference-link/${ref[1]}${hashStr}`;
   }
 
   // we need to perform two matches for changelogs in case
   // of legacy links that use 'blog' instead of 'changelog'
-  const blog = href.match(/^blog:([-_a-zA-Z0-9#]*)$/);
-  const changelog = href.match(/^changelog:([-_a-zA-Z0-9#]*)$/);
+  const blog = path.match(/^blog:([-_a-zA-Z0-9#]*)$/);
+  const changelog = path.match(/^changelog:([-_a-zA-Z0-9#]*)$/);
   const changelogMatch = blog || changelog;
   if (changelogMatch) {
-    return `${base}/changelog/${changelogMatch[1]}`;
+    return `${base}/changelog/${changelogMatch[1]}${hashStr}`;
   }
 
-  const custompage = href.match(/^page:([-_a-zA-Z0-9#]*)$/);
+  const custompage = path.match(/^page:([-_a-zA-Z0-9#]*)$/);
   if (custompage) {
-    return `${base}/page/${custompage[1]}`;
+    return `${base}/page/${custompage[1]}${hashStr}`;
   }
 
   return href;


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-2485
:-------------------:|:----------:

There's a bug with our [internal link](https://docs.readme.com/docs/linking-to-pages#internal-links) feature where if you pass a url hash of non-unicode characters as an anchor link, the `href` doesn't get parsed in the `Anchor` component. 

Here's an example: https://busted-links.readme.io/docs/intercom-3

## 🧰 Changes
- Ignore anchor hash when parsing internal link syntax that generates a link's path, and append the hash to the path string separately.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
