### PR TITLE
fix: compatibility for unknown nodes

### DIFF
--- a/processor/compile/compatibility.ts
+++ b/processor/compile/compatibility.ts
@@ -4,7 +4,7 @@ import { toMarkdown } from 'mdast-util-to-markdown';
 import { toXast } from 'hast-util-to-xast';
 import { toXml } from 'xast-util-to-xml';
 import { NodeTypes } from '../../enums';
-import { formatHProps, formatProps } from '../utils';
+import { formatProps } from '../utils';
 
 type CompatNodes =
   | { type: NodeTypes.glossary; data: { hProperties: { term: string } } }
@@ -13,6 +13,7 @@ type CompatNodes =
   | { type: 'embed'; data: { hProperties: { [key: string]: string } } }
   | { type: 'escape'; value: string }
   | { type: 'figure'; children: [Image, { type: 'figcaption'; children: [{ type: 'text'; value: string }] }] }
+  | { type: 'i'; data: { hProperties: { className: string[]}} }
   | Html;
 
 /*
@@ -80,6 +81,8 @@ const compatibility = (node: CompatNodes) => {
       return figureToImageBlock(node);
     case 'embed':
       return embedToEmbedBlock(node);
+    case 'i':
+      return `:${node.data.hProperties.className[1]}:`;
     default:
       throw new Error('Unhandled node type!');
   }

--- a/processor/compile/index.ts
+++ b/processor/compile/index.ts
@@ -27,6 +27,7 @@ function compilers() {
     escape: compatibility,
     figure: compatibility,
     html: compatibility,
+    i: compatibility,
   };
 
   toMarkdownExtensions.push({ extensions: [{ handlers }] });

--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -1,3 +1,4 @@
+import { Parent } from 'mdast';
 import { NodeTypes } from '../../enums';
 import { Transform } from 'mdast-util-from-markdown';
 import { MdxJsxAttribute } from 'mdast-util-mdx-jsx';
@@ -5,6 +6,12 @@ import { MdxJsxAttribute } from 'mdast-util-mdx-jsx';
 import { visit } from 'unist-util-visit';
 
 const readmeToMdx = (): Transform => tree => {
+  // Unwrap pinned nodes, replace rdme-pin with its child node
+  visit(tree, 'rdme-pin', (node: Parent, i, parent) => {
+    const newNode = node.children[0];
+    parent.children.splice(i, 1, newNode);
+  });
+
   visit(tree, NodeTypes.tutorialTile, (tile, index, parent) => {
     const attributes: MdxJsxAttribute[] = ['backgroundColor', 'emoji', 'id', 'link', 'slug', 'title'].map(name => {
       const value = tile[name];


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-10063
:-------------------:|:----------:

## 🧰 Changes

Unhandled nodes are throwing errors during migration. Offending node types:

- [] `div`
- [x] `embed` 
- [x] `figure`
- [x] `i`
- [x] `rdme-pin`
- [] `yaml`???

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
