### PR TITLE
fix(code-tabs): setting theme

### DIFF
--- a/__tests__/components/CodeTabs.test.jsx
+++ b/__tests__/components/CodeTabs.test.jsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+
+import { react } from '../../index';
+
+describe('Callout', () => {
+  it('render _all_ its children', () => {
+    const md = `
+\`\`\`
+assert('theme', 'dark');
+\`\`\`
+    `;
+    const { container } = render(react(md, { theme: 'dark' }));
+
+    expect(container.querySelector('code.theme-dark')).toBeVisible();
+  });
+});

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ export function reactProcessor(opts = {}, components = {}) {
   return htmlProcessor({ ...opts })
     .use(sectionAnchorId)
     .use(rehypeReact, {
-      createElement,
+      createElement: createElement(opts),
       Fragment: React.Fragment,
       components: {
         'code-tabs': CodeTabs(opts),

--- a/lib/createElement/index.js
+++ b/lib/createElement/index.js
@@ -1,11 +1,15 @@
 const React = require('react');
 
-const { CodeTabs } = require('../../components/CodeTabs');
+const CreateCodeTabs = require('../../components/CodeTabs');
 
-const createElement = (type, props, ...children) => {
-  const rdmdType = type === 'div' && props?.className === 'code-tabs' ? CodeTabs : type;
+const createElement =
+  opts =>
+  // eslint-disable-next-line react/display-name
+  (type, props, ...children) => {
+    // eslint-disable-next-line react/prop-types
+    const rdmdType = type === 'div' && props?.className === 'code-tabs' ? CreateCodeTabs(opts) : type;
 
-  return React.createElement(rdmdType, props, ...children);
-};
+    return React.createElement(rdmdType, props, ...children);
+  };
 
 module.exports = createElement;


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

Fixes setting the theme on code tabs.

It appears that after a prior fix, we weren't setting the theme on CodeTabs. This resulted in a using a hack to set the theme in the main app.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
