### PR TITLE
fix: compact headings

### DIFF
--- a/__tests__/flavored-parsers/compact-headings.test.js
+++ b/__tests__/flavored-parsers/compact-headings.test.js
@@ -26,4 +26,15 @@ describe('Compact headings', () => {
     expect(tree.children[0].position.start.offset).toBe(0);
     expect(tree.children[0].position.end.offset).toBe(21);
   });
+
+  it('can parse a compact heading followed by a setext heading', () => {
+    const heading = `
+##Non-compact Heading
+---
+`;
+    const tree = mdast(heading);
+
+    expect(tree.children[0].children[0].value).toBe('Non-compact Heading');
+    expect(tree.children[1].type).toBe('thematicBreak');
+  });
 });

--- a/__tests__/flavored-parsers/utils.test.js
+++ b/__tests__/flavored-parsers/utils.test.js
@@ -1,0 +1,62 @@
+import { insertBlockTokenizerBefore, insertInlineTokenizerBefore } from '../../processor/parse/utils';
+
+let self;
+
+beforeEach(() => {
+  self = {
+    Parser: {
+      prototype: {
+        blockTokenizers: {},
+        blockMethods: ['one', 'two'],
+        inlineTokenizers: {},
+        inlineMethods: ['one', 'two'],
+      },
+    },
+  };
+});
+
+describe('insertBlockTokenizerBefore', () => {
+  it('correctly splices the tokenizer into place', () => {
+    insertBlockTokenizerBefore.call(self, {
+      name: 'test',
+      before: 'one',
+      tokenizer: () => {},
+    });
+
+    expect(self.Parser.prototype.blockMethods).toStrictEqual(['test', 'one', 'two']);
+    expect(self.Parser.prototype.blockTokenizers).toHaveProperty('test');
+  });
+
+  it('throws an error if the method does not exist', () => {
+    expect(() =>
+      insertBlockTokenizerBefore.call(self, {
+        name: 'test',
+        before: 'oh no',
+        tokenizer: () => {},
+      })
+    ).toThrow("The 'oh no' tokenizer does not exist!");
+  });
+});
+
+describe('insertInlineTokenizerBefore', () => {
+  it('correctly splices the tokenizer into place', () => {
+    insertInlineTokenizerBefore.call(self, {
+      name: 'test',
+      before: 'one',
+      tokenizer: () => {},
+    });
+
+    expect(self.Parser.prototype.inlineMethods).toStrictEqual(['test', 'one', 'two']);
+    expect(self.Parser.prototype.inlineTokenizers).toHaveProperty('test');
+  });
+
+  it('throws an error if the method does not exist', () => {
+    expect(() =>
+      insertInlineTokenizerBefore.call(self, {
+        name: 'test',
+        before: 'oh no',
+        tokenizer: () => {},
+      })
+    ).toThrow("The 'oh no' tokenizer does not exist!");
+  });
+});

--- a/processor/parse/compact-headings.js
+++ b/processor/parse/compact-headings.js
@@ -1,3 +1,5 @@
+const { insertBlockTokenizerBefore } = require('./utils');
+
 const rgx = /^(#{1,6})(?!(?:#|\s))([^\n]+)\n/;
 
 function tokenizer(eat, value) {
@@ -15,12 +17,11 @@ function tokenizer(eat, value) {
 }
 
 function parser() {
-  const { Parser } = this;
-  const tokenizers = Parser.prototype.blockTokenizers;
-  const methods = Parser.prototype.blockMethods;
-
-  tokenizers.compactHeading = tokenizer;
-  methods.splice(methods.indexOf('newline'), 0, 'compactHeading');
+  insertBlockTokenizerBefore.call(this, {
+    name: 'compactHeading',
+    before: 'atxHeading',
+    tokenizer,
+  });
 }
 
 module.exports = parser;

--- a/processor/parse/flavored/code-tabs.js
+++ b/processor/parse/flavored/code-tabs.js
@@ -1,5 +1,7 @@
 const decode = require('parse-entities');
 
+const { insertBlockTokenizerBefore } = require('../utils');
+
 function tokenizer(eat, value) {
   // eslint-disable-next-line unicorn/no-unsafe-regex
   const TAB_BLOCK_RGXP = /^(?:(?:^|\n)```(?:(?!\n```).)*\n```[^\S\n]*){2,}/gs;
@@ -47,12 +49,11 @@ function tokenizer(eat, value) {
 }
 
 function parser() {
-  const { Parser } = this;
-  const tokenizers = Parser.prototype.blockTokenizers;
-  const methods = Parser.prototype.blockMethods;
-
-  tokenizers.codeTabs = tokenizer;
-  methods.splice(methods.indexOf('indentedCode') - 1, 0, 'codeTabs');
+  insertBlockTokenizerBefore.call(this, {
+    name: 'codeTabs',
+    before: 'indentedCode',
+    tokenizer,
+  });
 }
 
 module.exports = parser;

--- a/processor/parse/flavored/embed.js
+++ b/processor/parse/flavored/embed.js
@@ -1,3 +1,5 @@
+const { insertBlockTokenizerBefore } = require('../utils');
+
 const rgx = /^\[([^\]]*)\]\((\S*) ["'](@\w+)"\)/;
 
 function tokenizer(eat, value) {
@@ -30,12 +32,11 @@ function tokenizer(eat, value) {
 }
 
 function parser() {
-  const { Parser } = this;
-  const tokenizers = Parser.prototype.blockTokenizers;
-  const methods = Parser.prototype.blockMethods;
-
-  tokenizers.embed = tokenizer;
-  methods.splice(methods.indexOf('newline'), 0, 'embed');
+  insertBlockTokenizerBefore.call(this, {
+    name: 'embed',
+    before: 'blankLine',
+    tokenizer,
+  });
 }
 
 module.exports = parser;

--- a/processor/parse/gemoji-parser.js
+++ b/processor/parse/gemoji-parser.js
@@ -1,5 +1,7 @@
 const Emoji = require('@readme/emojis').emoji;
 
+const { insertInlineTokenizerBefore } = require('./utils');
+
 const emojis = new Emoji();
 
 const colon = ':';
@@ -58,13 +60,11 @@ function locate(value, fromIndex) {
 tokenize.locator = locate;
 
 function parser() {
-  const { Parser } = this;
-  const tokenizers = Parser.prototype.inlineTokenizers;
-  const methods = Parser.prototype.inlineMethods;
-
-  tokenizers.gemoji = tokenize;
-
-  methods.splice(methods.indexOf('text'), 0, 'gemoji');
+  insertInlineTokenizerBefore.call(this, {
+    name: 'gemoji',
+    before: 'text',
+    tokenizer: tokenize,
+  });
 }
 
 module.exports = parser;

--- a/processor/parse/magic-block-parser.js
+++ b/processor/parse/magic-block-parser.js
@@ -1,4 +1,6 @@
 /* eslint-disable consistent-return */
+const { insertBlockTokenizerBefore } = require('./utils');
+
 const RGXP = /^\[block:(.*)\]([^]+?)\[\/block\]/;
 
 const WrapPinnedBlocks = (node, json) => {
@@ -281,16 +283,17 @@ function tokenize({ compatibilityMode, safeMode, alwaysThrow }) {
 }
 
 function parser() {
-  const { Parser } = this;
-  const tokenizers = Parser.prototype.blockTokenizers;
-  const methods = Parser.prototype.blockMethods;
-
-  tokenizers.magicBlocks = tokenize({
+  const tokenizer = tokenize({
     compatibilityMode: this.data('compatibilityMode'),
     safeMode: this.data('safeMode'),
     alwaysThrow: this.data('alwaysThrow'),
   });
-  methods.splice(methods.indexOf('newline'), 0, 'magicBlocks');
+
+  insertBlockTokenizerBefore.call(this, {
+    name: 'magicBlocks',
+    before: 'blankLine',
+    tokenizer,
+  });
 }
 
 module.exports = parser;

--- a/processor/parse/utils.js
+++ b/processor/parse/utils.js
@@ -5,7 +5,7 @@ function insertTokenizerBefore({ name, before, tokenizer, type = 'block' }) {
 
   const index = methods.indexOf(before);
   if (index === -1) {
-    throw new Error(`The '${before}' tokenizer doesn't exist!`);
+    throw new Error(`The '${before}' tokenizer does not exist!`);
   }
 
   tokenizers[name] = tokenizer;

--- a/processor/parse/utils.js
+++ b/processor/parse/utils.js
@@ -1,0 +1,21 @@
+function insertTokenizerBefore({ name, before, tokenizer, type = 'block' }) {
+  const { Parser } = this;
+  const tokenizers = Parser.prototype[`${type}Tokenizers`];
+  const methods = Parser.prototype[`${type}Methods`];
+
+  const index = methods.indexOf(before);
+  if (index === -1) {
+    throw new Error(`The '${before}' tokenizer doesn't exist!`);
+  }
+
+  tokenizers[name] = tokenizer;
+  methods.splice(index, 0, name);
+}
+
+export function insertBlockTokenizerBefore(args) {
+  insertTokenizerBefore.call(this, args);
+}
+
+export function insertInlineTokenizerBefore(args) {
+  return insertTokenizerBefore.call(this, { ...args, type: 'inline' });
+}

--- a/processor/parse/variable-parser.js
+++ b/processor/parse/variable-parser.js
@@ -1,5 +1,7 @@
 const { VARIABLE_REGEXP } = require('@readme/variable');
 
+const { insertInlineTokenizerBefore } = require('./utils');
+
 function tokenizeVariable(eat, value, silent) {
   // Modifies the regular expression to match from
   // the start of the line
@@ -42,13 +44,11 @@ function locate(value, fromIndex) {
 tokenizeVariable.locator = locate;
 
 function parser() {
-  const { Parser } = this;
-  const tokenizers = Parser.prototype.inlineTokenizers;
-  const methods = Parser.prototype.inlineMethods;
-
-  tokenizers.variable = tokenizeVariable;
-
-  methods.splice(methods.indexOf('text'), 0, 'variable');
+  insertInlineTokenizerBefore.call(this, {
+    name: 'variable',
+    before: 'text',
+    tokenizer: tokenizeVariable,
+  });
 }
 
 module.exports = parser;


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

Fixes a very specific edge case with our compact headings:

```
##Heading
---
```

Should get render as:
```
<h2>Heading</h2>
<hr>
```

But would get render as:

```
<h2>##Heading</h2>
```

Also, to try and prevent this, does a little error checking when configuring the tokenizers.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
