### PR TITLE
feat: support legacy gemoji

### DIFF
--- a/__tests__/flavored-compilers/gemoji.test.js
+++ b/__tests__/flavored-compilers/gemoji.test.js
@@ -7,4 +7,11 @@ describe('gemoji compiler', () => {
 
     expect(md(tree)).toMatch(doc);
   });
+
+  it('writes legacy gemojis back to shortcodes', () => {
+    const doc = ':white-check-mark:';
+    const tree = mdast(doc);
+
+    expect(md(tree)).toMatch(doc.replaceAll(/-/g, '_'));
+  });
 });

--- a/__tests__/gemoji-parser.test.js
+++ b/__tests__/gemoji-parser.test.js
@@ -94,6 +94,32 @@ test('should output an <i> for a font awesome icon', () => {
   );
 });
 
+test('should support legacy dashes', () => {
+  const emoji = 'white-check-mark';
+  const markdown = `This is a gemoji :${emoji}:.`;
+  const ast = {
+    type: 'root',
+    children: [
+      {
+        type: 'paragraph',
+        children: [
+          { type: 'text', value: 'This is a gemoji ' },
+          {
+            type: 'gemoji',
+            value: '✅',
+            name: emoji,
+          },
+          { type: 'text', value: '.' },
+        ],
+      },
+    ],
+  };
+
+  expect(unified().use(remarkParse).use(parser).data('settings', { position: false }).parse(markdown)).toStrictEqual(
+    ast,
+  );
+});
+
 test('should output nothing for unknown emojis', () => {
   const emoji = 'unknown-emoji';
   const markdown = `This is a gemoji :${emoji}:.`;

--- a/__tests__/gemoji-parser.test.js
+++ b/__tests__/gemoji-parser.test.js
@@ -107,7 +107,7 @@ test('should support legacy dashes', () => {
           {
             type: 'gemoji',
             value: '✅',
-            name: emoji,
+            name: 'white_check_mark',
           },
           { type: 'text', value: '.' },
         ],

--- a/lib/owlmoji.js
+++ b/lib/owlmoji.js
@@ -40,14 +40,10 @@ class Owlmoji {
     if (name in nameToEmoji) return 'gemoji';
     else if (name.match(/^fa-/)) return 'fontawesome';
     else if (owlmojiNames.includes(name)) return 'owlmoji';
-
-    return name.match(/-/) ? Owlmoji.kind(name.replaceAll(/-/g, '_')) : null;
+    return null;
   };
 
-  static nameToEmoji = new Proxy(nameToEmoji, {
-    get: (emojis, name) =>
-      name in emojis ? emojis[name] : name.match(/-/) ? emojis[name.replaceAll(/-/g, '_')] : null,
-  });
+  static nameToEmoji = nameToEmoji;
 
   static owlmoji = gemoji.concat(owlmoji).sort((a, b) => a.names[0] - b.names[0]);
 }

--- a/lib/owlmoji.js
+++ b/lib/owlmoji.js
@@ -40,10 +40,14 @@ class Owlmoji {
     if (name in nameToEmoji) return 'gemoji';
     else if (name.match(/^fa-/)) return 'fontawesome';
     else if (owlmojiNames.includes(name)) return 'owlmoji';
-    return null;
+
+    return name.match(/-/) ? Owlmoji.kind(name.replaceAll(/-/g, '_')) : null;
   };
 
-  static nameToEmoji = nameToEmoji;
+  static nameToEmoji = new Proxy(nameToEmoji, {
+    get: (emojis, name) =>
+      name in emojis ? emojis[name] : name.match(/-/) ? emojis[name.replaceAll(/-/g, '_')] : null,
+  });
 
   static owlmoji = gemoji.concat(owlmoji).sort((a, b) => a.names[0] - b.names[0]);
 }

--- a/processor/parse/gemoji-parser.js
+++ b/processor/parse/gemoji-parser.js
@@ -50,8 +50,20 @@ function tokenize(eat, value, silent) {
           },
         },
       });
-    default:
+    default: {
+      if (name.match(/-/)) {
+        const standardized = name.replaceAll(/-/g, '_');
+        if (Owlmoji.kind(standardized) === 'gemoji') {
+          return eat(match)({
+            type: 'gemoji',
+            value: Owlmoji.nameToEmoji[standardized],
+            name: standardized,
+          });
+        }
+      }
+
       return false;
+    }
   }
 }
 


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-9702 |
| :--------------------: | :---------: |

## 🧰 Changes

Adds support for our legacy emoji syntax.

Previously, we swapped out our custom emoji library for a more standard one. Unrealized by me, our custom one used dashes instead of underscores. This checks if the same emoji name exists using underscores instead of dashes.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
