### PR TITLE
fix: add css semi-colons

### DIFF
--- a/styles/gfm.scss
+++ b/styles/gfm.scss
@@ -23,11 +23,11 @@
     float: left;
     line-height: 1;
     margin-left: -20px;
-    padding-right: 4px
+    padding-right: 4px;
   }
 
   .anchor:focus {
-    outline: 0
+    outline: 0;
   }
 
   h1:hover .anchor,
@@ -36,19 +36,19 @@
   h4:hover .anchor,
   h5:hover .anchor,
   h6:hover .anchor {
-    text-decoration: none
+    text-decoration: none;
   }
 
   details {
-    display: block
+    display: block;
   }
 
   summary {
-    display: list-item
+    display: list-item;
   }
 
   a {
-    transition: .15s ease;
+    transition: 0.15s ease;
 
     &:hover {
       text-decoration: underline;
@@ -57,22 +57,22 @@
 
   a:active,
   a:hover {
-    outline-width: 0
+    outline-width: 0;
   }
 
   a:not([href]) {
     color: inherit;
-    text-decoration: none
+    text-decoration: none;
   }
 
   strong {
     font-weight: inherit;
-    font-weight: bolder
+    font-weight: bolder;
   }
 
   h1 {
     font-size: 2em;
-    margin: .67em 0
+    margin: 0.67em 0;
   }
 
   hr {
@@ -91,34 +91,34 @@
 
   input {
     font: inherit;
-    margin: 0
+    margin: 0;
   }
 
   input {
-    overflow: visible
+    overflow: visible;
   }
 
-  [type=checkbox] {
+  [type='checkbox'] {
     box-sizing: border-box;
-    padding: 0
+    padding: 0;
   }
 
   * {
-    box-sizing: border-box
+    box-sizing: border-box;
   }
 
   input {
     font-family: inherit;
     font-size: inherit;
-    line-height: inherit
+    line-height: inherit;
   }
 
   strong {
-    font-weight: 600
+    font-weight: 600;
   }
 
   details summary {
-    cursor: pointer
+    cursor: pointer;
   }
 
   h1,
@@ -140,7 +140,7 @@
     font-size: 1.75em;
     font-size: var(--markdown-title-size, 1.75em);
   }
-  
+
   h2 {
     font-size: 1.5em;
     font-size: var(--markdown-title-size, 1.5em);
@@ -179,62 +179,62 @@
   }
 
   h5 {
-    font-size: .875em;
-    font-size: var(--markdown-title-size, .875em);
+    font-size: 0.875em;
+    font-size: var(--markdown-title-size, 0.875em);
   }
 
   h6 {
-    font-size: .85em;
-    font-size: var(--markdown-title-size, .85em);
+    font-size: 0.85em;
+    font-size: var(--markdown-title-size, 0.85em);
     color: var(--markdown-title, #6a737d);
   }
 
   p,
   .p {
     margin-bottom: 10px;
-    margin-top: 0
+    margin-top: 0;
   }
 
   blockquote {
-    margin: 0
+    margin: 0;
   }
 
   ol,
   ul {
     margin-bottom: 0;
     margin-top: 0;
-    padding-left: 0
+    padding-left: 0;
   }
 
   ol ol,
   ul ol {
-    list-style-type: lower-roman
+    list-style-type: lower-roman;
   }
 
   ol ol ol,
   ol ul ol,
   ul ol ol,
   ul ul ol {
-    list-style-type: lower-alpha
+    list-style-type: lower-alpha;
   }
 
   dd {
-    margin-left: 0
+    margin-left: 0;
   }
 
   input::-webkit-inner-spin-button,
   input::-webkit-outer-spin-button {
     -webkit-appearance: none;
     appearance: none;
-    margin: 0
+    margin: 0;
   }
 
-  &> :first-child {
-    margin-top: 0 !important
+  & > :first-child {
+    margin-top: 0 !important;
   }
 
-  &>:last-child {
-    margin-bottom: 0 !important
+  & > :last-child {
+    margin-bottom: 0 !important;
   }
 
   blockquote,
@@ -250,22 +250,22 @@
 
   blockquote {
     display: block;
-    border-left: .25em solid #dfe2e5;
+    border-left: 0.25em solid #dfe2e5;
     color: #6a737d;
-    padding: 0 1em
+    padding: 0 1em;
   }
 
-  blockquote>:first-child {
-    margin-top: 0
+  blockquote > :first-child {
+    margin-top: 0;
   }
 
-  blockquote>:last-child {
-    margin-bottom: 0
+  blockquote > :last-child {
+    margin-bottom: 0;
   }
 
   ol,
   ul {
-    padding-left: 2em
+    padding-left: 2em;
   }
 
   ol ol,
@@ -273,23 +273,23 @@
   ul ol,
   ul ul {
     margin-bottom: 0;
-    margin-top: 0
+    margin-top: 0;
   }
 
   li {
-    word-wrap: break-all
+    word-wrap: break-all;
   }
 
-  li>p {
-    margin-top: 1em
+  li > p {
+    margin-top: 1em;
   }
 
-  li+li {
-    margin-top: .25em
+  li + li {
+    margin-top: 0.25em;
   }
 
   dl {
-    padding: 0
+    padding: 0;
   }
 
   dl dt {
@@ -297,31 +297,31 @@
     font-style: italic;
     font-weight: 600;
     margin-top: 1em;
-    padding: 0
+    padding: 0;
   }
 
   dl dd {
     margin-bottom: 1em;
-    padding: 0 1em
+    padding: 0 1em;
   }
 
-  :checked+.radio-label {
+  :checked + .radio-label {
     border-color: var(--project-color-primary);
     position: relative;
-    z-index: 1
+    z-index: 1;
   }
 
   .task-list-item {
-    list-style-type: none
+    list-style-type: none;
   }
 
-  .task-list-item+.task-list-item {
-    margin-top: 3px
+  .task-list-item + .task-list-item {
+    margin-top: 3px;
   }
 
   .task-list-item input {
-    margin: 0 .2em .25em -1.6em;
-    vertical-align: middle
+    margin: 0 0.2em 0.25em -1.6em;
+    vertical-align: middle;
   }
 
   p.blank-line {
@@ -332,35 +332,36 @@
 @mixin markdownOverrides {
   h5,
   h6 {
-    font-size: .9em;
+    font-size: 0.9em;
   }
-
 
   blockquote h1:last-child,
   blockquote h2:last-child {
     border-bottom: 0;
   }
 
-
-  >* {
+  > * {
     margin-top: 15px;
     margin-bottom: 15px !important;
   }
 
-
   .task-list-item input {
-    margin: 0 .5em .25em -1.25em;
+    margin: 0 0.5em 0.25em -1.25em;
   }
 
-  a[href], a:not([href=""]) {
-    text-decoration: underline
+  a[href],
+  a:not([href='']) {
+    text-decoration: underline;
   }
 }
 
 @mixin _clearfix() {
-  &:before, &:after {
-    content: "";
+  &:before,
+  &:after {
+    content: '';
     display: table;
   }
-  &:after { clear: both }
+  &:after {
+    clear: both;
+  }
 }


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

Adds what appear to be a bunch of missing semi-colons.

IIUC, scss requires semi-colons, so I have no idea how this worked before?

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
