### PR TITLE
chore: remove reference-link

### DIFF
--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -10,7 +10,7 @@ exports[`anchors 1`] = `
 "<p><a href=\\"http://example.com\\" target=\\"\\" title=\\"\\">link</a><br>
 <a href=\\"\\" target=\\"\\" title=\\"\\">xss</a><br>
 <a href=\\"/docs/slug\\" target=\\"\\" title=\\"\\" class=\\"doc-link\\" data-sidebar=\\"slug\\">doc</a><br>
-<a href=\\"/reference-link/slug\\" target=\\"\\" title=\\"\\">ref</a><br>
+<a href=\\"/reference/slug\\" target=\\"\\" title=\\"\\">ref</a><br>
 <a href=\\"/changelog/slug\\" target=\\"\\" title=\\"\\">blog</a><br>
 <a href=\\"/changelog/slug\\" target=\\"\\" title=\\"\\">changelog</a><br>
 <a href=\\"/page/slug\\" target=\\"\\" title=\\"\\">page</a></p>"
@@ -24,7 +24,7 @@ exports[`anchors with baseUrl 1`] = `
 &lt;a href=\\"page:slug\\"&gt;page&lt;/a&gt;&lt;/p&gt;"
 `;
 
-exports[`anchors with baseUrl and special characters in url hash 1`] = `"<p><a href=\\"/reference-link/slug#%E6%95%B4\\" target=\\"\\" title=\\"\\">ref</a></p>"`;
+exports[`anchors with baseUrl and special characters in url hash 1`] = `"<p><a href=\\"/reference/slug#%E6%95%B4\\" target=\\"\\" title=\\"\\">ref</a></p>"`;
 
 exports[`check list items 1`] = `
 "<ul class=\\"contains-task-list\\">

--- a/components/Anchor.jsx
+++ b/components/Anchor.jsx
@@ -18,7 +18,7 @@ function getHref(href, baseUrl) {
 
   const ref = path.match(/^ref:([-_a-zA-Z0-9#]*)$/);
   if (ref) {
-    return `${base}/reference-link/${ref[1]}${hashStr}`;
+    return `${base}/reference/${ref[1]}${hashStr}`;
   }
 
   // we need to perform two matches for changelogs in case


### PR DESCRIPTION
We don't need /reference-link in hub3 since everything is under /reference, so I updated the links generated to just be that instead since hub2 is dead!