### PR TITLE
feat: tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ Parses mdx to an hast.
 
 #### `plain`
 
-> [!NOTE]
-> unimplemented
+Parses mdx to a plain string. It **does** not execute the doc.
+
+#### `tags`
+
+Returns a list of tag names from the doc. It **does** not execute the doc.
 
 #### `utils`
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,17 @@ Parses mdx to an hast.
 
 #### `plain`
 
-Parses mdx to a plain string. It **does** not execute the doc.
+Parses mdx to a plain string.
+
+> [!WARNING]
+> This **does** not `eval` the doc.
 
 #### `tags`
 
-Returns a list of tag names from the doc. It **does** not execute the doc.
+Returns a list of tag names from the doc.
+
+> [!WARNING]
+> This **does** not `eval` the doc.
 
 #### `utils`
 

--- a/__tests__/lib/tags.test.ts
+++ b/__tests__/lib/tags.test.ts
@@ -1,0 +1,37 @@
+import { tags } from '../../lib';
+
+describe('tags', () => {
+  it('returns custom element names', () => {
+    const mdx = `<TagMe />`;
+
+    expect(tags(mdx)).toStrictEqual(['TagMe']);
+  });
+
+  it('does not return html tags', () => {
+    const mdx = `<br />`;
+
+    expect(tags(mdx)).toStrictEqual([]);
+  });
+
+  it('returns block and phrasing content', () => {
+    const mdx = `
+<Block />
+
+This is phrasing: <Inline />
+`;
+
+    expect(tags(mdx)).toStrictEqual(['Block', 'Inline']);
+  });
+
+  it('returns a unique set of names', () => {
+    const mdx = `
+<Block />
+
+<Block />
+
+<Block />
+`;
+
+    expect(tags(mdx)).toStrictEqual(['Block']);
+  });
+});

--- a/index.tsx
+++ b/index.tsx
@@ -13,5 +13,5 @@ const utils = {
   calloutIcons: {},
 };
 
-export { compile, hast, run, mdast, mdx, plain, remarkPlugins } from './lib';
+export { compile, hast, run, mdast, mdx, plain, remarkPlugins, tags } from './lib';
 export { Components, utils };

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@ import mdast from './mdast';
 import mdx from './mdx';
 import plain from './plain';
 import run from './run';
+import tags from './tags';
 
 export type { MdastOpts };
-export { astProcessor, compile, hast, mdast, mdx, plain, run, remarkPlugins };
+export { astProcessor, compile, hast, mdast, mdx, plain, run, remarkPlugins, tags };

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -1,0 +1,18 @@
+import { visit } from 'unist-util-visit';
+import mdast from './mdast';
+import { isMDXElement } from '../processor/utils';
+import { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
+
+const tags = (doc: string) => {
+  const set = new Set<string>();
+
+  visit(mdast(doc), isMDXElement, (node: MdxJsxFlowElement | MdxJsxTextElement) => {
+    if (node.name.match(/^[A-Z]/)) {
+      set.add(node.name);
+    }
+  });
+
+  return Array.from(set);
+};
+
+export default tags;


### PR DESCRIPTION
| [![PR App][icn]][demo] | RM-10502 |
| :--------------------: | :------: |

## 🧰 Changes

Adds the `tags` export.

`tags` will return a list of custom tags in the document.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
