### PR TITLE
style: show border for empty th

### DIFF
--- a/components/Table/style.scss
+++ b/components/Table/style.scss
@@ -18,7 +18,7 @@
     thead tr {
       background: var(--table-head, #{$head});
     }
-    
+
     tr {
       background-color: var(--table-row, #{$row});
       & + tr {
@@ -31,7 +31,6 @@
       font-weight: 600;
       &:empty {
         padding: 0;
-        border: none;
       }
     }
 


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-5246
:-------------------:|:----------:

## 🧰 Changes

Displays borders on empty th's.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
