### PR TITLE
feat: html block

### DIFF
--- a/__tests__/__snapshots__/html-block-parser.test.js.snap
+++ b/__tests__/__snapshots__/html-block-parser.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Parse html block parses an html block 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "block": true,
+      "type": "html",
+      "value": "<div>Some block html</div>
+    ",
+    },
+  ],
+  "type": "root",
+}
+`;

--- a/__tests__/flavored-compilers.test.js
+++ b/__tests__/flavored-compilers.test.js
@@ -4,7 +4,7 @@ const remarkParse = require('remark-parse');
 const remarkStringify = require('remark-stringify');
 const unified = require('unified');
 
-const parsers = Object.values(require('../processor/parse')).map(parser => parser.sanitize(sanitize));
+const parsers = Object.values(require('../processor/parse')).map(parser => parser.sanitize?.(sanitize) || parser);
 const compilers = Object.values(require('../processor/compile'));
 const options = require('../options').options.markdownOptions;
 

--- a/__tests__/html-block-parser.test.js
+++ b/__tests__/html-block-parser.test.js
@@ -1,0 +1,11 @@
+import { mdast } from '../index';
+
+describe('Parse html block', () => {
+  it('parses an html block', () => {
+    const text = `
+<div>Some block html</div>
+    `;
+
+    expect(mdast(text)).toMatchSnapshot();
+  });
+});

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ export function processor(opts = {}) {
     .data('compatibilityMode', opts.compatibilityMode)
     .data('alwaysThrow', opts.alwaysThrow)
     .use(!opts.correctnewlines ? remarkBreaks : () => {})
-    .use(CustomParsers.map(parser => parser.sanitize(sanitize)))
+    .use(CustomParsers.map(parser => parser?.sanitize(sanitize)))
     .use(remarkSlug)
     .use(remarkDisableTokenizers, opts.disableTokenizers)
     .use(remarkRehype, { allowDangerousHtml: true })

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ export function processor(opts = {}) {
     .data('compatibilityMode', opts.compatibilityMode)
     .data('alwaysThrow', opts.alwaysThrow)
     .use(!opts.correctnewlines ? remarkBreaks : () => {})
-    .use(CustomParsers.map(parser => parser.sanitize?.(sanitize)))
+    .use(CustomParsers.map(parser => parser.sanitize?.(sanitize) || parser))
     .use(remarkSlug)
     .use(remarkDisableTokenizers, opts.disableTokenizers)
     .use(remarkRehype, { allowDangerousHtml: true })

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ export function processor(opts = {}) {
     .data('compatibilityMode', opts.compatibilityMode)
     .data('alwaysThrow', opts.alwaysThrow)
     .use(!opts.correctnewlines ? remarkBreaks : () => {})
-    .use(CustomParsers.map(parser => parser?.sanitize(sanitize)))
+    .use(CustomParsers.map(parser => parser.sanitize?.(sanitize)))
     .use(remarkSlug)
     .use(remarkDisableTokenizers, opts.disableTokenizers)
     .use(remarkRehype, { allowDangerousHtml: true })

--- a/processor/parse/html-block.js
+++ b/processor/parse/html-block.js
@@ -1,0 +1,29 @@
+const blockHtml = htmlTokenizer => {
+  return function tokenizer(...args) {
+    const node = htmlTokenizer.call(this, ...args);
+
+    if (node) {
+      node.block = true;
+    }
+
+    return node;
+  };
+};
+
+function parser() {
+  const { Parser } = this;
+  const tokenizers = Parser.prototype.blockTokenizers;
+  const { html } = tokenizers;
+
+  tokenizers.html = blockHtml(html);
+}
+
+parser.sanitize = sanitizeSchema => {
+  const tags = sanitizeSchema.tagNames;
+
+  tags.push('code-tabs');
+
+  return parser;
+};
+
+export default parser;

--- a/processor/parse/html-block.js
+++ b/processor/parse/html-block.js
@@ -18,12 +18,4 @@ function parser() {
   tokenizers.html = blockHtml(html);
 }
 
-parser.sanitize = sanitizeSchema => {
-  const tags = sanitizeSchema.tagNames;
-
-  tags.push('code-tabs');
-
-  return parser;
-};
-
 export default parser;

--- a/processor/parse/html-block.js
+++ b/processor/parse/html-block.js
@@ -2,7 +2,7 @@ const blockHtml = htmlTokenizer => {
   return function tokenizer(...args) {
     const node = htmlTokenizer.call(this, ...args);
 
-    if (node) {
+    if (typeof node === 'object') {
       node.block = true;
     }
 

--- a/processor/parse/index.js
+++ b/processor/parse/index.js
@@ -8,3 +8,4 @@ export { default as escape } from './escape';
 export { default as compactHeadings } from './compact-headings';
 export { default as variableParser } from './variable-parser';
 export { default as gemojiParser } from './gemoji-parser';
+export { default as htmlBlockParser } from './html-block';


### PR DESCRIPTION
[![PR App][icn]][demo] |
:-------------------:|

## 🧰 Changes

It's endlessly frustrating that remark <= v7 uses the same type for block and inline html. Today, I did something about it.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
