### PR TITLE
feat: add html to hast

### DIFF
--- a/__tests__/lib/hast.test.ts
+++ b/__tests__/lib/hast.test.ts
@@ -1,4 +1,4 @@
-import { hast } from '../../lib';
+import { hast, hastFromHtml } from '../../lib';
 import { h } from 'hastscript';
 
 describe('hast transformer', () => {
@@ -20,5 +20,19 @@ describe('hast transformer', () => {
     );
 
     expect(hast(md, { components })).toStrictEqualExceptPosition(expected);
+  });
+});
+
+describe('hastFromHtml', () => {
+  it('parses html', () => {
+    const html = '<div><span>Nice</span></div>';
+    const tree = hastFromHtml(html);
+
+    // @ts-ignore
+    expect(tree.children[0].tagName).toBe('html');
+    // @ts-ignore
+    expect(tree.children[0].children[1].children[0].tagName).toBe('div');
+    // @ts-ignore
+    expect(tree.children[0].children[1].children[0].children[0].tagName).toBe('span');
   });
 });

--- a/index.tsx
+++ b/index.tsx
@@ -6,8 +6,6 @@ import * as Components from './components';
 import { getHref } from './components/Anchor';
 import { options } from './options';
 
-import { compile, hast, run, mdast, mdx, plain, remarkPlugins } from './lib';
-
 import './styles/main.scss';
 
 const unimplemented = debug('mdx:unimplemented');
@@ -33,4 +31,5 @@ export const esast = (text: string, opts = {}) => {
   unimplemented('esast export');
 };
 
-export { compile, hast, run, mdast, mdx, plain, Components, utils };
+export { compile, hast, hastFromHtml, run, mdast, mdx, plain, remarkPlugins } from './lib';
+export { Components, utils };

--- a/lib/hast.ts
+++ b/lib/hast.ts
@@ -3,6 +3,8 @@ import remarkRehype from 'remark-rehype';
 import { injectComponents } from '../processor/transform';
 import { MdastComponents } from '../types';
 import mdast from './mdast';
+import { unified } from 'unified';
+import rehypeParse from 'rehype-parse';
 
 interface Options {
   components?: Record<string, string>;
@@ -17,6 +19,10 @@ const hast = (text: string, opts: Options = {}) => {
   const processor = astProcessor(opts).use(injectComponents({ components })).use(remarkRehype);
 
   return processor.runSync(processor.parse(text));
+};
+
+export const hastFromHtml = (html: string) => {
+  return unified().use(rehypeParse).parse(html);
 };
 
 export default hast;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,10 +1,10 @@
 import astProcessor, { MdastOpts, remarkPlugins } from './ast-processor';
 import compile from './compile';
-import hast from './hast';
+import hast, { hastFromHtml } from './hast';
 import mdast from './mdast';
 import mdx from './mdx';
 import plain from './plain';
 import run from './run';
 
 export type { MdastOpts };
-export { astProcessor, compile, hast, mdast, mdx, plain, run, remarkPlugins };
+export { astProcessor, compile, hast, hastFromHtml, mdast, mdx, plain, run, remarkPlugins };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
         "prop-types": "^15.8.1",
+        "rehype-parse": "^9.0.0",
         "rehype-remark": "^10.0.0",
         "rehype-slug": "^6.0.0",
         "remark": "^15.0.1",
@@ -26968,6 +26969,20 @@
         "hast-util-is-element": "^3.0.0",
         "hast-util-whitespace": "^3.0.0",
         "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-parse": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.0.tgz",
+      "integrity": "sha512-WG7nfvmWWkCR++KEkZevZb/uw41E8TsH4DsY9UxsTbIXCVGbAs4S+r8FrQ+OtH5EEQAs+5UxKC42VinkmpA1Yw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "prop-types": "^15.8.1",
+    "rehype-parse": "^9.0.0",
     "rehype-remark": "^10.0.0",
     "rehype-slug": "^6.0.0",
     "remark": "^15.0.1",


### PR DESCRIPTION
| [![PR App][icn]][demo] | RM-9820 |
| :--------------------: | :-----: |

## 🧰 Changes

Adds a `htmlToHast` function.

This will be used in indexing,

```
mdx -> rmdx.run(rmdx.compile(mdx)) ->
       react -> renderToSring(react) ->
       html -> htmlToHast(html) ->
       hast -> plain(hast) -> indexable plain text!
```

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
