### PR TITLE
style(glossary): dark mode

### DIFF
--- a/components/GlossaryItem/style.scss
+++ b/components/GlossaryItem/style.scss
@@ -1,4 +1,29 @@
 .GlossaryItem {
+  --GlossaryItem-bg: var(--color-bg-page, var(--white));
+  --GlossaryItem-color: var(--color-text-default, var(--gray20));
+  --GlossaryItem-shadow: var(--box-shadow-menu-light, 0 5px 10px rgba(0, 0, 0, .05),
+    0 2px 6px rgba(0, 0, 0, .025),
+    0 1px 3px rgba(0, 0, 0, .025));
+
+  /* what the dark-mode mixin does in the readme project */
+  [data-color-mode='dark'] & {
+    --GlossaryItem-bg: var(--gray15);
+    --GlossaryItem-color: var(--color-text-default, var(--white));
+    --GlossaryItem-shadow: var(--box-shadow-menu-dark, 0 1px 3px rgba(0, 0, 0, 0.025),
+      0 2px 6px rgba(0, 0, 0, 0.025),
+      0 5px 10px rgba(0, 0, 0, 0.05))
+  }
+
+  @media (prefers-color-scheme: dark) {
+    [data-color-mode='auto'] & {
+      --GlossaryItem-bg: var(--Tooltip-bg, var(--gray0));
+      --GlossaryItem-color: var(--color-text-default, var(--white));
+      --GlossaryItem-shadow: var(--box-shadow-menu-dark, 0 1px 3px rgba(0, 0, 0, 0.025),
+        0 2px 6px rgba(0, 0, 0, 0.025),
+        0 5px 10px rgba(0, 0, 0, 0.05))
+    }
+  }
+
   &-trigger {
     border-bottom: 1px solid #737c83;
     border-style: dotted;
@@ -9,16 +34,17 @@
   }
 
   &-tooltip-content {
-    background-color: #fff;
-    border: 1px solid #e2e3e3;
-    border-radius: 5px;
-    box-shadow: 0 1px 3px -1px #e2e3e3;
+    background-color: var(--GlossaryItem-bg);
+    border: 1px solid #{var(--color-border-default, rgba(black, 0.1))};
+    border-radius: var(--border-radius);
+    box-shadow: var(--GlossaryItem-shadow);
+    color: var(--GlossaryItem-color);
     font-size: 15px;
     font-weight: 400;
     line-height: 1.5;
     padding: 15px;
     text-align: left;
-    width: 350px; 
+    width: 350px;
   }
 
   &-term {

--- a/components/GlossaryItem/style.scss
+++ b/components/GlossaryItem/style.scss
@@ -1,29 +1,4 @@
 .GlossaryItem {
-  --GlossaryItem-bg: var(--color-bg-page, var(--white));
-  --GlossaryItem-color: var(--color-text-default, var(--gray20));
-  --GlossaryItem-shadow: var(--box-shadow-menu-light, 0 5px 10px rgba(0, 0, 0, .05),
-    0 2px 6px rgba(0, 0, 0, .025),
-    0 1px 3px rgba(0, 0, 0, .025));
-
-  /* what the dark-mode mixin does in the readme project */
-  [data-color-mode='dark'] & {
-    --GlossaryItem-bg: var(--gray15);
-    --GlossaryItem-color: var(--color-text-default, var(--white));
-    --GlossaryItem-shadow: var(--box-shadow-menu-dark, 0 1px 3px rgba(0, 0, 0, 0.025),
-      0 2px 6px rgba(0, 0, 0, 0.025),
-      0 5px 10px rgba(0, 0, 0, 0.05))
-  }
-
-  @media (prefers-color-scheme: dark) {
-    [data-color-mode='auto'] & {
-      --GlossaryItem-bg: var(--Tooltip-bg, var(--gray0));
-      --GlossaryItem-color: var(--color-text-default, var(--white));
-      --GlossaryItem-shadow: var(--box-shadow-menu-dark, 0 1px 3px rgba(0, 0, 0, 0.025),
-        0 2px 6px rgba(0, 0, 0, 0.025),
-        0 5px 10px rgba(0, 0, 0, 0.05))
-    }
-  }
-
   &-trigger {
     border-bottom: 1px solid #737c83;
     border-style: dotted;
@@ -34,6 +9,31 @@
   }
 
   &-tooltip-content {
+    --GlossaryItem-bg: var(--color-bg-page, var(--white));
+    --GlossaryItem-color: var(--color-text-default, var(--gray20));
+    --GlossaryItem-shadow: var(--box-shadow-menu-light, 0 5px 10px rgba(0, 0, 0, .05),
+      0 2px 6px rgba(0, 0, 0, .025),
+      0 1px 3px rgba(0, 0, 0, .025));
+
+    /* what the dark-mode mixin does in the readme project */
+    [data-color-mode='dark'] & {
+      --GlossaryItem-bg: var(--gray15);
+      --GlossaryItem-color: var(--color-text-default, var(--white));
+      --GlossaryItem-shadow: var(--box-shadow-menu-dark, 0 1px 3px rgba(0, 0, 0, 0.025),
+        0 2px 6px rgba(0, 0, 0, 0.025),
+        0 5px 10px rgba(0, 0, 0, 0.05))
+    }
+
+    @media (prefers-color-scheme: dark) {
+      [data-color-mode='auto'] & {
+        --GlossaryItem-bg: var(--Tooltip-bg, var(--gray0));
+        --GlossaryItem-color: var(--color-text-default, var(--white));
+        --GlossaryItem-shadow: var(--box-shadow-menu-dark, 0 1px 3px rgba(0, 0, 0, 0.025),
+          0 2px 6px rgba(0, 0, 0, 0.025),
+          0 5px 10px rgba(0, 0, 0, 0.05))
+      }
+    }
+
     background-color: var(--GlossaryItem-bg);
     border: 1px solid #{var(--color-border-default, rgba(black, 0.1))};
     border-radius: var(--border-radius);


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

Dark mode for Glossary tooltips

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
