### PR TITLE
fix: dont require newline

### DIFF
--- a/__tests__/flavored-parsers/__snapshots__/reusable-content.test.js.snap
+++ b/__tests__/flavored-parsers/__snapshots__/reusable-content.test.js.snap
@@ -225,9 +225,9 @@ Object {
   ],
   "position": Position {
     "end": Object {
-      "column": 1,
+      "column": 2,
       "line": 3,
-      "offset": 23,
+      "offset": 24,
     },
     "indent": Array [
       1,

--- a/__tests__/flavored-parsers/reusable-content.test.js
+++ b/__tests__/flavored-parsers/reusable-content.test.js
@@ -1,6 +1,23 @@
 import { mdast } from '../../index';
 
 describe('reusable content transfomer', () => {
+  it('parses camel cased content', () => {
+    const md = '<TestComponent />';
+    const tree = mdast(md);
+
+    expect(tree.children[0].type).toBe('reusable-content');
+    expect(tree.children[0].tag).toBe('TestComponent');
+  });
+
+  it('parses content in a container', () => {
+    const md = '> <TestComponent />';
+    const tree = mdast(md);
+
+    expect(tree.children[0].type).toBe('blockquote');
+    expect(tree.children[0].children[0].type).toBe('reusable-content');
+    expect(tree.children[0].children[0].tag).toBe('TestComponent');
+  });
+
   it('should replace a reusable content block if the block is provided', () => {
     const tags = {
       Test: `

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
       },
       "peerDependencies": {
         "@readme/variable": "^16.0.0",
-        "@tippyjs/react": "^4.2.6",
+        "@tippyjs/react": "^4.1.0",
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
       },
       "peerDependencies": {
         "@readme/variable": "^16.0.0",
-        "@tippyjs/react": "^4.1.0",
+        "@tippyjs/react": "^4.2.6",
         "react": "^16.14.0",
         "react-dom": "^16.14.0"
       }

--- a/processor/parse/reusable-content-parser.js
+++ b/processor/parse/reusable-content-parser.js
@@ -8,7 +8,7 @@ function tokenizeReusableContent(eat, value, silent) {
 
   // Modifies the regular expression to match from
   // the start of the line
-  const match = /^<(?<tag>[A-Z]\S+)\s*\/>\s*\n/.exec(value);
+  const match = /^<(?<tag>[A-Z]\S+)\s*\/>\s*/.exec(value);
 
   if (!match || !match.groups.tag) return false;
   const { tag } = match.groups;


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

A recent PR introduced a regression where we could no longer parse RC within container blocks.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
