### PR TITLE
fix: avoid nesting button in code block

### DIFF
--- a/__tests__/components/Code.test.jsx
+++ b/__tests__/components/Code.test.jsx
@@ -25,6 +25,13 @@ describe('Code', () => {
     expect(copy).toHaveBeenCalledWith(expect.stringMatching(/VARIABLE_SUBSTITUTED/));
   });
 
+  it('does not nest the button inside the code block', () => {
+    render(<Code>{'console.log("hi");'}</Code>);
+    const btn = screen.getByRole('button');
+
+    expect(btn.parentNode.nodeName.toLowerCase()).not.toBe('code');
+  });
+
   it('allows undefined children?!', () => {
     const { container } = render(<Code />);
 

--- a/components/Code/index.jsx
+++ b/components/Code/index.jsx
@@ -55,6 +55,7 @@ function Code(props) {
 
   return (
     <React.Fragment>
+      {copyButtons && <CopyCode className="fa" codeRef={codeRef} />}
       <code
         ref={codeRef}
         className={['rdmd-code', `lang-${language}`, `theme-${theme}`].join(' ')}
@@ -62,7 +63,6 @@ function Code(props) {
         name={meta}
         suppressHydrationWarning={true}
       >
-        {copyButtons && <CopyCode className="fa" codeRef={codeRef} />}
         {codeContent}
       </code>
     </React.Fragment>


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-5222
:-------------------:|:----------:

## 🧰 Changes

This is a bit more semantic and therefore helps Localize, which we use for translations, parse our html correctly.

Tried a few other things before going with this approach. One thought was that we could just not render the button at all for inline code. Unfortunately there isn't a very easy way to distinguish between inline vs block code. We use the presence of a `lang` property in the props as a proxy, but you can definitely have a code block with no lang, so I didn't feel that was accurate enough. Also my assumption is that this translation parsing issue could still be present for code blocks, so this is just the safer approach.

Visually this ends up looking exactly the same given we're only ever [showing](https://github.com/readmeio/markdown/blob/0e59b23d24b3896d2d9b3a759564fc07098657c6/components/Code/style.scss#L148) the button as an `:after` pseudo selector on the `pre` element.

## 📸 Screenshot

<img width="530" alt="image" src="https://user-images.githubusercontent.com/4505008/191621383-20928337-704a-456a-ba6c-dac21b29f925.png">

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
