### PR TITLE
fix: insert newlines before images

### DIFF
--- a/__tests__/flavored-compilers/magic-blocks.test.js
+++ b/__tests__/flavored-compilers/magic-blocks.test.js
@@ -39,6 +39,7 @@ describe('Compile Magic Blocks', () => {
     expect(compiled).toMatchInlineSnapshot(`
       "> 👍 It works!
       > 
+      > 
       > [block:image]{\\"images\\":[{\\"image\\":[\\"https://owlbertsio-resized.s3.amazonaws.com/This-Is-Fine.jpg.full.png\\",\\"\\",\\"\\"],\\"align\\":\\"center\\"}]}[/block]
       "
     `);

--- a/processor/compile/magic-block.js
+++ b/processor/compile/magic-block.js
@@ -1,7 +1,7 @@
 const magicBlock = (type, data, parent) => {
   return parent.type === 'root'
     ? `[block:${type}]\n${JSON.stringify(data, null, 2)}\n[/block]\n`
-    : `[block:${type}]${JSON.stringify(data)}[/block]`;
+    : `\n[block:${type}]${JSON.stringify(data)}[/block]`;
 };
 
 export default magicBlock;


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix CX-572 |
| :--------------------: | :--------: |

## 🧰 Changes

Fixes a case where serializing an image in a list fails.

Consider the following markdown:

```
- list item

  [block:image]{"images":[{"image":["https://files.readme.io/b1fe6ca-fdfd5f9a-50b5-4188-889c-8b34dfb8697b.gif","",""],"align":"center"}]}[/block]
```

This is equivalent to the following mdast:

```
{
  "mdast": {
    "type": "root",
    "children": [
      {
        "type": "list",
        "ordered": false,
        "spread": false,
        "children": [
          {
            "type": "list-item",
            "spread": false,
            "children": [
              {
                "type": "paragraph",
                "children": [
                  {
                    "type": "text",
                    "value": "list item"
                  }
                ]
              },
              {
                "align": "center",
                "alt": "",
                "title": "",
                "type": "image",
                "url": "https://files.readme.io/b1fe6ca-fdfd5f9a-50b5-4188-889c-8b34dfb8697b.gif",
                "data": {
                  "hProperties": {
                    "align": "center"
                  }
                }
              }
            ]
          }
        ]
      }
    ]
  }
}
```

But this gets serialized as:

```
- list item
  [block:image]{"images":[{"image":["https://files.readme.io/b1fe6ca-fdfd5f9a-50b5-4188-889c-8b34dfb8697b.gif","",""],"align":"center"}]}[/block]
```

Which **does not** re-parse as the same mdast. :sad-penguin:. This PR adds an extra newline in front of **all** inlined magic blocks. I think this is generally safe, it looks like this works for lists and blockquotes.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
