### PR TITLE
feat: adds new transformer for inline code nodes inside table cells

### DIFF
--- a/__tests__/transformers/__snapshots__/table-cell-inline-code.test.js.snap
+++ b/__tests__/transformers/__snapshots__/table-cell-inline-code.test.js.snap
@@ -4,65 +4,63 @@ exports[`tableCellInlineCode preserves escaped pipe chars inside text table cell
 Object {
   "children": Array [
     Object {
-      "align": Array [
-        "left",
-        "left",
-      ],
+      "type": "text",
+      "value": "
+
+
+
+
+
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "children": Array [
             Object {
               "children": Array [
                 Object {
-                  "type": "text",
-                  "value": "these ",
+                  "children": Array [
+                    Object {
+                      "type": "text",
+                      "value": "these | stay | escaped | inside | a single cell",
+                    },
+                  ],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "th",
+                  "type": "element",
                 },
                 Object {
-                  "type": "escape",
-                  "value": "|",
-                },
-                Object {
-                  "type": "text",
-                  "value": " stay ",
-                },
-                Object {
-                  "type": "escape",
-                  "value": "|",
-                },
-                Object {
-                  "type": "text",
-                  "value": " escaped ",
-                },
-                Object {
-                  "type": "escape",
-                  "value": "|",
-                },
-                Object {
-                  "type": "text",
-                  "value": " inside ",
-                },
-                Object {
-                  "type": "escape",
-                  "value": "|",
-                },
-                Object {
-                  "type": "text",
-                  "value": " a single cell",
+                  "children": Array [],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "th",
+                  "type": "element",
                 },
               ],
-              "type": "tableCell",
-            },
-            Object {
-              "children": Array [],
-              "type": "tableCell",
+              "properties": Object {},
+              "tagName": "tr",
+              "type": "element",
             },
           ],
-          "type": "tableRow",
+          "properties": Object {},
+          "tagName": "thead",
+          "type": "element",
+          "value": "these | stay | escaped | inside | a single cell",
         },
       ],
-      "type": "table",
+      "properties": Object {},
+      "tagName": "table",
+      "type": "element",
     },
   ],
+  "data": Object {
+    "quirksMode": false,
+  },
   "type": "root",
 }
 `;
@@ -71,83 +69,68 @@ exports[`tableCellInlineCode splits table cells when inline code contains "unesc
 Object {
   "children": Array [
     Object {
-      "align": Array [
-        "left",
-        "left",
-      ],
+      "type": "text",
+      "value": "
+
+
+
+
+
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "children": Array [
             Object {
               "children": Array [
                 Object {
-                  "type": "text",
-                  "value": "\`this",
+                  "children": Array [
+                    Object {
+                      "type": "text",
+                      "value": "\`this",
+                    },
+                  ],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "th",
+                  "type": "element",
                 },
-              ],
-              "type": "tableCell",
-            },
-            Object {
-              "children": Array [
                 Object {
-                  "type": "text",
-                  "value": "splits",
+                  "children": Array [
+                    Object {
+                      "type": "text",
+                      "value": "splits",
+                    },
+                  ],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "th",
+                  "type": "element",
                 },
               ],
-              "type": "tableCell",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "type": "text",
-                  "value": "up",
-                },
-              ],
-              "type": "tableCell",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "type": "text",
-                  "value": "to",
-                },
-              ],
-              "type": "tableCell",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "type": "text",
-                  "value": "more",
-                },
-              ],
-              "type": "tableCell",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "type": "text",
-                  "value": "cells\`",
-                },
-              ],
-              "type": "tableCell",
-            },
-            Object {
-              "children": Array [
-                Object {
-                  "type": "text",
-                  "value": "two",
-                },
-              ],
-              "type": "tableCell",
+              "properties": Object {},
+              "tagName": "tr",
+              "type": "element",
             },
           ],
-          "type": "tableRow",
+          "properties": Object {},
+          "tagName": "thead",
+          "type": "element",
+          "value": "\`this splits",
         },
       ],
-      "type": "table",
+      "properties": Object {},
+      "tagName": "table",
+      "type": "element",
     },
   ],
+  "data": Object {
+    "quirksMode": false,
+  },
   "type": "root",
 }
 `;
@@ -156,38 +139,75 @@ exports[`tableCellInlineCode unescapes escaped pipe chars inside inline code wit
 Object {
   "children": Array [
     Object {
-      "align": Array [
-        "left",
-        "left",
-      ],
+      "type": "text",
+      "value": "
+
+
+
+
+
+
+",
+    },
+    Object {
       "children": Array [
         Object {
           "children": Array [
             Object {
               "children": Array [
                 Object {
-                  "type": "inlineCode",
-                  "value": "one | two | three | four",
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "text",
+                          "value": "one | two | three | four",
+                        },
+                      ],
+                      "properties": Object {},
+                      "tagName": "code",
+                      "type": "element",
+                    },
+                  ],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "th",
+                  "type": "element",
                 },
-              ],
-              "type": "tableCell",
-            },
-            Object {
-              "children": Array [
                 Object {
-                  "type": "text",
-                  "value": "two",
+                  "children": Array [
+                    Object {
+                      "type": "text",
+                      "value": "two",
+                    },
+                  ],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "th",
+                  "type": "element",
                 },
               ],
-              "type": "tableCell",
+              "properties": Object {},
+              "tagName": "tr",
+              "type": "element",
             },
           ],
-          "type": "tableRow",
+          "properties": Object {},
+          "tagName": "thead",
+          "type": "element",
+          "value": "one | two | three | four two",
         },
       ],
-      "type": "table",
+      "properties": Object {},
+      "tagName": "table",
+      "type": "element",
     },
   ],
+  "data": Object {
+    "quirksMode": false,
+  },
   "type": "root",
 }
 `;

--- a/__tests__/transformers/__snapshots__/table-cell-inline-code.test.js.snap
+++ b/__tests__/transformers/__snapshots__/table-cell-inline-code.test.js.snap
@@ -147,6 +147,120 @@ Object {
 
 
 
+
+
+
+
+
+
+",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "th",
+                  "type": "element",
+                },
+                Object {
+                  "children": Array [],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "th",
+                  "type": "element",
+                },
+              ],
+              "properties": Object {},
+              "tagName": "tr",
+              "type": "element",
+            },
+          ],
+          "properties": Object {},
+          "tagName": "thead",
+          "type": "element",
+          "value": "",
+        },
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "children": Array [
+                    Object {
+                      "children": Array [
+                        Object {
+                          "type": "text",
+                          "value": "one | two | three | four",
+                        },
+                      ],
+                      "properties": Object {},
+                      "tagName": "code",
+                      "type": "element",
+                    },
+                  ],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "td",
+                  "type": "element",
+                },
+                Object {
+                  "children": Array [
+                    Object {
+                      "type": "text",
+                      "value": "two",
+                    },
+                  ],
+                  "properties": Object {
+                    "align": "left",
+                  },
+                  "tagName": "td",
+                  "type": "element",
+                },
+              ],
+              "properties": Object {},
+              "tagName": "tr",
+              "type": "element",
+            },
+          ],
+          "properties": Object {},
+          "tagName": "tbody",
+          "type": "element",
+          "value": "one | two | three | four two",
+        },
+      ],
+      "properties": Object {},
+      "tagName": "table",
+      "type": "element",
+    },
+  ],
+  "data": Object {
+    "quirksMode": false,
+  },
+  "type": "root",
+}
+`;
+
+exports[`tableCellInlineCode unescapes escaped pipe chars inside inline code within table headers 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "type": "text",
+      "value": "
+
+
+
+
+
+
 ",
     },
     Object {

--- a/__tests__/transformers/__snapshots__/table-cell-inline-code.test.js.snap
+++ b/__tests__/transformers/__snapshots__/table-cell-inline-code.test.js.snap
@@ -1,0 +1,193 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tableCellInlineCode preserves escaped pipe chars inside text table cells 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "align": Array [
+        "left",
+        "left",
+      ],
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "these ",
+                },
+                Object {
+                  "type": "escape",
+                  "value": "|",
+                },
+                Object {
+                  "type": "text",
+                  "value": " stay ",
+                },
+                Object {
+                  "type": "escape",
+                  "value": "|",
+                },
+                Object {
+                  "type": "text",
+                  "value": " escaped ",
+                },
+                Object {
+                  "type": "escape",
+                  "value": "|",
+                },
+                Object {
+                  "type": "text",
+                  "value": " inside ",
+                },
+                Object {
+                  "type": "escape",
+                  "value": "|",
+                },
+                Object {
+                  "type": "text",
+                  "value": " a single cell",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [],
+              "type": "tableCell",
+            },
+          ],
+          "type": "tableRow",
+        },
+      ],
+      "type": "table",
+    },
+  ],
+  "type": "root",
+}
+`;
+
+exports[`tableCellInlineCode splits table cells when inline code contains "unescaped" pipe chars 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "align": Array [
+        "left",
+        "left",
+      ],
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "\`this",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "splits",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "up",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "to",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "more",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "cells\`",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "two",
+                },
+              ],
+              "type": "tableCell",
+            },
+          ],
+          "type": "tableRow",
+        },
+      ],
+      "type": "table",
+    },
+  ],
+  "type": "root",
+}
+`;
+
+exports[`tableCellInlineCode unescapes escaped pipe chars inside inline code within table cells 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "align": Array [
+        "left",
+        "left",
+      ],
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "children": Array [
+                Object {
+                  "type": "inlineCode",
+                  "value": "one | two | three | four",
+                },
+              ],
+              "type": "tableCell",
+            },
+            Object {
+              "children": Array [
+                Object {
+                  "type": "text",
+                  "value": "two",
+                },
+              ],
+              "type": "tableCell",
+            },
+          ],
+          "type": "tableRow",
+        },
+      ],
+      "type": "table",
+    },
+  ],
+  "type": "root",
+}
+`;

--- a/__tests__/transformers/table-cell-inline-code.test.js
+++ b/__tests__/transformers/table-cell-inline-code.test.js
@@ -1,33 +1,47 @@
-import { mdast } from '../../index';
+import { hast, md, mdast } from '../../index';
 
 describe('tableCellInlineCode', () => {
   it('unescapes escaped pipe chars inside inline code within table cells', () => {
-    const md = `
+    const doc = `
 | \`one \\| two \\| three \\| four\` | two |
 | :- | :- |
 `;
 
-    const tree = mdast(md);
+    const tree = hast(doc);
     expect(tree).toMatchSnapshot();
   });
 
   it('preserves escaped pipe chars inside text table cells', () => {
-    const md = `
+    const doc = `
 | these \\| stay \\| escaped \\| inside \\| a single cell | |
 | :- | :- |
 `;
 
-    const tree = mdast(md);
+    const tree = hast(doc);
     expect(tree).toMatchSnapshot();
   });
 
   it('splits table cells when inline code contains "unescaped" pipe chars', () => {
-    const md = `
+    const doc = `
 | \`this | splits | up | to | more | cells\` | two |
 | :- | :- |
 `;
 
-    const tree = mdast(md);
+    const tree = hast(doc);
     expect(tree).toMatchSnapshot();
+  });
+
+  it('preserves the escaped pipe character when re-serializing from mdast', () => {
+    const doc = `
+| \`one \\| two \\| three \\| four\` | two |
+| :- | :- |
+`;
+
+    const tree = mdast(doc);
+    expect(md(tree)).toMatchInlineSnapshot(`
+      "| \`one \\\\| two \\\\| three \\\\| four\` | two |
+      | :---------------------------- | :-- |
+      "
+    `);
   });
 });

--- a/__tests__/transformers/table-cell-inline-code.test.js
+++ b/__tests__/transformers/table-cell-inline-code.test.js
@@ -1,0 +1,33 @@
+import { mdast } from '../../index';
+
+describe('tableCellInlineCode', () => {
+  it('unescapes escaped pipe chars inside inline code within table cells', () => {
+    const md = `
+| \`one \\| two \\| three \\| four\` | two |
+| :- | :- |
+`;
+
+    const tree = mdast(md);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('preserves escaped pipe chars inside text table cells', () => {
+    const md = `
+| these \\| stay \\| escaped \\| inside \\| a single cell | |
+| :- | :- |
+`;
+
+    const tree = mdast(md);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('splits table cells when inline code contains "unescaped" pipe chars', () => {
+    const md = `
+| \`this | splits | up | to | more | cells\` | two |
+| :- | :- |
+`;
+
+    const tree = mdast(md);
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/__tests__/transformers/table-cell-inline-code.test.js
+++ b/__tests__/transformers/table-cell-inline-code.test.js
@@ -1,10 +1,21 @@
 import { hast, md, mdast } from '../../index';
 
 describe('tableCellInlineCode', () => {
-  it('unescapes escaped pipe chars inside inline code within table cells', () => {
+  it('unescapes escaped pipe chars inside inline code within table headers', () => {
     const doc = `
 | \`one \\| two \\| three \\| four\` | two |
 | :- | :- |
+`;
+
+    const tree = hast(doc);
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('unescapes escaped pipe chars inside inline code within table cells', () => {
+    const doc = `
+|    |    |
+| :- | :- |
+| \`one \\| two \\| three \\| four\` | two |
 `;
 
     const tree = hast(doc);

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const { icons: calloutIcons } = require('./processor/parse/flavored/callout');
 const toPlainText = require('./processor/plugin/plain-text');
 const sectionAnchorId = require('./processor/plugin/section-anchor-id');
 const tableFlattening = require('./processor/plugin/table-flattening');
-const transformers = Object.values(require('./processor/transform'));
+const { remarkTransformers, rehypeTransformers } = require('./processor/transform');
 const createSchema = require('./sanitize.schema');
 
 const {
@@ -100,7 +100,7 @@ export function processor(opts = {}) {
     .data('alwaysThrow', opts.alwaysThrow)
     .use(!opts.correctnewlines ? remarkBreaks : () => {})
     .use(CustomParsers.map(parser => parser.sanitize?.(sanitize) || parser))
-    .use(transformers)
+    .use(...remarkTransformers)
     .use(remarkSlug)
     .use(remarkDisableTokenizers, opts.disableTokenizers);
 }
@@ -130,7 +130,11 @@ export function htmlProcessor(opts = {}) {
    * - sanitize and remove any disallowed attributes
    * - output the hast to a React vdom with our custom components
    */
-  return processor(opts).use(remarkRehype, { allowDangerousHtml: true }).use(rehypeRaw).use(rehypeSanitize, sanitize);
+  return processor(opts)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeSanitize, sanitize)
+    .use(...rehypeTransformers);
 }
 
 export function plain(text, opts = {}, components = {}) {

--- a/processor/plugin/table-flattening.js
+++ b/processor/plugin/table-flattening.js
@@ -26,11 +26,13 @@ function transformer(ast) {
               ...node.children[0],
               value: valuesToString(header),
             },
-            {
-              ...node.children[1],
-              value: valuesToString(body),
-            },
-          ],
+            body
+              ? {
+                  ...node.children[1],
+                  value: valuesToString(body),
+                }
+              : null,
+          ].filter(x => x),
         },
       ];
     }

--- a/processor/transform/index.js
+++ b/processor/transform/index.js
@@ -1,1 +1,2 @@
 export { default as singleCodeTabs } from './single-code-tabs';
+export { default as tableCellInlineCode } from './table-cell-inline-code';

--- a/processor/transform/index.js
+++ b/processor/transform/index.js
@@ -1,2 +1,5 @@
-export { default as singleCodeTabs } from './single-code-tabs';
-export { default as tableCellInlineCode } from './table-cell-inline-code';
+import singleCodeTabs from './single-code-tabs';
+import tableCellInlineCode from './table-cell-inline-code';
+
+export const remarkTransformers = [singleCodeTabs];
+export const rehypeTransformers = [tableCellInlineCode];

--- a/processor/transform/table-cell-inline-code.js
+++ b/processor/transform/table-cell-inline-code.js
@@ -1,18 +1,25 @@
-import { visit } from 'unist-util-visit';
+import { SKIP, visit } from 'unist-util-visit';
 
 const rxEscapedPipe = /\\\|/g;
 
 /**
- * Finds all inline code nodes within table cells and unescapes any escaped pipe
- * chars so that the editor outputs them without escape chars.
+ * HAST Transformer that finds all inline code nodes within table cells and
+ * unescapes any escaped pipe chars so that the editor outputs them without
+ * escape chars.
+ *
+ * This appears to be a bug with remark-parse < ~8
  */
 const tableCellInlineCode = () => tree => {
-  visit(tree, 'tableCell', tableCellNode => {
-    visit(tableCellNode, 'inlineCode', inlineCodeNode => {
-      if (rxEscapedPipe.test(inlineCodeNode.value)) {
-        inlineCodeNode.value = inlineCodeNode.value.replace(rxEscapedPipe, '|');
+  visit(tree, [{ tagName: 'th' }, { tagName: 'td' }], tableCellNode => {
+    visit(tableCellNode, { tagName: 'code' }, inlineCodeNode => {
+      const textNode = inlineCodeNode.children[0];
+
+      if (rxEscapedPipe.test(textNode.value)) {
+        textNode.value = textNode.value.replace(rxEscapedPipe, '|');
       }
     });
+
+    return SKIP;
   });
 };
 

--- a/processor/transform/table-cell-inline-code.js
+++ b/processor/transform/table-cell-inline-code.js
@@ -1,0 +1,19 @@
+import { visit } from 'unist-util-visit';
+
+const rxEscapedPipe = /\\\|/g;
+
+/**
+ * Finds all inline code nodes within table cells and unescapes any escaped pipe
+ * chars so that the editor outputs them without escape chars.
+ */
+const tableCellInlineCode = () => tree => {
+  visit(tree, 'tableCell', tableCellNode => {
+    visit(tableCellNode, 'inlineCode', inlineCodeNode => {
+      if (rxEscapedPipe.test(inlineCodeNode.value)) {
+        inlineCodeNode.value = inlineCodeNode.value.replace(rxEscapedPipe, '|');
+      }
+    });
+  });
+};
+
+export default tableCellInlineCode;


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-7646
:-------------------:|:----------:

## 🧰 Changes

This unescapes escaped pipe chars when rendering html. There appears to be a bug in remark or rehype where it displays the escaped pipe character in inline code spans within a table cell.

When using pipe characters in code spans within tables, you have to escape the pipe character, otherwise, it would result in additional table cells.

Consider the following markdown:

```
| td |
| -  |
| `echo \| cat` |
```

This would result in:

```
<table>
  <thead>
    <tr>
      <td><code>echo \| cat</code></td>
    </tr>
  </thead>
</table>
```

Which doesn't seem like what was intended.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
