### PR TITLE
refactor: reusable content syntax

### DIFF
--- a/__tests__/flavored-compilers/reusable-content.test.js
+++ b/__tests__/flavored-compilers/reusable-content.test.js
@@ -2,7 +2,7 @@ import { mdast, md } from '../../index';
 
 describe('reusable content compiler', () => {
   it('writes an undefined reusable content block back to markdown', () => {
-    const doc = '<RMReusableContent slug="undefined" />';
+    const doc = '<Undefined />';
     const tree = mdast(doc);
 
     expect(md(tree)).toMatch(doc);
@@ -10,9 +10,20 @@ describe('reusable content compiler', () => {
 
   it('writes a defined reusable content block back to markdown', () => {
     const reusableContent = {
-      defined: '# Whoa',
+      Defined: '# Whoa',
     };
-    const doc = '<RMReusableContent slug="defined" />';
+    const doc = '<Defined />';
+    const tree = mdast(doc, { reusableContent });
+
+    expect(tree.children[0].children[0].type).toBe('heading');
+    expect(md(tree)).toMatch(doc);
+  });
+
+  it('writes a defined reusable content block with multiple words back to markdown', () => {
+    const reusableContent = {
+      MyCustomComponent: '# Whoa',
+    };
+    const doc = '<MyCustomComponent />';
     const tree = mdast(doc, { reusableContent });
 
     expect(tree.children[0].children[0].type).toBe('heading');

--- a/__tests__/transformers/__snapshots__/reusable-content.test.js.snap
+++ b/__tests__/transformers/__snapshots__/reusable-content.test.js.snap
@@ -36,7 +36,48 @@ Object {
       "type": "paragraph",
     },
   ],
-  "slug": "test",
+  "tag": "Test",
+  "type": "reusable-content",
+}
+`;
+
+exports[`reusable content transfomer should replace a reusable content block with multiple words if the block is provided 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "children": Array [
+        Object {
+          "type": "text",
+          "value": "Test",
+        },
+      ],
+      "data": Object {
+        "hProperties": Object {
+          "id": "test",
+        },
+        "id": "test",
+      },
+      "depth": 1,
+      "type": "heading",
+    },
+    Object {
+      "children": Array [
+        Object {
+          "children": Array [
+            Object {
+              "type": "text",
+              "value": "link",
+            },
+          ],
+          "title": null,
+          "type": "link",
+          "url": "http://example.com",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "tag": "MyCustomComponent",
   "type": "reusable-content",
 }
 `;

--- a/__tests__/transformers/reusable-content.test.js
+++ b/__tests__/transformers/reusable-content.test.js
@@ -3,7 +3,7 @@ import { mdast } from '../../index';
 describe('reusable content transfomer', () => {
   it('should replace a reusable content block if the block is provided', () => {
     const reusableContent = {
-      test: `
+      Test: `
 # Test
 
 [link](http://example.com)
@@ -12,7 +12,7 @@ describe('reusable content transfomer', () => {
     const md = `
 Before
 
-<RMReusableContent slug="test" />
+<Test />
 
 After
     `;
@@ -24,8 +24,23 @@ After
     expect(tree.children[2].children[0].value).toBe('After');
   });
 
+  it('should replace a reusable content block with multiple words if the block is provided', () => {
+    const reusableContent = {
+      MyCustomComponent: `
+# Test
+
+[link](http://example.com)
+    `,
+    };
+    const md = '<MyCustomComponent />';
+
+    const tree = mdast(md, { reusableContent });
+
+    expect(tree.children[0]).toMatchSnapshot();
+  });
+
   it('should insert an empty node if the reusable content block is not defined', () => {
-    const md = '<RMReusableContent slug="not-defined" />';
+    const md = '<NotDefined />';
     const tree = mdast(md);
 
     expect(tree.children[0].type).toBe('reusable-content');
@@ -34,9 +49,9 @@ After
 
   it('does not expand reusable content recursively', () => {
     const reusableContent = {
-      test: '<RMReusableContent slug="test" />',
+      Test: '<Test />',
     };
-    const md = '<RMReusableContent slug="test" />';
+    const md = '<Test />';
     const tree = mdast(md, { reusableContent });
 
     expect(tree.children[0].children[0].type).toBe('reusable-content');

--- a/processor/compile/reusable-content.js
+++ b/processor/compile/reusable-content.js
@@ -1,8 +1,8 @@
-import { type, tag } from '../transform/reusable-content';
+import { type } from '../transform/reusable-content';
 
 export default function ReusableContentCompiler() {
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
 
-  visitors[type] = node => `<${tag} slug="${node.slug}" />`;
+  visitors[type] = node => `<${node.tag} />`;
 }

--- a/processor/transform/reusable-content.js
+++ b/processor/transform/reusable-content.js
@@ -1,9 +1,8 @@
 import { visit } from 'unist-util-visit';
 
 export const type = 'reusable-content';
-export const tag = 'RMReusableContent';
 
-const regexp = new RegExp(`^\\s*<${tag} slug="(?<slug>.*)" />\\s*$`);
+const regexp = /^\s*<(?<tag>[A-Z]\S+)\s*\/>\s*$/;
 
 const reusableContentTransformer = function () {
   const reusableContent = this.data('reusableContent');
@@ -11,13 +10,14 @@ const reusableContentTransformer = function () {
   return tree => {
     visit(tree, 'html', (node, index, parent) => {
       const result = regexp.exec(node.value);
-      if (!result || !result.groups.slug) return;
+      if (!result || !result.groups.tag) return;
 
-      const { slug } = result.groups;
+      const { tag } = result.groups;
+
       const block = {
         type,
-        slug,
-        children: slug in reusableContent ? reusableContent[slug] : [],
+        tag,
+        children: tag in reusableContent ? reusableContent[tag] : [],
       };
 
       parent.children[index] = block;


### PR DESCRIPTION
| [![PR App][icn]][demo] | Part of RM-8041 |
| :--------------------: | :-------------: |

## 🧰 Changes

Updates the reusable content syntax to be just the tag name.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
