### PR TITLE
fix: handle null variable defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ export function astToPlainText(node, opts = {}) {
 
   const { defaults: defaultVars = [], user: userVars = {} } = opts.variables || {};
   const variables = {
-    ...Object.fromEntries(defaultVars.map(({ name: key, default: val }) => [key, val])),
+    ...Object.fromEntries(defaultVars.filter(Boolean).map(({ name: key, default: val }) => [key, val])),
     ...userVars,
   };
 


### PR DESCRIPTION
| 🔥 [Channel] | ✅ Approved as #920 |
| :----------: | :----------------: |

## 🧰 Changes

Because of [how we model empty `variableDefaults` in the project schema](https://github.com/readmeio/readme/blob/5f0a0c3768b2cb3f745cdb0ffb696a49e614c5c5/packages/models/project/index.js#L684-L706), these arrays were being passed to RDMD as `[null]` instead of `null`.

- [x] handle `[null]` variable defaults

## 🧬 QA & Testing

Hard to test until this hits the monorepo, but once it does we should be on the lookout for [this error](https://readme.sentry.io/issues/5549356424/?project=2052166&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&stream_index=0).

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[channel]: https://readmeio.slack.com/archives/C07ACJ61A6Q
