### PR TITLE
fix: centering in firefox

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -1030,7 +1030,7 @@ exports[`list items 1`] = `
 </ul>"
 `;
 
-exports[`magic image 1`] = `"<figure><span aria-label=\\"A guy. Eating pizza. And making an OK gesture.\\" class=\\"img lightbox closed\\" role=\\"button\\" tabindex=\\"0\\"><span class=\\"lightbox-inner\\"><img src=\\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\" alt=\\"A guy. Eating pizza. And making an OK gesture.\\" title=\\"man-eating-pizza-and-making-an-ok-gesture.jpg\\" align=\\"center\\" class=\\"\\" width=\\"100%\\" caption=\\"\\" height=\\"auto\\" loading=\\"lazy\\"></span></span><figcaption><p>A guy. Eating pizza. And making an OK gesture.</p></figcaption></figure>"`;
+exports[`magic image 1`] = `"<figure><span aria-label=\\"A guy. Eating pizza. And making an OK gesture.\\" class=\\"img lightbox closed\\" role=\\"button\\" tabindex=\\"0\\"><span class=\\"lightbox-inner\\"><img src=\\"https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg\\" alt=\\"A guy. Eating pizza. And making an OK gesture.\\" title=\\"man-eating-pizza-and-making-an-ok-gesture.jpg\\" align=\\"middle\\" class=\\"\\" width=\\"100%\\" caption=\\"\\" height=\\"auto\\" loading=\\"lazy\\"></span></span><figcaption><p>A guy. Eating pizza. And making an OK gesture.</p></figcaption></figure>"`;
 
 exports[`prefix anchors with "section-" should add a section- prefix to heading anchors 1`] = `"<h1 id=\\"heading\\">heading</h1>"`;
 

--- a/__tests__/components/Image.test.jsx
+++ b/__tests__/components/Image.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import CreateImage from '../../components/Image';
+
+const Image = CreateImage({ lazyImages: true });
+
+describe('Image', () => {
+  it('render _all_ its children', () => {
+    render(<Image align="center" src="https://files.readme.io/b8674d6-pizzabro.jpg"></Image>);
+
+    expect(screen.getByRole('img')).toMatchInlineSnapshot(`
+      <img
+        align="middle"
+        alt=""
+        caption=""
+        height="auto"
+        loading="lazy"
+        src="https://files.readme.io/b8674d6-pizzabro.jpg"
+        title=""
+        width="auto"
+      />
+    `);
+  });
+});

--- a/components/Image/index.jsx
+++ b/components/Image/index.jsx
@@ -48,11 +48,14 @@ class Image extends React.Component {
 
   render() {
     const { props } = this;
+
     const { alt, lazy = true } = props;
 
     if (this.isEmoji) {
       return <img {...props} alt={alt} loading={lazy ? 'lazy' : ''} />;
     }
+
+    const align = props.align === 'center' ? 'middle' : props.align;
 
     return (
       <span
@@ -64,7 +67,7 @@ class Image extends React.Component {
         tabIndex={0}
       >
         <span className="lightbox-inner">
-          <img {...props} alt={alt} loading={lazy ? 'lazy' : ''} />
+          <img {...props} align={align} alt={alt} loading={lazy ? 'lazy' : ''} />
         </span>
       </span>
     );

--- a/components/Image/style.scss
+++ b/components/Image/style.scss
@@ -1,11 +1,11 @@
 %img-align {
   &-right {
     float: right;
-    margin-left: .75rem;
+    margin-left: 0.75rem;
   }
   &-left {
     float: left;
-    margin-right: .75rem;
+    margin-right: 0.75rem;
   }
   &-center {
     display: block;
@@ -26,28 +26,28 @@
       outline: none !important;
     }
 
-    &[align=right],
-    &[alt~=align-right] {
+    &[align='right'],
+    &[alt~='align-right'] {
       @extend %img-align-right;
     }
-    &[align=left],
-    &[alt~=align-left] {
+    &[align='left'],
+    &[alt~='align-left'] {
       @extend %img-align-left;
     }
-    &[width="80%"],
-    &[align=center],
-    &[alt~=align-center] {
+    &[width='80%'],
+    &[align='middle'],
+    &[alt~='align-center'] {
       @extend %img-align-center;
     }
 
-    &[width=smart] {
+    &[width='smart'] {
       width: auto;
       max-width: 100%;
       max-height: 450px;
     }
 
     &.border {
-      border: 1px solid rgba(0,0,0,.2);
+      border: 1px solid rgba(0, 0, 0, 0.2);
     }
   }
 
@@ -57,19 +57,21 @@
     }
     figcaption {
       margin-top: 8px;
-      font-size: .93em;
+      font-size: 0.93em;
       font-style: italic;
       text-align: center;
     }
   }
 
-  > img, figure > img {
+  > img,
+  figure > img {
     @extend %img-align-center;
   }
 
   figure .img {
     display: inline-block;
-    &, >img:only-of-type {
+    &,
+    > img:only-of-type {
       display: block;
     }
   }
@@ -90,7 +92,7 @@
       height: 100vh;
       overflow: hidden;
       overflow-y: scroll;
-      background: rgba(white, .966);
+      background: rgba(white, 0.966);
       user-select: none;
 
       margin-top: 0;
@@ -98,7 +100,7 @@
     }
 
     // Close Button
-    // 
+    //
     &:after {
       position: fixed;
       top: 1em;
@@ -116,7 +118,7 @@
 
       opacity: 1;
       transform: scale(1.5);
-      transition: .3s .3s ease-in;
+      transition: 0.3s 0.3s ease-in;
     }
     &:not(.open):after {
       transform: scale(0);
@@ -140,8 +142,9 @@
       min-width: unset !important;
       max-width: 97.5vw !important;
       max-height: 97.5vh !important;
-      &.border, &:not([src$=".png"]):not([src$=".svg"]):not([src$=".jp2"]):not([src$=".tiff"]) {
-        box-shadow: 0 .5em 3em -1em rgba(0, 0, 0, .2);
+      &.border,
+      &:not([src$='.png']):not([src$='.svg']):not([src$='.jp2']):not([src$='.tiff']) {
+        box-shadow: 0 0.5em 3em -1em rgba(0, 0, 0, 0.2);
       }
     }
   }


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix CX-151
:-------------------:|:----------:

## 🧰 Changes

Used the correct value for the align attribute. Chrome for some reason allows images to be centered via `[align=center]`. But this isn't strictly correct: [The Image Embed element | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#deprecated_attributes)

Firefox only recognizes 'middle' and not 'center'.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
