### PR TITLE
fix(img): set src properly for magic image blocks

### DIFF
--- a/__tests__/fixtures/image-block-no-attrs.mdx
+++ b/__tests__/fixtures/image-block-no-attrs.mdx
@@ -1,6 +1,6 @@
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Possimus magni delectus dolorum velit sit laboriosam a quos? Animi ut quam impedit inventore ratione. Delectus quaerat similique natus optio, magnam quam deleniti, iste fugiat ipsam sapiente modi hic cupiditate sint. Quod dolor, inventore facere laudantium facilis molestias reprehenderit. Consectetur, inventore doloremque.
 
-<Image align="left" className="" width="50% " />
+<Image align="left" className="" width="50% " src="https://files.readme.io/327e65d-image.png" />
 
 # Hello world
 

--- a/__tests__/transformers/images.test.ts
+++ b/__tests__/transformers/images.test.ts
@@ -1,4 +1,6 @@
-import { mdast } from '../../index';
+import { mdast as mdastLegacy } from '@readme/markdown-legacy';
+
+import { mdast, mdx } from '../../index';
 
 describe('images transformer', () => {
   it('converts single children images of paragraphs to an image-block', () => {
@@ -19,5 +21,31 @@ describe('images transformer', () => {
 
     expect(tree.children[0].children[0].children[0].type).toBe('strong');
     expect(tree.children[0].children[0].children[2].type).toBe('emphasis');
+  });
+
+  it('can parse and transform magic image block AST to MDX', () => {
+    const rdmd = `
+[block:image]
+{
+  "images": [
+    {
+      "image": [
+        "https://files.readme.io/4a1c7a0-Iphone.jpeg",
+        null,
+        ""
+      ],
+      "align": "center",
+      "sizing": "250px"
+    }
+  ]
+}
+[/block]
+`;
+
+    const rmdx = mdx(mdastLegacy(rdmd));
+
+    expect(rmdx).toMatch(
+      '<Image align="center" className="" width="250px" src="https://files.readme.io/4a1c7a0-Iphone.jpeg" />',
+    );
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "@commitlint/config-angular": "^17.4.4",
         "@commitlint/config-conventional": "^17.4.4",
         "@readme/eslint-config": "^14.0.0",
-        "@readme/markdown-legacy": "npm:@readme/markdown@^6.84.0",
+        "@readme/markdown-legacy": "npm:@readme/markdown@^6.87.1",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@testing-library/jest-dom": "^6.4.2",
@@ -5037,10 +5037,11 @@
     },
     "node_modules/@readme/markdown-legacy": {
       "name": "@readme/markdown",
-      "version": "6.84.0",
-      "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-6.84.0.tgz",
-      "integrity": "sha512-Z0vq10bRruDT1KNrpDkTA/l5FGOBBkpTCfG4JOMYCPPJHV+h267NAFpCJbQsib+C1Gf1I/9zjbmTIRsE92//Bg==",
+      "version": "6.87.1",
+      "resolved": "https://registry.npmjs.org/@readme/markdown/-/markdown-6.87.1.tgz",
+      "integrity": "sha512-4wCCxdQU7YGCpF1a0BkOiiDZQs6Tv01s3OpDzI6fcHVj+zCdI2fOBfkHxokxDWi0cGzleuy8X/4nRUpV87DjVg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@readme/syntax-highlighter": "^13.0.0",
         "copy-to-clipboard": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@commitlint/config-angular": "^17.4.4",
     "@commitlint/config-conventional": "^17.4.4",
     "@readme/eslint-config": "^14.0.0",
-    "@readme/markdown-legacy": "npm:@readme/markdown@^6.84.0",
+    "@readme/markdown-legacy": "npm:@readme/markdown@^6.87.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@testing-library/jest-dom": "^6.4.2",

--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -40,6 +40,8 @@ const readmeToMdx = (): Transform => tree => {
 
   visit(tree, 'image', (image, index, parent) => {
     if (!('data' in image)) return;
+
+    if ('url' in image) image.data.hProperties.src = image.url;
     const attributes = toAttributes(image.data.hProperties, imageAttrs);
 
     if (hasExtra(attributes)) {


### PR DESCRIPTION
| 🎫 Fixes RM-10621 |
| :---------------: |

## 🧰 Changes

- [x] set `<Image[src]>` properly from magic blocks `url` field
- [x] update legacy RDMD to the latest pre-v7.x release

## 🧬 QA & Testing

Pull this branch down and try running [the new test in the `images.test.ts` file](https://github.com/readmeio/markdown/pull/952/files#diff-9b10647639421f1135101ae63ca87780ab63af9e81c8da0b00ea6d0ddd08b8b6R26-R50).
