### PR TITLE
fix: callout breaks

### DIFF
--- a/__tests__/compilers/callout.test.ts
+++ b/__tests__/compilers/callout.test.ts
@@ -34,4 +34,15 @@ describe('callouts compiler', () => {
 
     expect(mdx(mdast(markdown))).toBe(markdown);
   });
+
+  it('compiles callouts with paragraphs', () => {
+    const markdown = `> 🚧 It **works**!
+>
+> And...
+>
+> it correctly compiles paragraphs. :grimace:
+`;
+
+    expect(mdx(mdast(markdown))).toBe(markdown);
+  });
 });

--- a/processor/compile/callout.ts
+++ b/processor/compile/callout.ts
@@ -2,31 +2,20 @@ import { NodeTypes } from '../../enums';
 import { Callout } from '../../types';
 
 const callout = (node: Callout, _, state, info) => {
-  const tracker = state.createTracker(info);
   const exit = state.enter(NodeTypes.callout);
+  const tracker = state.createTracker(info);
 
-  state.join.push(() => 0);
-  const value = state.containerFlow(node, tracker.current());
-  state.join.pop();
+  tracker.move('> ');
+  tracker.shift(2);
 
+  const map = (line: string, index: number, blank: boolean) => {
+    return `>${index === 0 ? ` ${node.data.hProperties.icon}` : ''}${blank ? '' : ' '}${line}`;
+  };
+
+  const value = state.indentLines(state.containerFlow(node, tracker.current()), map);
   exit();
 
-  let lines = value.split('\n');
-
-  if (lines.length > 1) {
-    const [first, ...rest] = lines;
-    lines = [first, '', ...rest];
-  }
-
-  let content = lines
-    .map((line: string, index: number) => (index > 0 ? `>${line.length > 0 ? ' ' : ''}${line}` : line))
-    .join('\n');
-
-  if (content.match(/^[^\n]/)) content = ' ' + content;
-
-  const block = `> ${node.data.hProperties.icon}${content}`;
-
-  return block;
+  return value;
 };
 
 export default callout;


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-9785 |
| :--------------------: | :---------: |

## 🧰 Changes

Fixes saving callouts, again.

I had started copying a compiler from the source package. But I appear to have tried to reimplement the blockquote compiler, but incorrectly. This PR is much closer to the actual [block quote compiler](https://github.com/syntax-tree/mdast-util-to-markdown/blob/main/lib/handle/blockquote.js)

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
