### PR TITLE
fix: blank api headers crashing reference pages

### DIFF
--- a/__tests__/__snapshots__/magic-block-parser.test.js.snap
+++ b/__tests__/__snapshots__/magic-block-parser.test.js.snap
@@ -11,7 +11,7 @@ exports[`Blank Magic Blocks 2`] = `
 Object {
   "children": Array [
     Object {
-      "children": "",
+      "children": Array [],
       "depth": 2,
       "type": "heading",
     },
@@ -21,6 +21,19 @@ Object {
 `;
 
 exports[`Blank Magic Blocks 3`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [],
+      "depth": 2,
+      "type": "heading",
+    },
+  ],
+  "type": "root",
+}
+`;
+
+exports[`Blank Magic Blocks 4`] = `
 Object {
   "children": Array [
     Object {

--- a/__tests__/magic-block-parser.test.js
+++ b/__tests__/magic-block-parser.test.js
@@ -21,6 +21,12 @@ test('Blank Magic Blocks', () => {
   [/block]`;
   expect(process(blank)).toMatchSnapshot();
 
+  const blankBasic = `[block:api-header]
+  { "type": "basic" }
+  [/block]
+  `;
+  expect(process(blankBasic)).toMatchSnapshot();
+
   const noTitle = `[block:api-header]
   { "level": 2 }
   [/block]`;

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -93,7 +93,7 @@ function tokenize(eat, value) {
           {
             type: 'heading',
             depth,
-            children: 'title' in json ? this.tokenizeInline(json.title, eat.now()) : '',
+            children: 'title' in json ? this.tokenizeInline(json.title, eat.now()) : [],
           },
           json
         )


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-5725
:-------------------:|:----------:

## 🧰 Changes

The following block was crashing the editor, with the TypeError `node.children.map is not a function`:
```
[block:api-header]
{
  "type": "basic"
}
[/block]
```

It's somewhat of a mystery to me how this type of empty api header magic block is ending up in our customers' markdown anyway, because an empty header inserted in the old editor looks like
```
[block:api-header]
{}
[/block]
```
and an empty header inserted in the new editor looks like `##` (or similar). My best guess is that this is somehow a legacy bug, from a time when api-header magic blocks had a different shape?

The error was being thrown in our `reactTOC` function, when we [try to normalize heading levels](https://github.com/readmeio/markdown/blob/fd4a61b980a2db623c02883a8b911f93f7e5dd71/index.js#L202) using `map` from unist-util-map.

[This line](https://github.com/syntax-tree/unist-util-map/blob/913737d206bf5ce620fc962e85281edc0f74247d/index.js#L35) in that library tries to run every time our node has children. However, if our api-header didn't have a title, we were assigning the block `children: ''`, which made unist-util-map confused and annoyed. Now, we set children to be an empty array, which `map` knows how to handle.
 

## 🧬 QA & Testing

To test, insert 
```
[block:api-header]
{
  "type": "basic"
}
[/block]
```
The editor shouldn't crash. 

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
