### PR TITLE
style(img): disallow images on same line as text

### DIFF
--- a/components/Image/style.scss
+++ b/components/Image/style.scss
@@ -1,10 +1,12 @@
 %img-align {
   &-right {
-    float: right;
+    float: unset;
     margin-left: .75rem;
+    margin-right: 0;
   }
   &-left {
-    float: left;
+    float: unset;
+    margin-left: 0;
     margin-right: .75rem;
   }
   &-center {
@@ -16,8 +18,7 @@
   img {
     & {
       box-sizing: content-box;
-      display: inline-block;
-      vertical-align: middle;
+      display: block;
       max-width: 100%;
       margin-left: auto;
       margin-right: auto;


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-6496
:-------------------:|:----------:

## 🧰 Changes

In the new editor, we've noticed there are occasional differences in how we render images there vs how they're rendered on the hub via RDMD. As it turns out, we've been accidentally allowing "inline" images because our left or right aligned images have been using `float`s to move the images left or right. This PR moves these elements to `block` level elements and uses `margin` instead. This might break some images in some customers projects, but it shouldn't be many (if at all) and we are okay with that.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
