### PR TITLE
chore(astToPlainText): processor improvements

### DIFF
--- a/__tests__/astToPlainText.test.js
+++ b/__tests__/astToPlainText.test.js
@@ -1,3 +1,5 @@
+import { dim, magenta } from 'chalk'; // eslint-disable-line unicorn/import-style
+
 import { hast, astToPlainText } from '../index';
 
 const find = (node, matcher) => {
@@ -9,140 +11,142 @@ const find = (node, matcher) => {
   return null;
 };
 
-describe('astToPlainText()', () => {
-  it("converts br's to ''", () => {
-    const txt = '<br>';
+const wordsOnly = (str, rgx) =>
+  str
+    .replace(typeof rgx === 'string' ? new RegExp(`[^\\w${rgx}]`, 'g') : rgx || /\W/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 
-    expect(astToPlainText(hast(txt))).toBe('');
+describe('Plain Text Serialization', () => {
+  describe('RDMD Syntax', () => {
+    it('tables', () => {
+      const txt = `
+  | Header 1 | Header 2 |
+  | :------- | :------- |
+  | Cell 1   | Cell 2   |
+      `;
+
+      expect(astToPlainText(hast(txt))).toBe('Header 1 Header 2 Cell 1 Cell 2');
+    });
+
+    it('images', () => {
+      const body = `
+  ![image **label**](http://placekitten.com/600/600 "entitled kittens")
+      `;
+      const tree = hast(body);
+      const elem = find(tree, n => n.tagName === 'img');
+
+      expect(astToPlainText(tree)).toBe('entitled kittens');
+      expect(astToPlainText(elem)).toBe('entitled kittens');
+    });
+
+    it('glossary terms', () => {
+      const tree = hast('try the <<glossary:demo>>');
+      const text = astToPlainText(tree);
+      expect(text).toBe('try the demo');
+    });
+
+    it('variables', () => {
+      const vars = { user: { name: 'John Doe' }, defaults: [null] };
+      const tree = hast('<<name>>');
+      const text = astToPlainText(tree, { variables: vars });
+      expect(text).toBe(vars.user.name);
+    });
+
+    describe.each([
+      ['title', 'simple body'],
+      ['title (no body)'],
+      ['', 'simple body (no title)'],
+      ['title', 'complex|multi\n> ---|---\n> child|body'],
+      ['', 'complex|body\n> ---|---\n> (no|title)'],
+    ])(`${magenta('↓')} ${dim('callouts:')}`, (...args) => {
+      // construct the callout syntax
+      const body = `> 👍 ${args.join('\n> ')}`;
+
+      const tree = hast(body);
+      const text = astToPlainText(tree);
+      const name = wordsOnly(text, ':()').replace(': ', ' w/');
+
+      it(`${name}`, () => {
+        // ensure syntax input matches plaintext output (words only)
+        const [is, ought] = [body, text].map(x => wordsOnly(x));
+        expect(is).toBe(ought);
+      });
+    });
   });
 
-  it("converts hr's to ''", () => {
-    const txt = '<hr>';
-
-    expect(astToPlainText(hast(txt))).toBe('');
-  });
-
-  it('converts flavored callouts', () => {
-    const txt = `
-> 📘 Title
->
-> Some body
-    `;
-
-    expect(astToPlainText(hast(txt))).toBe('📘 Title: Some body');
-  });
-
-  it('converts markdown tables', () => {
-    const txt = `
-| Header 1 | Header 2 |
-| :------- | :------- |
-| Cell 1   | Cell 2   |
-    `;
-
-    expect(astToPlainText(hast(txt))).toBe('Header 1 Header 2 Cell 1 Cell 2');
-  });
-
-  it('converts magic block tables', () => {
-    const txt = `
-[block:parameters]
-${JSON.stringify(
-  {
-    data: {
-      'h-0': 'Header 1',
-      'h-1': 'Header 2',
-      '0-0': 'Cell 1',
-      '0-1': 'Cell 2  \nCell 2.1',
+  describe('Magic Blocks', () => {
+    it('table blocks', () => {
+      const txt = `
+  [block:parameters]
+  ${JSON.stringify(
+    {
+      data: {
+        'h-0': 'Header 1',
+        'h-1': 'Header 2',
+        '0-0': 'Cell 1',
+        '0-1': 'Cell 2  \nCell 2.1',
+      },
+      cols: 2,
+      rows: 1,
+      align: ['left', 'left', 'left'],
     },
-    cols: 2,
-    rows: 1,
-    align: ['left', 'left', 'left'],
-  },
-  null,
-  2,
-)}
-[/block]
-    `;
+    null,
+    2,
+  )}
+  [/block]
+      `;
 
-    expect(astToPlainText(hast(txt))).toBe('Header 1 Header 2 Cell 1 Cell 2 Cell 2.1');
+      expect(astToPlainText(hast(txt))).toBe('Header 1 Header 2 Cell 1 Cell 2 Cell 2.1');
+    });
+
+    it('image blocks', () => {
+      const body = `
+        [block:image]
+        {
+          "images": [
+            {
+              "image": ["https://files.readme.io/test.png", "Test Image Title", 100, 100, "#fff"]
+            }
+          ]
+        }
+        [/block]
+      `;
+      const tree = hast(body);
+      const elem = find(tree, n => n.tagName === 'img');
+
+      expect(astToPlainText(tree)).toBe('Test Image Title');
+      expect(astToPlainText(elem)).toBe('Test Image Title');
+    });
+
+    it('custom HTML blocks', () => {
+      const tree = hast(`[block:html]
+        {"html":"<p>Lorem <b>ipsum</b> dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>"}
+      [/block]`);
+      const text = astToPlainText(tree);
+      expect(text.startsWith('Lorem ipsum dolor sit amet')).toBe(true);
+    });
   });
 
-  it('converts images', () => {
-    const txt = `
-![image **label**](http://placekitten.com/600/600 "entitled kittens")
-    `;
+  describe('HTML Markup', () => {
+    it('strips <br> tags', () => {
+      const txt = '<br>';
 
-    expect(astToPlainText(hast(txt))).toBe('entitled kittens');
-  });
+      expect(astToPlainText(hast(txt))).toBe('');
+    });
 
-  it('converts a single image', () => {
-    const txt = `
-![image **label**](http://placekitten.com/600/600 "entitled kittens")
-    `;
-    const ast = hast(txt);
+    it('strips <hr> tags', () => {
+      const txt = '<hr>';
 
-    expect(astToPlainText(find(ast, n => n.tagName === 'img'))).toBe('entitled kittens');
-  });
+      expect(astToPlainText(hast(txt))).toBe('');
+    });
 
-  it('converts magic block images', () => {
-    const txt = `
-      [block:image]
-      {
-        "images": [
-          {
-            "image": ["https://files.readme.io/test.png", "Test Image Title", 100, 100, "#fff"]
-          }
-        ]
-      }
-      [/block]
-    `;
+    it('strips <style> tags', () => {
+      const tree = hast('<style>*{color:red!important}</style>\n\nLorem ipsum dolor sit amet.');
+      const text = astToPlainText(tree);
 
-    expect(astToPlainText(hast(txt))).toBe('Test Image Title');
-  });
-
-  it('converts a lone magic block image', () => {
-    const txt = `
-      [block:image]
-      {
-        "images": [
-          {
-            "image": ["https://files.readme.io/test.png", "Test Image Title", 100, 100, "#fff"]
-          }
-        ]
-      }
-      [/block]
-    `;
-    const tree = hast(txt);
-    const img = find(tree, n => n.tagName === 'img');
-
-    expect(astToPlainText(img)).toBe('Test Image Title');
-  });
-
-  it('converts magic HTML blocks', () => {
-    const tree = hast(`[block:html]
-      {"html":"<p>Lorem <b>ipsum</b> dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>"}
-    [/block]`);
-    const text = astToPlainText(tree);
-    expect(text.startsWith('Lorem ipsum dolor sit amet')).toBe(true);
-  });
-
-  it('converts glossary terms', () => {
-    const tree = hast('try the <<glossary:demo>>');
-    const text = astToPlainText(tree);
-    expect(text).toBe('try the demo');
-  });
-
-  it('converts ReadMe variables', () => {
-    const vars = { user: { name: 'John Doe' }, defaults: [null] };
-    const tree = hast('<<name>>');
-    const text = astToPlainText(tree, { variables: vars });
-    expect(text).toBe(vars.user.name);
-  });
-
-  it('strips style tags', () => {
-    const tree = hast('<style>*{color:red!important}</style>\n\nLorem ipsum dolor sit amet.');
-    const text = astToPlainText(tree);
-
-    expect(text).not.toContain('*{color:red!important}');
-    expect(text).toBe('Lorem ipsum dolor sit amet.');
+      expect(text).not.toContain('*{color:red!important}');
+      expect(text).toBe('Lorem ipsum dolor sit amet.');
+    });
   });
 });

--- a/__tests__/astToPlainText.test.js
+++ b/__tests__/astToPlainText.test.js
@@ -116,4 +116,33 @@ ${JSON.stringify(
 
     expect(astToPlainText(img)).toBe('Test Image Title');
   });
+
+  it('converts magic HTML blocks', () => {
+    const tree = hast(`[block:html]
+      {"html":"<p>Lorem <b>ipsum</b> dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>"}
+    [/block]`);
+    const text = astToPlainText(tree);
+    expect(text.startsWith('Lorem ipsum dolor sit amet')).toBe(true);
+  });
+
+  it('converts glossary terms', () => {
+    const tree = hast('try the <<glossary:demo>>');
+    const text = astToPlainText(tree);
+    expect(text).toBe('try the demo');
+  });
+
+  it('converts ReadMe variables', () => {
+    const vars = { user: { name: 'John Doe' }, defaults: [null] };
+    const tree = hast('<<name>>');
+    const text = astToPlainText(tree, { variables: vars });
+    expect(text).toBe(vars.user.name);
+  });
+
+  it('strips style tags', () => {
+    const tree = hast('<style>*{color:red!important}</style>\n\nLorem ipsum dolor sit amet.');
+    const text = astToPlainText(tree);
+
+    expect(text).not.toContain('*{color:red!important}');
+    expect(text).toBe('Lorem ipsum dolor sit amet.');
+  });
 });

--- a/index.js
+++ b/index.js
@@ -55,20 +55,13 @@ export { Components };
  * Setup Options
  * !Normalize Magic Block Raw Text!
  */
-export function setup(blocks, { stripTags, ...opts } = {}) {
+export function setup(blocks, opts = {}) {
   // merge default and user options
   opts = parseOptions(opts);
 
   if (!opts.sanitize) {
     opts.sanitize = createSchema(opts);
-
     Object.values(Components).forEach(Component => Component.sanitize && Component.sanitize(opts.sanitize));
-
-    if (Array.isArray(stripTags))
-      stripTags.forEach(tag => {
-        opts.sanitize.strip.push(tag);
-        opts.sanitize.tagNames.splice(opts.sanitize.tagNames.indexOf(tag), 1);
-      });
   }
 
   // normalize magic block linebreaks

--- a/processor/plugin/plain-text.js
+++ b/processor/plugin/plain-text.js
@@ -1,8 +1,13 @@
-/* @see: https://github.com/rehypejs/rehype-minify/blob/main/packages/hast-util-to-string/index.js
+/*
+ @see: https://github.com/rehypejs/rehype-minify/blob/main/packages/hast-util-to-string/index.js
  */
+
+const STRIP_TAGS = ['script', 'style'];
 
 /* eslint-disable no-use-before-define */
 function one(node, context) {
+  if (STRIP_TAGS.includes(node.tagName)) return '';
+
   if (node.tagName === 'rdme-callout') {
     const { icon, title } = node.properties;
 
@@ -56,6 +61,7 @@ const toPlainText = function () {
       const hasKid = 'children' in node && node.children.length;
       const method = hasKid ? all : one;
       const output = method(node, this.data('context'));
+
       return output.trim().replace(/\s+/g, ' ');
     },
   });

--- a/processor/plugin/plain-text.js
+++ b/processor/plugin/plain-text.js
@@ -2,11 +2,17 @@
  @see: https://github.com/rehypejs/rehype-minify/blob/main/packages/hast-util-to-string/index.js
  */
 
+const { hast } = require('../..');
+
 const STRIP_TAGS = ['script', 'style'];
 
 /* eslint-disable no-use-before-define */
 function one(node, context) {
   if (STRIP_TAGS.includes(node.tagName)) return '';
+
+  if (node.tagName === 'html-block') {
+    return all(hast(node.properties.html), context);
+  }
 
   if (node.tagName === 'rdme-callout') {
     const { icon, title } = node.properties;

--- a/processor/plugin/plain-text.js
+++ b/processor/plugin/plain-text.js
@@ -17,8 +17,8 @@ function one(node, context) {
   if (node.tagName === 'rdme-callout') {
     const { icon, title } = node.properties;
 
-    let body = node?.children?.[title ? 1 : 0];
-    body = body ? all(body, context) : '';
+    const children = node?.children?.slice(title ? 1 : 0);
+    const body = children ? all({ children }, context) : '';
 
     return [icon, ' ', title, title && body && ': ', body].filter(Boolean).join('');
   }


### PR DESCRIPTION
| 📖 [PR App][demo] |
| :---------------: |

## 🧰 Changes

Magic HTML blocks were being entirely skipped when serializing to plain text.

- [x] **[Reparse HTML blocks](https://github.com/readmeio/markdown/pull/925/files#diff-7af6da0312613e76e9bbc069cbd431d6904f10ebd51a2a70ffc0cc126e249c83R14)** instead of serializing to a blank string.
- [x] **Fix multi-child callout** sub-node serialization.
- [x] **Nix the `stripTags` option**; [internalized in the `astToPlainText` processor](https://github.com/readmeio/markdown/pull/925/files#diff-7af6da0312613e76e9bbc069cbd431d6904f10ebd51a2a70ffc0cc126e249c83R7-R11). ([#914])
- [x] **Add various unit tests** for variables, glossary terms, custom HTML blocks, complex callouts, and style tags.

## 🧬 QA & Testing

Pull down this branch and try running the following snippet. If the HTML block serializes to plain text nicely (instead of giving back a blank string) this worked! :tada:

```js
const docBody = '[block:html]{ "html": "<p>Lorem <b>ipsum</b> dolor sit amet, consectetur adipiscing elit.</p>" }[/block]\n\n> 👍 title\n> complex|multi\n> ---|---\n> child|body';

const output = rdmd.astToPlainText(rdmd.hast(docBody));
```

Now give the `astToPlainText()` unit tests a whirl. If everything comes up green, we're good! 🤘

```
npx jest --watch -- astToPlainText.test.js
```

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[#914]: https://github.com/readmeio/markdown/pull/914