### PR TITLE
chore(stylelint): upgrade to latest and fix all issues

### DIFF
--- a/components/Code/style.scss
+++ b/components/Code/style.scss
@@ -127,7 +127,7 @@
     }
 
     &:active {
-      box-shadow: inset 0 0 0 1px rgba(#8b8b8b, 0.5), inset 1px 4px 6px -2px rgba(0, 0, 0, 17.5%);
+      box-shadow: inset 0 0 0 1px rgba(#8b8b8b, 0.5), inset 1px 4px 6px -2px rgba(0, 0, 0, 0.175);
 
       &::before,
       &::after {

--- a/components/CodeTabs/style.scss
+++ b/components/CodeTabs/style.scss
@@ -74,7 +74,7 @@
   }
 
   &-toolbar button:not(.CodeTabs_active):hover {
-    background: rgba(0, 0, 0, 7.5%);
+    background: rgba(0, 0, 0, 0.075);
   }
 
   pre {

--- a/components/GlossaryItem/style.scss
+++ b/components/GlossaryItem/style.scss
@@ -15,9 +15,9 @@
     --GlossaryItem-color: var(--color-text-default, var(--gray20));
     --GlossaryItem-shadow: var(
       --box-shadow-menu-light,
-      0 5px 10px rgba(0, 0, 0, 5%),
-      0 2px 6px rgba(0, 0, 0, 2.5%),
-      0 1px 3px rgba(0, 0, 0, 2.5%)
+      0 5px 10px rgba(0, 0, 0, 0.05),
+      0 2px 6px rgba(0, 0, 0, 0.025),
+      0 1px 3px rgba(0, 0, 0, 0.025)
     );
 
     /* what the dark-mode mixin does in the readme project */
@@ -26,9 +26,9 @@
       --GlossaryItem-color: var(--color-text-default, var(--white));
       --GlossaryItem-shadow: var(
         --box-shadow-menu-dark,
-        0 1px 3px rgba(0, 0, 0, 2.5%),
-        0 2px 6px rgba(0, 0, 0, 2.5%),
-        0 5px 10px rgba(0, 0, 0, 5%)
+        0 1px 3px rgba(0, 0, 0, 0.025),
+        0 2px 6px rgba(0, 0, 0, 0.025),
+        0 5px 10px rgba(0, 0, 0, 0.05)
       );
     }
 
@@ -38,9 +38,9 @@
         --GlossaryItem-color: var(--color-text-default, var(--white));
         --GlossaryItem-shadow: var(
           --box-shadow-menu-dark,
-          0 1px 3px rgba(0, 0, 0, 2.5%),
-          0 2px 6px rgba(0, 0, 0, 2.5%),
-          0 5px 10px rgba(0, 0, 0, 5%)
+          0 1px 3px rgba(0, 0, 0, 0.025),
+          0 2px 6px rgba(0, 0, 0, 0.025),
+          0 5px 10px rgba(0, 0, 0, 0.05)
         );
       }
     }

--- a/components/Image/style.scss
+++ b/components/Image/style.scss
@@ -51,7 +51,7 @@
     }
 
     &.border {
-      border: 1px solid rgba(0, 0, 0, 20%);
+      border: 1px solid rgba(0, 0, 0, 0.2);
     }
   }
 
@@ -137,7 +137,7 @@
 
       &.border,
       &:not([src$='.png']):not([src$='.svg']):not([src$='.jp2']):not([src$='.tiff']) {
-        box-shadow: 0 0.5em 3em -1em rgba(0, 0, 0, 20%);
+        box-shadow: 0 0.5em 3em -1em rgba(0, 0, 0, 0.2);
       }
 
       &[src$='svg'] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "@commitlint/config-conventional": "^17.1.0",
         "@hot-loader/react-dom": "^16.14.0",
         "@readme/eslint-config": "^10.5.2",
-        "@readme/stylelint-config": "^3.1.16",
+        "@readme/stylelint-config": "^3.2.0",
         "@readme/variable": "^15.1.2",
         "@semantic-release/changelog": "^6.0.1",
         "@semantic-release/git": "^10.0.1",
@@ -4192,9 +4192,9 @@
       }
     },
     "node_modules/@readme/stylelint-config": {
-      "version": "3.1.16",
-      "resolved": "https://registry.npmjs.org/@readme/stylelint-config/-/stylelint-config-3.1.16.tgz",
-      "integrity": "sha512-8ZZXq75G18hkQxINFhkjl+04/KpU24C+9NZxuGPBqZuvbOorlFcHfZ8kYPT+8iu9j4Hqx2cc+2KFXnFQ6ij3Dw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/stylelint-config/-/stylelint-config-3.2.0.tgz",
+      "integrity": "sha512-px7QskRDNWYlyMHkPN6/Kd7uJHsTOvoswxehCfnMoBsgkwYnw4Al9pXHD/iMBe/Oyqpek+hEUuslIgxfP+M3rQ==",
       "dev": true,
       "dependencies": {
         "stylelint-config-css-modules": "^4.2.0",
@@ -28879,9 +28879,9 @@
       }
     },
     "@readme/stylelint-config": {
-      "version": "3.1.16",
-      "resolved": "https://registry.npmjs.org/@readme/stylelint-config/-/stylelint-config-3.1.16.tgz",
-      "integrity": "sha512-8ZZXq75G18hkQxINFhkjl+04/KpU24C+9NZxuGPBqZuvbOorlFcHfZ8kYPT+8iu9j4Hqx2cc+2KFXnFQ6ij3Dw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@readme/stylelint-config/-/stylelint-config-3.2.0.tgz",
+      "integrity": "sha512-px7QskRDNWYlyMHkPN6/Kd7uJHsTOvoswxehCfnMoBsgkwYnw4Al9pXHD/iMBe/Oyqpek+hEUuslIgxfP+M3rQ==",
       "dev": true,
       "requires": {
         "stylelint-config-css-modules": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@commitlint/config-conventional": "^17.1.0",
     "@hot-loader/react-dom": "^16.14.0",
     "@readme/eslint-config": "^10.5.2",
-    "@readme/stylelint-config": "^3.1.16",
+    "@readme/stylelint-config": "^3.2.0",
     "@readme/variable": "^15.1.2",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix CX-410
:-------------------:|:----------:

## 🧰 Changes

Stylelint was recently updated to include other necessary rules that
previously used to exist only in the main `readme` repo. Missing these
rules caused a style regression whereever `rgba` values were used with
percentages instead of decimals.

This should fix all background colors to have dimmed opacity as
intended.




## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
