### PR TITLE
fix(image): force SVG dimensions in lightbox

### DIFF
--- a/components/Image/style.scss
+++ b/components/Image/style.scss
@@ -137,14 +137,21 @@
     }
 
     img {
-      width: auto !important;
-      height: auto !important;
-      min-width: unset !important;
-      max-width: 97.5vw !important;
-      max-height: 97.5vh !important;
+      width: auto;
+      height: auto;
+      min-width: unset;
+      max-width: 97.5vw;
+      max-height: 97.5vh;
       &.border,
       &:not([src$='.png']):not([src$='.svg']):not([src$='.jp2']):not([src$='.tiff']) {
         box-shadow: 0 0.5em 3em -1em rgba(0, 0, 0, 0.2);
+      }
+      &[src$='svg'] {
+        width: 42vw;
+        min-width: 200px;
+        max-width: 100%;
+        height: 66vw;
+        display: block;
       }
     }
   }


### PR DESCRIPTION
| [📖 PR App][demo] | 🎫 Fix CX-217 |
| :---------------: | :-----------: |

## 🧰 Changes

SVGs weren't displaying at all when shown in the lightbox.

- [x] override dimensions for lightboxed SVG images

## 🧬 QA & Testing

> 🚧 **Note**: _we'll need to cut a new release and merge this in to ReadMe to fully test._

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
