### PR TITLE
fix: code tabs with *

### DIFF
--- a/__tests__/flavored-compilers/code-tabs.test.js
+++ b/__tests__/flavored-compilers/code-tabs.test.js
@@ -1,0 +1,39 @@
+import { mdast, md } from '../../index';
+
+describe('code-tabs compiler', () => {
+  it('compiles code tabs', () => {
+    const markdown = `\`\`\`
+const works = true;
+\`\`\`
+\`\`\`
+const cool = true;
+\`\`\`
+`;
+
+    expect(md(mdast(markdown))).toBe(markdown);
+  });
+
+  it('compiles code tabs with metadata', () => {
+    const markdown = `\`\`\`js Testing
+const works = true;
+\`\`\`
+\`\`\`js
+const cool = true;
+\`\`\`
+`;
+
+    expect(md(mdast(markdown))).toBe(markdown);
+  });
+
+  it('compiles code tabs with an asterisk in the name', () => {
+    const markdown = `\`\`\`js Testing*
+const works = true;
+\`\`\`
+\`\`\`
+const cool = true;
+\`\`\`
+`;
+
+    expect(md(mdast(markdown))).toBe(markdown);
+  });
+});

--- a/processor/compile/code-tabs.js
+++ b/processor/compile/code-tabs.js
@@ -3,7 +3,15 @@ module.exports = function CodeTabsCompiler() {
   const { visitors } = Compiler.prototype;
 
   function compile(node) {
-    return this.block(node).split('```\n\n').join('```\n');
+    const fence = '```';
+
+    return node.children
+      .map(code => {
+        return `${fence}${code.lang || ''}${code.meta ? ` ${code.meta}` : ''}\n${
+          code.value ? `${code.value}\n` : ''
+        }${fence}`;
+      })
+      .join('\n');
   }
 
   visitors['code-tabs'] = compile;


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix CX-379 |
| :--------------------: | :--------: |

## 🧰 Changes

Prevent escaping asterisks in code tab names.

Not sure why the default code compiler escapes asterisks, but I don't see a reason for it. So I've added a custom compiler for code tabs to prevent this behavior.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
