### PR TITLE
fix: styles and toc

### DIFF
--- a/example/demo.scss
+++ b/example/demo.scss
@@ -17,6 +17,7 @@
 
   #content-container {
     padding-top: 0 !important;
+    display: flex;
   }
   // end hub overrides
 

--- a/example/demo.scss
+++ b/example/demo.scss
@@ -1,3 +1,6 @@
+@import 'https://cdn.readme.io/public/hub/web/main.3f4ed9ef7e8b221de43c.css';
+@import 'https://cdn.readme.io/public/hub/web/3435.9200159a8fec79d971c4.css';
+
 @import '../styles/main.scss';
 
 #rdmd-demo {

--- a/example/demo.scss
+++ b/example/demo.scss
@@ -1,5 +1,5 @@
-@import 'https://cdn.readme.io/public/hub/web/main.3f4ed9ef7e8b221de43c.css';
-@import 'https://cdn.readme.io/public/hub/web/3435.9200159a8fec79d971c4.css';
+@import url('https://cdn.readme.io/public/hub/web/main.3f4ed9ef7e8b221de43c.css');
+@import url('https://cdn.readme.io/public/hub/web/3435.9200159a8fec79d971c4.css');
 
 @import '../styles/main.scss';
 

--- a/example/index.html
+++ b/example/index.html
@@ -2,8 +2,6 @@
 <html>
   <head>
     <title>Markdown Demo</title>
-    <link rel="stylesheet" type="text/css" href="https://cdn.readme.io/public/hub/web/main.3f4ed9ef7e8b221de43c.css" />
-    <link rel="stylesheet" type="text/css" href="https://cdn.readme.io/public/hub/web/3435.9200159a8fec79d971c4.css" />
     <link rel="stylesheet" type="text/css" href="demo.css" />
     <link
       rel="stylesheet"

--- a/example/index.html
+++ b/example/index.html
@@ -2,7 +2,8 @@
 <html>
   <head>
     <title>Markdown Demo</title>
-    <link rel="stylesheet" type="text/css" href="https://cdn.readme.io/css/bundle-hub2.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.readme.io/public/hub/web/main.3f4ed9ef7e8b221de43c.css" />
+    <link rel="stylesheet" type="text/css" href="https://cdn.readme.io/public/hub/web/3435.9200159a8fec79d971c4.css" />
     <link rel="stylesheet" type="text/css" href="demo.css" />
     <link
       rel="stylesheet"


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

Fixes rendering the ToC to the right, as well as loads in the main apps bundles.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
