### PR TITLE
fix: trim callout titles

### DIFF
--- a/processor/parse/flavored/callout.js
+++ b/processor/parse/flavored/callout.js
@@ -146,7 +146,7 @@ function blockquoteReadme(eat, value, silent) {
     icon = match[1];
     contents[0] = contents[0].slice(match[0].length);
 
-    title = contents[0];
+    title = trim(contents[0]);
     body = trim(contents.slice(1).join(lineFeed));
   }
 


### PR DESCRIPTION
[![PR App][icn]][demo] |
:-------------------:|

## 🧰 Changes

In a previous PR, I refactored the callout parser, and it was no longer trimming the titles.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
