### PR TITLE
feat: allow disabling reusable content

### DIFF
--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -16,6 +16,7 @@ test('it should have the proper utils exports', () => {
     compatibilityMode: false,
     copyButtons: true,
     correctnewlines: false,
+    disableReusableContent: false,
     lazyImages: true,
     markdownOptions: {
       fences: true,

--- a/__tests__/transformers/reusable-content.test.js
+++ b/__tests__/transformers/reusable-content.test.js
@@ -57,4 +57,15 @@ After
     expect(tree.children[0].children[0].type).toBe('reusable-content');
     expect(tree.children[0].children[0].children).toStrictEqual([]);
   });
+
+  it('does not replace reusable content if it is disabled', () => {
+    const reusableContent = {
+      Test: '<Test />',
+    };
+    const md = '<Test />';
+    const tree = mdast(md, { disableReusableContent: true, reusableContent });
+
+    expect(tree.children[0].type).toBe('html');
+    expect(tree.children[0].value).toBe('<Test />');
+  });
 });

--- a/index.js
+++ b/index.js
@@ -90,6 +90,8 @@ export const utils = {
  * blocks recursively.
  */
 const parseReusableContent = ({ reusableContent, ...opts }) => {
+  if (opts.disableReusableContent) return [null, opts];
+
   const parsedReusableContent = Object.entries(reusableContent).reduce((memo, [name, content]) => {
     // eslint-disable-next-line no-use-before-define
     memo[name] = mdast(content, opts).children;

--- a/options.js
+++ b/options.js
@@ -3,6 +3,7 @@ const options = {
   compatibilityMode: false,
   copyButtons: true,
   correctnewlines: false,
+  disableReusableContent: false,
   markdownOptions: {
     fences: true,
     commonmark: true,

--- a/processor/transform/reusable-content.js
+++ b/processor/transform/reusable-content.js
@@ -6,6 +6,7 @@ const regexp = /^\s*<(?<tag>[A-Z]\S+)\s*\/>\s*$/;
 
 const reusableContentTransformer = function () {
   const reusableContent = this.data('reusableContent');
+  if (!reusableContent) return () => undefined;
 
   return tree => {
     visit(tree, 'html', (node, index, parent) => {

--- a/scripts/perf-test.js
+++ b/scripts/perf-test.js
@@ -1,0 +1,56 @@
+const childProcess = require('child_process');
+const { Blob } = require('node:buffer');
+
+const rdmd = require('..');
+
+const mdBuffer = childProcess.execSync('cat ./docs/*', { encoding: 'utf8' });
+
+const createDoc = bytes => {
+  let doc = '';
+
+  while (new Blob([doc]).size < bytes) {
+    const start = Math.ceil(Math.random() * mdBuffer.length);
+    doc += mdBuffer.slice(start, start + bytes);
+  }
+
+  return doc;
+};
+
+// https://stackoverflow.com/a/14919494
+function humanFileSize(bytes, si = false, dp = 1) {
+  const thresh = si ? 1000 : 1024;
+
+  if (Math.abs(bytes) < thresh) {
+    return `${bytes} B`;
+  }
+
+  const units = si
+    ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+    : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+  let u = -1;
+  const r = 10 ** dp;
+
+  do {
+    // eslint-disable-next-line no-param-reassign
+    bytes /= thresh;
+    // eslint-disable-next-line no-plusplus
+    ++u;
+  } while (Math.round(Math.abs(bytes) * r) / r >= thresh && u < units.length - 1);
+
+  return `${bytes.toFixed(dp)} ${units[u]}`;
+}
+
+const max = 8;
+
+console.log('n : string size : duration');
+
+new Array(max).fill(0).forEach((_, i) => {
+  const bytes = 10 ** i;
+  const doc = createDoc(bytes);
+  const then = Date.now();
+
+  rdmd.mdast(doc);
+  const duration = Date.now() - then;
+
+  console.log(`${i} : ${humanFileSize(new Blob([doc]).size)} : ${duration / 1000} s`);
+});


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-8364 |
| :--------------------: | :---------: |

## 🧰 Changes

Add an option to **not** parse reusable content. Useful for nested editors.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
