### PR TITLE
fix: include shrinkwrap in npm output

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-.babelrc
-.eslint*
-.jsinspectrc
-.prettier*
-__tests__/
-coverage/
-jest.config.js
-wepback.*.js

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "files": [
     "styles",
     "components",
-    "dist"
+    "dist",
+    "npm-shrinkwrap.json"
   ],
   "scripts": {
     "build": "webpack --mode production",


### PR DESCRIPTION
[![PR App][icn]][demo] | Follow up to https://github.com/readmeio/markdown/pull/836
:-------------------:|:----------:

## 🧰 Changes

This repo has [a `files` array definition in the `package.json`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#files) as well as a root-level `.npmignore`. The former mostly renders the latter useless, so I removed the latter. I also added the `npm-shrinkwrap.json` file to the `files` array so it will be properly published to the NPM registry.

## 🧬 QA & Testing

To test this, you can run `npm pack` and you'll see a list of files that will be published. Note how `npm-shrinkwrap.json` now properly shows up in that list:

![CleanShot 2024-03-11 at 09 07 38@2x](https://github.com/readmeio/markdown/assets/8854718/7fb856a4-754d-406a-bc04-77f52036bb65)


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
