### PR TITLE
chore(deps): bumping syntax-highlighter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@readme/emojis": "^5.0.0",
-        "@readme/syntax-highlighter": "^12.1.0",
+        "@readme/syntax-highlighter": "^12.1.1",
         "copy-to-clipboard": "^3.3.2",
         "emoji-regex": "^10.2.1",
         "hast-util-sanitize": "^4.0.0",
@@ -4194,9 +4194,9 @@
       }
     },
     "node_modules/@readme/syntax-highlighter": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-12.1.0.tgz",
-      "integrity": "sha512-qpadEYCMijJWkcReUtzur5Tw3QAFI7xtsWBac79PWcF2B9MZTUFwPGfwfPHB3+wYr6w7bErjm3ZMkeCHxOwmaQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-12.1.1.tgz",
+      "integrity": "sha512-5UKtpzb3Jf+eeIviQonNBJAJAhTPjQ7kkA2fOaAZSyMoKdy9fa+KPrl+8D/jb239YZmgsG5bj1D630kaqhRXEw==",
       "dependencies": {
         "codemirror": "5.54.0",
         "codemirror-graphql": "1.0.2",
@@ -27787,9 +27787,9 @@
       }
     },
     "@readme/syntax-highlighter": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-12.1.0.tgz",
-      "integrity": "sha512-qpadEYCMijJWkcReUtzur5Tw3QAFI7xtsWBac79PWcF2B9MZTUFwPGfwfPHB3+wYr6w7bErjm3ZMkeCHxOwmaQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-12.1.1.tgz",
+      "integrity": "sha512-5UKtpzb3Jf+eeIviQonNBJAJAhTPjQ7kkA2fOaAZSyMoKdy9fa+KPrl+8D/jb239YZmgsG5bj1D630kaqhRXEw==",
       "requires": {
         "codemirror": "5.54.0",
         "codemirror-graphql": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@readme/emojis": "^5.0.0",
-    "@readme/syntax-highlighter": "^12.1.0",
+    "@readme/syntax-highlighter": "^12.1.1",
     "copy-to-clipboard": "^3.3.2",
     "emoji-regex": "^10.2.1",
     "hast-util-sanitize": "^4.0.0",


### PR DESCRIPTION
[![PR App][icn]][demo] |
:-------------------:|

## 🧰 Changes

I've added improved highlighting for the Solidity language in https://github.com/readmeio/syntax-highlighter/pull/435, this pulls that work in here.


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
