### PR TITLE
fix: glossary item border styles

### DIFF
--- a/components/GlossaryItem/style.scss
+++ b/components/GlossaryItem/style.scss
@@ -4,8 +4,7 @@
 /* stylelint-disable order/properties-alphabetical-order */
 .GlossaryItem {
   &-trigger {
-    border-style: dotted;
-    border-bottom: 1px solid #737c83;
+    border-bottom: 1px dotted #737c83;
     border-left: none;
     border-right: none;
     border-top: none;

--- a/components/GlossaryItem/style.scss
+++ b/components/GlossaryItem/style.scss
@@ -1,7 +1,6 @@
 /* stylelint-disable declaration-property-value-disallowed-list */
 /* stylelint-disable custom-property-pattern */
 /* stylelint-disable order/order */
-/* stylelint-disable order/properties-alphabetical-order */
 .GlossaryItem {
   &-trigger {
     border-bottom: 1px dotted #737c83;

--- a/components/GlossaryItem/style.scss
+++ b/components/GlossaryItem/style.scss
@@ -1,12 +1,13 @@
 /* stylelint-disable declaration-property-value-disallowed-list */
 /* stylelint-disable custom-property-pattern */
 /* stylelint-disable order/order */
+/* stylelint-disable order/properties-alphabetical-order */
 .GlossaryItem {
   &-trigger {
+    border-style: dotted;
     border-bottom: 1px solid #737c83;
     border-left: none;
     border-right: none;
-    border-style: dotted;
     border-top: none;
     cursor: pointer;
   }


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix CX-386
:-------------------:|:----------:

[slack thread](https://readmeio.slack.com/archives/C0101J0HU1Z/p1687274834378059)

| before | after |
|--------|--------|
| <img width="80" alt="image" src="https://github.com/readmeio/markdown/assets/43232318/d53370dd-2e61-4c61-b104-e902d2c43787"> | <img width="90" alt="image" src="https://github.com/readmeio/markdown/assets/43232318/e013b8b4-5b59-44cb-9d1a-92ea69006876"> | 


## 🧰 Changes
- Fix `border-left` and `border-right` styles applying dotted lines incorrectly due to [changes in ordering](https://github.com/readmeio/markdown/pull/756/files#diff-0f5fbef626dd723f36428180e061af1a110698f6f9ad519a92e29c297451fb12R4-R10)
- Remove `border-style: dotted` and just replace `solid` with `dotted` in `border-bottom`

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
