### PR TITLE
fix: skip null align

### DIFF
--- a/__tests__/compilers/tables.test.js
+++ b/__tests__/compilers/tables.test.js
@@ -64,6 +64,53 @@ describe('table compiler', () => {
     `);
   });
 
+  it.only('saves to MDX if there are newlines and null alignment', () => {
+    const markdown = `
+|  th 1  |  th 2  |
+| ------ | ------ |
+| cell 1 | cell 2 |
+`;
+
+    const tree = mdast(markdown);
+
+    visit(tree, 'tableCell', cell => {
+      cell.children = [{ type: 'text', value: `${cell.children[0].value}\n🦉` }];
+    });
+
+    expect(mdx(tree)).toMatchInlineSnapshot(`
+      "<Table>
+        <thead>
+          <tr>
+            <th>
+              th 1
+              🦉
+            </th>
+
+            <th>
+              th 2
+              🦉
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>
+              cell 1
+              🦉
+            </td>
+
+            <td>
+              cell 2
+              🦉
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+      "
+    `);
+  });
+
   it('saves to MDX with lists', () => {
     const markdown = `
 |  th 1  |  th 2  |

--- a/__tests__/compilers/tables.test.js
+++ b/__tests__/compilers/tables.test.js
@@ -48,15 +48,15 @@ describe('table compiler', () => {
 
         <tbody>
           <tr>
-            <th style={{ textAlign: "center" }}>
+            <td style={{ textAlign: "center" }}>
               cell 1
               🦉
-            </th>
+            </td>
 
-            <th style={{ textAlign: "center" }}>
+            <td style={{ textAlign: "center" }}>
               cell 2
               🦉
-            </th>
+            </td>
           </tr>
         </tbody>
       </Table>
@@ -64,7 +64,7 @@ describe('table compiler', () => {
     `);
   });
 
-  it.only('saves to MDX if there are newlines and null alignment', () => {
+  it('saves to MDX if there are newlines and null alignment', () => {
     const markdown = `
 |  th 1  |  th 2  |
 | ------ | ------ |
@@ -148,13 +148,13 @@ describe('table compiler', () => {
 
         <tbody>
           <tr>
-            <th style={{ textAlign: "center" }}>
+            <td style={{ textAlign: "center" }}>
               cell 1
-            </th>
+            </td>
 
-            <th style={{ textAlign: "center" }}>
+            <td style={{ textAlign: "center" }}>
               cell 2
-            </th>
+            </td>
           </tr>
         </tbody>
       </Table>

--- a/processor/transform/tables-to-jsx.ts
+++ b/processor/transform/tables-to-jsx.ts
@@ -2,12 +2,11 @@ import { Parents, Table, TableCell, Text } from 'mdast';
 import { visit, EXIT } from 'unist-util-visit';
 import { Transform } from 'mdast-util-from-markdown';
 
-import { mdxJsx } from 'micromark-extension-mdx-jsx';
-import { fromMarkdown } from 'mdast-util-from-markdown';
-import { mdxJsxFromMarkdown } from 'mdast-util-mdx-jsx';
 import { phrasing } from 'mdast-util-phrasing';
 
-const alignToStyle = (align: 'left' | 'center' | 'right') => {
+const alignToStyle = (align: 'left' | 'center' | 'right' | null) => {
+  if (!align) return align;
+
   return {
     type: 'mdxJsxAttribute',
     name: 'style',
@@ -52,7 +51,7 @@ const visitor = (table: Table, index: number, parent: Parents) => {
             type: 'mdxJsxFlowElement',
             name: 'th',
             children: cell.children,
-            attributes: [styles[index]],
+            ...(styles[index] && { attributes: [styles[index]] }),
           };
         }),
       },
@@ -71,7 +70,7 @@ const visitor = (table: Table, index: number, parent: Parents) => {
             type: 'mdxJsxFlowElement',
             name: 'td',
             children: cell.children,
-            attributes: [styles[index]],
+            ...(styles[index] && { attributes: [styles[index]] }),
           };
         }),
       };
@@ -91,7 +90,7 @@ const visitor = (table: Table, index: number, parent: Parents) => {
   const jsx = {
     type: 'mdxJsxFlowElement',
     name: 'Table',
-    attributes,
+    ...(table.align.find(a => a) && { attributes }),
     children: [head, body],
   };
 


### PR DESCRIPTION
| [![PR App][icn]][demo] | RM-9793 |
| :--------------------: | :-----: |

## 🧰 Changes

Skips the align attrs if they're all null.

I didn't realize markdown tables default to null, rather than a string:

```
| foo |
| --- |
```

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
