### PR TITLE
fix: tables with invalid html

### DIFF
--- a/__tests__/flavored-parsers/tables.test.js
+++ b/__tests__/flavored-parsers/tables.test.js
@@ -1,4 +1,4 @@
-import { mdast } from '../../index';
+import { mdast, hast } from '../../index';
 
 describe('Parse magic block tables', () => {
   it('renders an table with missing cells', () => {
@@ -20,5 +20,19 @@ ${JSON.stringify(
     `;
 
     expect(mdast(text)).toMatchSnapshot();
+  });
+});
+
+describe('GFM style tables', () => {
+  it('renders a table with invalid html in code tags', () => {
+    const md = `
+| Alpha     | Beta                   |
+| :-------- | :--------------------- |
+| \`<valid>\` | <code><invalid></code> |
+`;
+
+    const tree = hast(md);
+
+    expect(tree.children[1].tagName).toBe('table');
   });
 });

--- a/processor/transform/table-cell-inline-code.js
+++ b/processor/transform/table-cell-inline-code.js
@@ -14,7 +14,7 @@ const tableCellInlineCode = () => tree => {
     visit(tableCellNode, { tagName: 'code' }, inlineCodeNode => {
       const textNode = inlineCodeNode.children[0];
 
-      if (rxEscapedPipe.test(textNode.value)) {
+      if (textNode && rxEscapedPipe.test(textNode.value)) {
         textNode.value = textNode.value.replace(rxEscapedPipe, '|');
       }
     });


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix CX-153 |
| :--------------------: | :--------: |

## 🧰 Changes

Fixes a case were having an empty (or invalid html) as children of a code tag crashed the process.

We have a custom plugin that escapes pipe characters (`|`) in code spans within tables, but it wasn't doing proper null checking.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
