### PR TITLE
fix: add css attribute selector for firefox

### DIFF
--- a/components/Image/style.scss
+++ b/components/Image/style.scss
@@ -40,6 +40,7 @@
 
     &[width='80%'],
     &[align='center'],
+    &[align='middle'],
     &[alt~='align-center'] {
       @extend %img-align-center;
     }


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-8544
:-------------------:|:----------:

## 🧰 Changes

We were determining whether `display: block` is applied to an image to center it based on the image has an `align` attribute with a value of `center`. The correct style doesn't get applied in Firefox since it uses `middle` in place of `center` for alignment values.

This PR just adds a CSS selector to target `align: middle` to make sure that images are aligned properly in Firefox as well.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
