### PR TITLE
fix: saving tables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Downgrade npm
-        run: npm -g install npm@10.8.1
+        run: npm -g install npm@^10.7.0
 
       - name: Install dependencies
-        run: npm ci
+        run: npm -v && npm ci
 
       - name: Install React <18 deps
         if: matrix.react == '16' || matrix.react == '17'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Downgrade npm
-        run: npm -g install npm@^10.7.0
+        run: npm install -g npm@^10.5.1
 
       - name: Install dependencies
         run: npm -v && npm ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         node-version:
           - lts/-1
           - lts/*
-          - latest
+          #- latest
         react: [16, 17, 18]
     steps:
       - uses: actions/checkout@v4
@@ -20,11 +20,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Downgrade npm
-        run: npm install -g npm@^10.5.1
-
       - name: Install dependencies
-        run: npm -v && npm ci
+        run: npm ci
 
       - name: Install React <18 deps
         if: matrix.react == '16' || matrix.react == '17'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - name: Downgrade npm
+        run: npm -g install npm@10.8.1
+
       - name: Install dependencies
         run: npm ci
 

--- a/__tests__/compilers/tables.test.js
+++ b/__tests__/compilers/tables.test.js
@@ -116,7 +116,6 @@ describe('table compiler', () => {
             <td style={{ textAlign: "center" }}>
               cell 1
               🦉
-<<<<<<< HEAD
             </td>
 
             <td style={{ textAlign: "center" }}>
@@ -155,7 +154,7 @@ describe('table compiler', () => {
             <th>
               th 2
               🦉
-            </td>
+            </th>
           </tr>
         </thead>
 

--- a/__tests__/compilers/tables.test.js
+++ b/__tests__/compilers/tables.test.js
@@ -17,6 +17,71 @@ describe('table compiler', () => {
     );
   });
 
+  it('compiles to jsx syntax', () => {
+    const markdown = `
+<Table align={["center","center"]}>
+  <thead>
+    <tr>
+      <th style={{ textAlign: "center" }}>
+        th 1
+        🦉
+      </th>
+
+      <th style={{ textAlign: "center" }}>
+        th 2
+        🦉
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td style={{ textAlign: "center" }}>
+        cell 1
+        🦉
+      </td>
+
+      <td style={{ textAlign: "center" }}>
+        cell 2
+        🦉
+      </td>
+    </tr>
+  </tbody>
+</Table>
+`;
+
+    expect(mdx(mdast(markdown))).toBe(`<Table align={["center","center"]}>
+  <thead>
+    <tr>
+      <th style={{ textAlign: "center" }}>
+        th 1
+        🦉
+      </th>
+
+      <th style={{ textAlign: "center" }}>
+        th 2
+        🦉
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td style={{ textAlign: "center" }}>
+        cell 1
+        🦉
+      </td>
+
+      <td style={{ textAlign: "center" }}>
+        cell 2
+        🦉
+      </td>
+    </tr>
+  </tbody>
+</Table>
+`);
+  });
+
   it('saves to MDX if there are newlines', () => {
     const markdown = `
 |  th 1  |  th 2  |
@@ -51,6 +116,7 @@ describe('table compiler', () => {
             <td style={{ textAlign: "center" }}>
               cell 1
               🦉
+<<<<<<< HEAD
             </td>
 
             <td style={{ textAlign: "center" }}>
@@ -89,7 +155,7 @@ describe('table compiler', () => {
             <th>
               th 2
               🦉
-            </th>
+            </td>
           </tr>
         </thead>
 
@@ -160,5 +226,43 @@ describe('table compiler', () => {
       </Table>
       "
     `);
+  });
+
+  it('compiles back to markdown syntax if there are no newlines/blocks', () => {
+    const markdown = `
+<Table align={["center","center"]}>
+  <thead>
+    <tr>
+      <th style={{ textAlign: "center" }}>
+        th 1
+      </th>
+
+      <th style={{ textAlign: "center" }}>
+        th 2
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td style={{ textAlign: "center" }}>
+        cell 1
+      </td>
+
+      <td style={{ textAlign: "center" }}>
+        cell 2
+      </td>
+    </tr>
+  </tbody>
+</Table>
+`;
+
+    expect(mdx(mdast(markdown)).trim()).toBe(
+      `
+|  th 1  |  th 2  |
+| :----: | :----: |
+| cell 1 | cell 2 |
+`.trim(),
+    );
   });
 });


### PR DESCRIPTION
| [![PR App][icn]][demo] | RM-9793 |
| :--------------------: | :-----: |

## 🧰 Changes

Fixes saving 'complex' tables.

In a prior PR, I added a new node type `tableau` to represent tables with block content. This mostly worked for the editor, but not when doing `mdx(mdast(doc))`. This PR adds a transformer, so the a `tableau` is converted to a JSX table just like regular `table`'s.

This also adds the check so, if a `tableau` no longer has block content, it's saved as markdown!

## 🧬 QA & Testing

Hard to test outside the main app.

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
