### PR TITLE
feat: compatibility for rdmd image/embed components

### DIFF
--- a/__tests__/compilers/compatability.test.ts
+++ b/__tests__/compilers/compatability.test.ts
@@ -27,6 +27,92 @@ describe('compatability with RDMD', () => {
     expect(mdx(ast).trim()).toBe('<Glossary>parliament</Glossary>');
   });
 
+  it('compiles mdx image nodes', () => {
+    const ast = {
+      type: 'figure',
+      data: {
+        hName: 'figure',
+      },
+      children: [
+        {
+          align: 'center',
+          width: '300px',
+          src: 'https://drastik.ch/wp-content/uploads/2023/06/blackcat.gif',
+          url: 'https://drastik.ch/wp-content/uploads/2023/06/blackcat.gif',
+          alt: '',
+          title: '',
+          type: 'image',
+          data: {
+            hProperties: {
+              align: 'center',
+              className: 'border',
+              width: '300px',
+            },
+          },
+        },
+        {
+          type: 'figcaption',
+          data: {
+            hName: 'figcaption',
+          },
+          children: [
+            {
+              type: 'paragraph',
+              children: [
+                {
+                  type: 'text',
+                  value: 'hello ',
+                },
+                {
+                  type: 'strong',
+                  children: [
+                    {
+                      type: 'text',
+                      value: 'cat',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(mdx(ast).trim()).toBe(
+      '<Image align="center" border="true" caption="hello **cat**" width="300px" src="https://drastik.ch/wp-content/uploads/2023/06/blackcat.gif" />',
+    );
+  });
+
+  it('compiles mdx embed nodes', () => {
+    const ast = {
+      data: {
+        hProperties: {
+          html: false,
+          url: 'https://cdn.shopify.com/s/files/1/0711/5132/1403/files/BRK0502-034178M.pdf',
+          title: 'iframe',
+          href: 'https://cdn.shopify.com/s/files/1/0711/5132/1403/files/BRK0502-034178M.pdf',
+          typeOfEmbed: 'iframe',
+          height: '300px',
+          width: '100%',
+          iframe: true,
+        },
+        hName: 'embed',
+        html: false,
+        url: 'https://cdn.shopify.com/s/files/1/0711/5132/1403/files/BRK0502-034178M.pdf',
+        title: 'iframe',
+        href: 'https://cdn.shopify.com/s/files/1/0711/5132/1403/files/BRK0502-034178M.pdf',
+        typeOfEmbed: 'iframe',
+        height: '300px',
+        width: '100%',
+        iframe: true,
+      },
+      type: 'embed',
+    };
+
+    expect(mdx(ast).trim()).toBe('<Embed html="false" url="https://cdn.shopify.com/s/files/1/0711/5132/1403/files/BRK0502-034178M.pdf" title="iframe" href="https://cdn.shopify.com/s/files/1/0711/5132/1403/files/BRK0502-034178M.pdf" typeOfEmbed="iframe" height="300px" width="100%" iframe="true" />');
+  });
+
   it('compiles reusable-content nodes', () => {
     const ast = {
       type: 'reusable-content',

--- a/__tests__/compilers/compatability.test.ts
+++ b/__tests__/compilers/compatability.test.ts
@@ -30,9 +30,7 @@ describe('compatability with RDMD', () => {
   it('compiles mdx image nodes', () => {
     const ast = {
       type: 'figure',
-      data: {
-        hName: 'figure',
-      },
+      data: { hName: 'figure' },
       children: [
         {
           align: 'center',
@@ -52,26 +50,12 @@ describe('compatability with RDMD', () => {
         },
         {
           type: 'figcaption',
-          data: {
-            hName: 'figcaption',
-          },
+          data: { hName: 'figcaption' },
           children: [
-            {
-              type: 'paragraph',
+            { type: 'paragraph',
               children: [
-                {
-                  type: 'text',
-                  value: 'hello ',
-                },
-                {
-                  type: 'strong',
-                  children: [
-                    {
-                      type: 'text',
-                      value: 'cat',
-                    },
-                  ],
-                },
+                { type: 'text', value: 'hello ' },
+                { type: 'strong', children: [{ type: 'text', value: 'cat' }] },
               ],
             },
           ],

--- a/processor/compile/index.ts
+++ b/processor/compile/index.ts
@@ -23,7 +23,9 @@ function compilers() {
     [NodeTypes.imageBlock]: image,
     [NodeTypes.reusableContent]: compatibility,
     [NodeTypes.variable]: variable,
+    embed: compatibility,
     escape: compatibility,
+    figure: compatibility,
     html: compatibility,
   };
 

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -12,8 +12,18 @@ import { MdxJsxFlowElement, MdxJsxTextElement, MdxFlowExpression } from 'mdast-u
  */
 export const formatHProps = <T>(node: Node): string => {
   const hProps = getHProps<T>(node);
-  const hPropKeys = getHPropKeys<T>(node) as string[];
-  return hPropKeys.map(key => `${key}="${hProps[key]}"`).join(' ');
+  return formatProps(hProps);
+}
+
+/**
+ * Formats an object of props as a string.
+ *
+ * @param {Object} props
+ * @returns {string}
+ */
+export const formatProps = (props: Object): string => {
+  const keys = Object.keys(props);
+  return keys.map(key => `${key}="${props[key]}"`).join(' ');
 }
 
 /**


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-10134
:-------------------:|:----------:

## 🧰 Changes

Converts the rdmd-style `mdast` for the image and embed blocks to the new MDX components

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
