### PR TITLE
fix: immutable options

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,10 +72,13 @@ export function setup(blocks, opts = {}) {
 }
 
 export const utils = {
+  get options() {
+    return { ...options };
+  },
+
   BaseUrlContext,
   getHref,
   GlossaryContext: GlossaryItem.GlossaryContext,
-  options,
   VariablesContext: Variable.VariablesContext,
   calloutIcons,
 };


### PR DESCRIPTION
[![PR App][icn]][demo] |
:-------------------:|

## 🧰 Changes

Makes `rdmd.utils.options` a new object on each `get`. Hopefully this fixes cases where `options` is being overwritten.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
