### PR TITLE
fix: add externals for node build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,6 +117,29 @@ const serverConfig = merge(getConfig({ target: 'node' }), {
   output: {
     filename: '[name].node.js',
   },
+  externals: {
+    react: {
+      amd: 'react',
+      commonjs: 'react',
+      commonjs2: 'react',
+      root: 'React',
+      umd: 'react',
+    },
+    'react-dom': {
+      amd: 'react-dom',
+      commonjs2: 'react-dom',
+      commonjs: 'react-dom',
+      root: 'ReactDOM',
+      umd: 'react-dom',
+    },
+    'react-dom/server': {
+      amd: 'react-dom/server',
+      commonjs2: 'react-dom/server',
+      commonjs: 'react-dom/server',
+      root: 'ReactDOM/server',
+      umd: 'react-dom/server',
+    },
+  },
 });
 
 module.exports = [browserConfig, serverConfig];


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

This allows the renderer to inject its own util module, which react-dom/server relies on for access to TextEncoder.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
