### PR TITLE
style: bump code font size

### DIFF
--- a/components/Code/style.scss
+++ b/components/Code/style.scss
@@ -5,6 +5,8 @@
 /* stylelint-disable scss/selector-no-redundant-nesting-selector */
 /* stylelint-disable order/properties-alphabetical-order */
 @mixin gfm-code-base-styles($background: #f6f8fa, $background-dark: #242e34, $text: inherit) {
+  --font-size: 95%;
+
   code,
   kbd,
   pre {
@@ -29,7 +31,7 @@
     background-color: var(--md-code-background, $background);
     border-radius: 3px;
     color: var(--md-code-text);
-    font-size: 85%;
+    font-size: var(--font-size);
     margin: 0;
     padding: 0.2em 0.4em;
 
@@ -56,7 +58,7 @@
     border-radius: 3px;
     border-radius: var(--markdown-radius, 3px);
     border-radius: var(--md-code-radius, var(--markdown-radius, 3px));
-    font-size: 85%;
+    font-size: var(--font-size);
     line-height: 1.45;
     overflow: auto;
     padding: 1em;

--- a/components/Code/style.scss
+++ b/components/Code/style.scss
@@ -5,7 +5,7 @@
 /* stylelint-disable scss/selector-no-redundant-nesting-selector */
 /* stylelint-disable order/properties-alphabetical-order */
 @mixin gfm-code-base-styles($background: #f6f8fa, $background-dark: #242e34, $text: inherit) {
-  --font-size: 95%;
+  --font-size: 90%;
 
   code,
   kbd,


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

Jaclyn and I noticed that the font size for code blocks was a little small:

![image](https://github.com/readmeio/markdown/assets/451488/08c70e54-c16c-49c0-8f68-b5b0875f12fc)

So this PR bumps it to `95%`

`beta` PR #912

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
