### PR TITLE
refactor: rename react to compile

### DIFF
--- a/example/Doc.tsx
+++ b/example/Doc.tsx
@@ -17,7 +17,7 @@ const Doc = () => {
     safeMode: searchParams.has('safeMode'),
   };
 
-  const Content = mdx.run(String(mdx.react(doc, opts)));
+  const Content = mdx.run(String(mdx.compile(doc, opts)));
 
   return (
     <React.Fragment>

--- a/index.tsx
+++ b/index.tsx
@@ -41,7 +41,7 @@ export const reactProcessor = (opts = {}) => {
   return createProcessor({ remarkPlugins: [calloutTransformer], ...opts });
 };
 
-export const react = (text: string, opts = {}) => {
+export const compile = (text: string, opts = {}) => {
   try {
     const code = compileSync(text, {
       outputFormat: 'function-body',


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

Renaming `react` to `compile`

Doesn't make much sense to call it `react`.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
