### PR TITLE
fix: decode HTML outside of component render

### DIFF
--- a/components/Embed/index.tsx
+++ b/components/Embed/index.tsx
@@ -44,7 +44,8 @@ const Embed = ({
         html = undefined;
       }
     } catch (e) {
-      if (html === 'false') html = undefined;
+      // html wasn't HTML apparently
+      html = undefined;
     }
   }
 

--- a/components/Embed/index.tsx
+++ b/components/Embed/index.tsx
@@ -38,7 +38,11 @@ const Embed = ({
 
   if (html) {
     try {
-      if (html !== decodeURIComponent(html)) html = decodeURIComponent(html);
+      if (html !== decodeURIComponent(html)) {
+        html = decodeURIComponent(html);
+      } else {
+        if (html === 'false') html = undefined;
+      }
     } catch (e) {
       if (html === 'false') html = undefined;
     }

--- a/components/Embed/index.tsx
+++ b/components/Embed/index.tsx
@@ -36,7 +36,9 @@ const Embed = ({
 }: EmbedProps) => {
   if (typeof iframe !== 'boolean') iframe = iframe === 'true';
   if (html === 'false') html = undefined;
-  if (html) html = decodeURIComponent(html);
+  if (html !== decodeURIComponent(html || '')) {
+    html = decodeURIComponent(html);
+  }
 
   if (iframe) {
     return <iframe {...attrs} src={url} style={{ border: 'none', display: 'flex', margin: 'auto' }} />;

--- a/components/Embed/index.tsx
+++ b/components/Embed/index.tsx
@@ -40,8 +40,8 @@ const Embed = ({
     try {
       if (html !== decodeURIComponent(html)) {
         html = decodeURIComponent(html);
-      } else {
-        if (html === 'false') html = undefined;
+      } else if (html === 'false') {
+        html = undefined;
       }
     } catch (e) {
       if (html === 'false') html = undefined;

--- a/components/Embed/index.tsx
+++ b/components/Embed/index.tsx
@@ -35,9 +35,13 @@ const Embed = ({
   ...attrs
 }: EmbedProps) => {
   if (typeof iframe !== 'boolean') iframe = iframe === 'true';
-  if (html === 'false') html = undefined;
-  if (html !== decodeURIComponent(html || '')) {
-    html = decodeURIComponent(html);
+
+  if (html) {
+    try {
+      if (html !== decodeURIComponent(html)) html = decodeURIComponent(html);
+    } catch (e) {
+      if (html === 'false') html = undefined;
+    }
   }
 
   if (iframe) {

--- a/components/Embed/index.tsx
+++ b/components/Embed/index.tsx
@@ -36,6 +36,7 @@ const Embed = ({
 }: EmbedProps) => {
   if (typeof iframe !== 'boolean') iframe = iframe === 'true';
   if (html === 'false') html = undefined;
+  if (html) html = decodeURIComponent(html);
 
   if (iframe) {
     return <iframe {...attrs} src={url} style={{ border: 'none', display: 'flex', margin: 'auto' }} />;
@@ -54,7 +55,7 @@ const Embed = ({
   return (
     <div className={classes.join(' ')}>
       {html ? (
-        <div className="embed-media" dangerouslySetInnerHTML={{ __html: decodeURIComponent(html) }} />
+        <div className="embed-media" dangerouslySetInnerHTML={{ __html: html }} />
       ) : (
         <a className="embed-link" href={url} rel="noopener noreferrer" target="_blank">
           {!image || <img alt={title} className="embed-img" loading={lazy ? 'lazy' : undefined} src={image} />}


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-10040
:-------------------:|:----------:

## 🧰 Changes

The hub was getting a flash of plain encoded HTML before the component decoded and rendered it. Hopefully this should solve that!

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
