### PR TITLE
fix(beta): toc generation when using MDX components

### DIFF
--- a/processor/plugin/toc.ts
+++ b/processor/plugin/toc.ts
@@ -52,9 +52,11 @@ export const rehypeToc = ({ components = {} }: Options): Transformer<Root, Root>
 };
 
 const MAX_DEPTH = 2;
-const getDepth = (el: HastHeading) => parseInt(el.tagName.match(/^h(\d)/)[1]);
+const getDepth = (el: HastHeading) => parseInt(el.tagName?.match(/^h(\d)/)[1]);
 
 const tocToHast = (headings: HastHeading[] = []): TocList => {
+  console.log({ headings });
+
   const min = Math.min(...headings.map(getDepth));
   const ast = h('ul') as TocList;
   const stack: TocList[] = [ast];
@@ -86,7 +88,8 @@ export const tocToMdx = (toc: IndexableElements[], components: CustomComponents)
   const tree: Root = { type: 'root', children: toc };
 
   visit(tree, 'mdxJsxFlowElement', (node, index, parent) => {
-    parent.children.splice(index, 1, ...components[node.name].toc);
+    const toc = components[node.name].toc || [];
+    parent.children.splice(index, 1, ...toc);
   });
 
   const tocHast = tocToHast(tree.children as HastHeading[]);


### PR DESCRIPTION
| 💬 [Thread] |
| :---------: |

- [x] optionally chain the TOC regex matcher

[thread]: https://readmeio.slack.com/archives/C04R9PADCS3/p1720026196603799?thread_ts=1720025418.443289&cid=C04R9PADCS3
