### PR TITLE
fix: lists in table headers

### DIFF
--- a/__tests__/compilers/tables.test.js
+++ b/__tests__/compilers/tables.test.js
@@ -267,14 +267,34 @@ describe('table compiler', () => {
 
   it('compiles to jsx if there is a single list item', () => {
     const doc = `
-|        | B1 |
-| ------ | -- |
-| A2     | B2 |
+<Table>
+  <thead>
+    <tr>
+      <th>
+        * list
+      </th>
+
+      <th>
+        th 2
+      </th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td>
+        cell 1
+      </td>
+
+      <td>
+        cell 2
+      </td>
+    </tr>
+  </tbody>
+</Table>
     `;
 
     const tree = mdast(doc);
-    const subtree = mdast(`* list`);
-    tree.children[0].children[0].children[0].children = subtree.children;
 
     expect(mdx(tree).trim()).toMatchInlineSnapshot(`
       "<Table>
@@ -285,7 +305,7 @@ describe('table compiler', () => {
             </th>
 
             <th>
-              B1
+              th 2
             </th>
           </tr>
         </thead>
@@ -293,11 +313,11 @@ describe('table compiler', () => {
         <tbody>
           <tr>
             <td>
-              A2
+              cell 1
             </td>
 
             <td>
-              B2
+              cell 2
             </td>
           </tr>
         </tbody>

--- a/__tests__/compilers/tables.test.js
+++ b/__tests__/compilers/tables.test.js
@@ -264,4 +264,44 @@ describe('table compiler', () => {
 `.trim(),
     );
   });
+
+  it('compiles to jsx if there is a single list item', () => {
+    const doc = `
+|        | B1 |
+| ------ | -- |
+| A2     | B2 |
+    `;
+
+    const tree = mdast(doc);
+    const subtree = mdast(`* list`);
+    tree.children[0].children[0].children[0].children = subtree.children;
+
+    expect(mdx(tree).trim()).toMatchInlineSnapshot(`
+      "<Table>
+        <thead>
+          <tr>
+            <th>
+              * list
+            </th>
+
+            <th>
+              B1
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>
+              A2
+            </td>
+
+            <td>
+              B2
+            </td>
+          </tr>
+        </tbody>
+      </Table>"
+    `);
+  });
 });

--- a/processor/transform/tables-to-jsx.ts
+++ b/processor/transform/tables-to-jsx.ts
@@ -17,6 +17,8 @@ const alignToStyle = (align: 'left' | 'center' | 'right' | null) => {
   };
 };
 
+const isTableCell = (node: Node) => ['tableHead', 'tableCell'].includes(node.type);
+
 const visitor = (table: Table, index: number, parent: Parents) => {
   let hasFlowContent = false;
 
@@ -39,7 +41,7 @@ const visitor = (table: Table, index: number, parent: Parents) => {
     });
   };
 
-  visit(table, 'tableCell', tableCellVisitor);
+  visit(table, isTableCell, tableCellVisitor);
   if (!hasFlowContent) {
     table.type = 'table';
     return;


### PR DESCRIPTION
| [![PR App][icn]][demo] | RM-9793 |
| :--------------------: | :--------: |

## 🧰 Changes

Fixes saving lists (other blocks too) in table headers.

## 🧬 QA & Testing

Kind of hard to test outside the editor. But I've been testing by running `make mdx` and playing around in the styleguidist playground thingy.

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
