### PR TITLE
docs(callouts): remove unnecessary metadata

### DIFF
--- a/docs/callouts.md
+++ b/docs/callouts.md
@@ -3,8 +3,6 @@ title: "Callouts"
 category: 5fdf7610134322007389a6ed
 hidden: false
 metadata: 
-  title: "Callouts — ReadMe-Favored Markdown"
-  description: "Callouts are very nearly equivalent to standard Markdown block quotes in their syntax, other than some specific requirements on their content: To be considered a “callout”, a block quote must start with an initial emoji, which is used to determine the callout's theme."
   image: 
     0: "https://files.readme.io/9134da7-rdmd.readme-stage-pr-2438.readme.ninja_docs_callouts.png"
     1: "rdmd.readme-stage-pr-2438.readme.ninja_docs_callouts.png"


### PR DESCRIPTION
## 🧰 Changes

I noticed that [this page](https://docs.readme.com/rdmd/docs/callouts) has a typo in the title:

![CleanShot 2022-12-16 at 15 13 15@2x](https://user-images.githubusercontent.com/8854718/208190002-6248ca3c-2de9-40dc-a46c-f6c56557db1f.png)

I dug a little deeper and realized we have the `title` + `description` metadata hardcoded in this file for some reason. I'm guessing this was added at some point for testing purposes, but I'm cleaning this up a bit both to fix the typo and just to ensure that the page contents actually match the metadata if we ever make changes in the future.



[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
