### PR TITLE
fix: use correct match value

### DIFF
--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -31,11 +31,11 @@ const imgSizeByWidth = new Proxy(new Map(Array.from(imgSizeValues).reverse()), {
 
 function tokenize({ compatibilityMode, safeMode, alwaysThrow }) {
   return function (eat, value) {
+    // eslint-disable-next-line prefer-const
     let [match, type, json] = RGXP.exec(value) || [];
 
     if (!type) return;
 
-    match = match.trim();
     type = type.trim();
 
     try {


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix CX-225 |
| :--------------------: | :--------: |

## 🧰 Changes

The magic block parser was generating incorrect position data becuase it was using the incorrect string to denote it's match. This was creating issues with the markdown editor since it using that position data.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
