### PR TITLE
feat: new `stripTags` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,22 +55,20 @@ export { Components };
  * Setup Options
  * !Normalize Magic Block Raw Text!
  */
-export function setup(blocks, opts = {}) {
+export function setup(blocks, { stripTags, ...opts } = {}) {
   // merge default and user options
   opts = parseOptions(opts);
 
   if (!opts.sanitize) {
-    const schema = createSchema(opts);
+    opts.sanitize = createSchema(opts);
 
-    Object.values(Components).forEach(Component => Component.sanitize && Component.sanitize(schema));
+    Object.values(Components).forEach(Component => Component.sanitize && Component.sanitize(opts.sanitize));
 
-    if (Array.isArray(opts.strip))
-      opts.strip.forEach(tag => {
-        schema.strip.push(tag);
-        schema.tagNames.splice(schema.tagNames.indexOf(tag), 1);
+    if (Array.isArray(stripTags))
+      stripTags.forEach(tag => {
+        opts.sanitize.strip.push(tag);
+        opts.sanitize.tagNames.splice(opts.sanitize.tagNames.indexOf(tag), 1);
       });
-
-    opts.sanitize = schema;
   }
 
   // normalize magic block linebreaks

--- a/index.js
+++ b/index.js
@@ -60,9 +60,17 @@ export function setup(blocks, opts = {}) {
   opts = parseOptions(opts);
 
   if (!opts.sanitize) {
-    opts.sanitize = createSchema(opts);
+    const schema = createSchema(opts);
 
-    Object.values(Components).forEach(Component => Component.sanitize && Component.sanitize(opts.sanitize));
+    Object.values(Components).forEach(Component => Component.sanitize && Component.sanitize(schema));
+
+    if (Array.isArray(opts.strip))
+      opts.strip.forEach(tag => {
+        schema.strip.push(tag);
+        schema.tagNames.splice(schema.tagNames.indexOf(tag), 1);
+      });
+
+    opts.sanitize = schema;
   }
 
   // normalize magic block linebreaks


### PR DESCRIPTION
| 🎫 RM-9982 |
| :--------: |

## 🧰 Changes

For the most part, our sanitizer is automatically configured. But in certain instances– namely where we need to generate plaintext from a string of Markdown –it would errantly serialize `<style>` tag content.

- [x] **new RDMD `stripTags` option**
      Pass a list of tag names to force-strip them from the RDMD output. So to get rid of all style tags, you'd pass:

  ```js
  rdmd.hast(body, { stripTags: ["style"] });
  ```

## 🤷 Customer Changes

[Once this hits the monorepo][integration], customers should no longer see weird looking meta excerpts for their docs in Google.

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[integration]: https://github.com/readmeio/readme/pull/12167