### PR TITLE
fix: add conditional to reusable content transformer

### DIFF
--- a/__tests__/flavored-compilers/reusable-content.test.js
+++ b/__tests__/flavored-compilers/reusable-content.test.js
@@ -30,13 +30,13 @@ describe('reusable content compiler', () => {
     expect(md(tree)).toMatch(doc);
   });
 
-  describe('writeTags = false', () => {
+  describe('serialize = false', () => {
     it('writes a reusable content block as content', () => {
       const tags = {
         Defined: '# Whoa',
       };
       const doc = '<Defined />';
-      const string = md(doc, { reusableContent: { tags, writeTags: false } });
+      const string = md(doc, { reusableContent: { tags, serialize: false } });
 
       expect(string).toBe('# Whoa\n');
     });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -30,7 +30,8 @@ test('it should have the proper utils exports', () => {
     reusableContent: {
       disabled: false,
       tags: {},
-      writeTags: true,
+      serialize: true,
+      wrap: true,
     },
     safeMode: false,
     settings: { position: true },

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ export const utils = {
  * blocks recursively.
  */
 const parseReusableContent = ({ reusableContent, ...opts }) => {
-  if (reusableContent.disabled) return [{ disabled: true, writeTags: true }, opts];
+  if (reusableContent.disabled) return [{ disabled: true, serialize: true }, opts];
 
   const tags = Object.entries(reusableContent.tags).reduce((memo, [name, content]) => {
     // eslint-disable-next-line no-use-before-define

--- a/options.js
+++ b/options.js
@@ -17,7 +17,8 @@ const options = {
   reusableContent: {
     tags: {},
     disabled: false,
-    writeTags: true,
+    serialize: true,
+    wrap: true,
   },
   safeMode: false,
   settings: {

--- a/processor/compile/reusable-content.js
+++ b/processor/compile/reusable-content.js
@@ -1,11 +1,11 @@
 import { type } from '../transform/reusable-content';
 
 export default function ReusableContentCompiler() {
-  const { writeTags = true } = this.data('reusableContent') || {};
+  const { serialize = true } = this.data('reusableContent') || {};
   const { Compiler } = this;
   const { visitors } = Compiler.prototype;
 
   visitors[type] = function (node) {
-    return writeTags ? `<${node.tag} />` : this.block(node);
+    return serialize ? `<${node.tag} />` : this.block(node);
   };
 }

--- a/processor/transform/reusable-content.js
+++ b/processor/transform/reusable-content.js
@@ -5,7 +5,7 @@ export const type = 'reusable-content';
 const regexp = /^\s*<(?<tag>[A-Z]\S+)\s*\/>\s*$/;
 
 const reusableContentTransformer = function () {
-  const { tags, disabled, writeTag = true } = this.data('reusableContent');
+  const { tags, disabled, writeTags = true } = this.data('reusableContent');
   if (disabled) return () => undefined;
 
   return tree => {
@@ -14,7 +14,7 @@ const reusableContentTransformer = function () {
       if (!result || !result.groups.tag) return;
       const { tag } = result.groups;
 
-      if (writeTag) {
+      if (writeTags) {
         parent.children[index] = { type, tag, children: tag in tags ? tags[tag] : [] };
       } else {
         parent.children[index] = tag in tags ? [...tags[tag]].pop() : {};

--- a/processor/transform/reusable-content.js
+++ b/processor/transform/reusable-content.js
@@ -5,7 +5,7 @@ export const type = 'reusable-content';
 const regexp = /^\s*<(?<tag>[A-Z]\S+)\s*\/>\s*$/;
 
 const reusableContentTransformer = function () {
-  const { tags, disabled } = this.data('reusableContent');
+  const { tags, disabled, writeTag = true } = this.data('reusableContent');
   if (disabled) return () => undefined;
 
   return tree => {
@@ -14,9 +14,11 @@ const reusableContentTransformer = function () {
       if (!result || !result.groups.tag) return;
       const { tag } = result.groups;
 
-      const block = tag in tags ? [...tags[tag]].pop() : null;
-
-      parent.children[index] = block;
+      if (writeTag) {
+        parent.children[index] = { type, tag, children: tag in tags ? tags[tag] : [] };
+      } else {
+        parent.children[index] = tag in tags ? [...tags[tag]].pop() : {};
+      }
     });
 
     return tree;

--- a/processor/transform/reusable-content.js
+++ b/processor/transform/reusable-content.js
@@ -12,14 +12,9 @@ const reusableContentTransformer = function () {
     visit(tree, 'html', (node, index, parent) => {
       const result = regexp.exec(node.value);
       if (!result || !result.groups.tag) return;
-
       const { tag } = result.groups;
 
-      const block = {
-        type,
-        tag,
-        children: tag in tags ? tags[tag] : [],
-      };
+      const block = tag in tags ? [...tags[tag]].pop() : null;
 
       parent.children[index] = block;
     });

--- a/processor/transform/reusable-content.js
+++ b/processor/transform/reusable-content.js
@@ -5,7 +5,7 @@ export const type = 'reusable-content';
 const regexp = /^\s*<(?<tag>[A-Z]\S+)\s*\/>\s*$/;
 
 const reusableContentTransformer = function () {
-  const { tags, disabled, writeTags = true } = this.data('reusableContent');
+  const { tags, disabled, wrap = true } = this.data('reusableContent');
   if (disabled) return () => undefined;
 
   return tree => {
@@ -14,10 +14,10 @@ const reusableContentTransformer = function () {
       if (!result || !result.groups.tag) return;
       const { tag } = result.groups;
 
-      if (writeTags) {
+      if (wrap) {
         parent.children[index] = { type, tag, children: tag in tags ? tags[tag] : [] };
       } else {
-        parent.children[index] = tag in tags ? [...tags[tag]].pop() : {};
+        parent.children.splice(index, tags[tag].length, ...tags[tag]);
       }
     });
 


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-7812
:-------------------:|:----------:

## 🧰 Changes

A little more flexibility so reusable content can be passed as regular content (eg, for the TOC) 

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
