### PR TITLE
fix: normalize root level magic blocks

### DIFF
--- a/__tests__/flavored-compilers/break.test.js
+++ b/__tests__/flavored-compilers/break.test.js
@@ -1,4 +1,4 @@
-import { mdast, md } from '../..';
+import { mdast, md } from '../../index';
 
 describe('break compiler', () => {
   it('uses two spaces with `correctnewlines: false`', () => {

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -26,6 +26,7 @@ test('it should have the proper utils exports', () => {
       spacedTable: true,
       paddedTable: true,
     },
+    normalize: true,
     reusableContent: {},
     safeMode: false,
     settings: { position: false },

--- a/__tests__/normalize.test.js
+++ b/__tests__/normalize.test.js
@@ -1,0 +1,38 @@
+import { mdast } from '../index';
+
+describe('normalize option', () => {
+  it('normalizes magic block newlines', () => {
+    const doc = `
+> blockquote
+>
+[block:image]
+{
+  "images": [
+    {
+      "image": [
+        "https://owlbertsio-resized.s3.amazonaws.com/This-Is-Fine.jpg.full.png",
+        "",
+        ""
+      ],
+      "align": "center"
+    }
+  ]
+}
+[/block]
+`;
+    const tree = mdast(doc);
+
+    expect(tree.children[1].type).toBe('image');
+  });
+
+  it('does not normalize nested magic blocks', () => {
+    const doc = `
+> blockquote
+>
+> [block:image]{ "images": [ { "image": [ "https://owlbertsio-resized.s3.amazonaws.com/This-Is-Fine.jpg.full.png", "", "" ], "align": "center" } ]}[/block]
+`;
+    const tree = mdast(doc, { normalize: false });
+
+    expect(tree.children[0].children[1].type).toBe('image');
+  });
+});

--- a/index.js
+++ b/index.js
@@ -65,6 +65,11 @@ export function setup(blocks, opts = {}) {
     Object.values(Components).forEach(Component => Component.sanitize && Component.sanitize(opts.sanitize));
   }
 
+  // normalize magic block linebreaks
+  if (opts.normalize && blocks) {
+    blocks = blocks.replace(/^\[block:/gm, '\n[block:').replace(/^\[\/block\]/gm, '[/block]\n');
+  }
+
   return [`${blocks}\n\n `, opts];
 }
 

--- a/options.js
+++ b/options.js
@@ -12,6 +12,7 @@ const options = {
     spacedTable: true,
     paddedTable: true,
   },
+  normalize: true,
   lazyImages: true,
   reusableContent: {},
   safeMode: false,


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

Only normalize magic blocks at the root level.

In a previous PR, I removed the normalize option because it breaks magic block inside container elements. This broke a lot of pages that have magic blocks directly following other blocks. ie:

```
> needs to be normalized
[block:foo]{}[/block]

<div>also needs to be normalized</div>
[block:foo]{}[/block]
```

The problem is with how blocks are parsed. They usually allow for continuations. For example, blockquotes allow for some following lines to not start with the `>`. As a result, the magic blocks in the above example don't get matched by the magic block tokenizer, but are rather read in as inline content. We'd probably have to update all the `remark` tokenizers to be aware of the magic block syntax.

The motivation behind this is ultimately to get magic blocks to work inside container elements: blockquotes, callouts, and lists. Prior to this set of changes, when nested magic blocks would get normalized, they'd break parsing. Consider the following:

```
> will get normalized
>
> [block:image]
> { ... }
> [/block]
```

This would get normalized into:

```
> will get normalized
>
>

[block:image]
> { ... }
> [/block]
```

1. The magic block is no longer a child of the blockquote
2. The magic block parser would blow up when it tried to parse it's contents as json

---

So in a previous PR, we're going to start saving magic blocks in containers on a single line, to get around the JSON parsing. And in this PR, we're going to normalize root level magic blocks to allow for legacy documents. Any magic blocks in containers in the wild are already broken. So this should be an improvement in that case.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
