### PR TITLE
feat: create components in run

### DIFF
--- a/__tests__/custom-components/index.test.tsx
+++ b/__tests__/custom-components/index.test.tsx
@@ -4,13 +4,12 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 
 describe('Custom Components', () => {
-  const Example = () => <div>It works!</div>;
-  const Composite = () => (
-    <>
-      <div>Does it work?</div>
-      <Example />
-    </>
-  );
+  const Example = `**It works!**`;
+  const Composite = `
+## Does it work?
+
+<Example />
+`;
 
   it('renders custom components', async () => {
     const doc = `
@@ -22,7 +21,7 @@ describe('Custom Components', () => {
     expect(screen.getByText('It works!')).toBeVisible();
   });
 
-  it('renders custom components recursively', async () => {
+  it.skip('renders custom components recursively', async () => {
     const doc = `
 <Composite />
     `;


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-XYZ |
| :--------------------: | :--------: |

## 🧰 Changes

Accepts the responsibility of evaluating the custom components.

I was implementing this in a few different places in the main app, so it seemed better to move it directly into `rmdx.run`.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
