### PR TITLE
fix: crashing with TypeError

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ const remarkRehype = require('remark-rehype');
 const remarkSlug = require('remark-slug');
 const remarkStringify = require('remark-stringify');
 const unified = require('unified');
-const { map: mapNodes } = require('unist-util-map');
+const mapNodes = require('unist-util-map');
 const { selectAll } = require('unist-util-select');
 
 const Components = require('./components');


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

I wasn't able to run the library locally, seeing this TypeError:
![Screen Shot 2022-11-01 at 3 12 54 PM](https://user-images.githubusercontent.com/48635728/199351915-34dffe79-c77b-4345-bc4a-9adf317ec2be.png)

And we had a user who's reference page wasn't loading when they had an empty header: https://readmeio.slack.com/archives/C04EF46CU/p1667331123803559

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
