### PR TITLE
feat: escapes

### DIFF
--- a/__tests__/compilers/compatability.test.ts
+++ b/__tests__/compilers/compatability.test.ts
@@ -104,4 +104,20 @@ This is an image: <img src="http://example.com/#\\>" >
 
     expect(mdx(rdmd.mdast(md)).trim()).toBe('This is an image: <img src="http://example.com/#\\>" />');
   });
+
+  it('compiles escapes', () => {
+    const md = `
+\\- not a list item
+    `;
+
+    expect(mdx(rdmd.mdast(md)).trim()).toBe('\\- not a list item');
+  });
+
+  it('compiles escapes of backslashes', () => {
+    const md = `
+\\\\**still emphatic**
+    `;
+
+    expect(mdx(rdmd.mdast(md)).trim()).toBe('\\\\**still emphatic**');
+  });
 });

--- a/processor/compile/compatibility.ts
+++ b/processor/compile/compatibility.ts
@@ -9,6 +9,7 @@ type CompatNodes =
   | { type: NodeTypes.glossary; data: { hProperties: { term: string } } }
   | { type: NodeTypes.glossary; data: { hName: 'Glossary' }; children: [{ type: 'text'; value: string }] }
   | { type: NodeTypes.reusableContent; tag: string }
+  | { type: 'escape'; value: string }
   | Html;
 
 /*
@@ -39,6 +40,8 @@ const compatibility = (node: CompatNodes) => {
       return `<${node.tag} />`;
     case 'html':
       return html(node);
+    case 'escape':
+      return `\\${node.value}`;
     default:
       throw new Error('Unhandled node type!');
   }

--- a/processor/compile/index.ts
+++ b/processor/compile/index.ts
@@ -22,6 +22,7 @@ function compilers() {
     [NodeTypes.variable]: compatibility,
     [NodeTypes.glossary]: compatibility,
     [NodeTypes.reusableContent]: compatibility,
+    escape: compatibility,
     html: compatibility,
   };
 


### PR DESCRIPTION
| [![PR App][icn]][demo] | RM-9897 |
| :--------------------: | :-----: |

## 🧰 Changes

Compiles `escape` nodes from rdmd.

In `remark@9`, they no longer treat escapes as a separate node type. This is mostly fine, except when we're migrating from rdmd to rmdx. The [rules for escapes](https://github.github.com/gfm/#backslash-escapes) seem pretty simple, so I'm not too worried about this change.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
