### PR TITLE
feat: allow colgroup + col

### DIFF
--- a/sanitize.schema.js
+++ b/sanitize.schema.js
@@ -37,6 +37,9 @@ const createSchema = ({ safeMode } = {}) => {
   schema.tagNames.push('input'); // allow GitHub-style todo lists
   schema.ancestors.input = ['li'];
 
+  schema.tagNames.push('colgroup'); // wat
+  schema.tagNames.push('col');
+
   return schema;
 };
 


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix SA-13 |
| :--------------------: | :-------: |

## 🧰 Changes

Adds `colgroup` and `col` to the allow list. No idea why these were being filtered?!

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
