### PR TITLE
chore: tabs component color

### DIFF
--- a/components/Tabs/style.scss
+++ b/components/Tabs/style.scss
@@ -18,8 +18,8 @@
     &_active {
       background: none;
       border: 0;
-      border-bottom: solid var(--blue, #118cfd);
-      color: var(--blue, #118cfd);
+      border-bottom: solid var(--project-color-primary, #384248);
+      color: var(--project-color-primary, #384248);
       font-size: 15px;
       font-weight: 600;
       margin-right: 15px;

--- a/components/Tabs/style.scss
+++ b/components/Tabs/style.scss
@@ -18,8 +18,8 @@
     &_active {
       background: none;
       border: 0;
-      border-bottom: solid var(--project-color-primary, #384248);
-      color: var(--project-color-primary, #384248);
+      border-bottom: solid var(--project-color-primary, var(--color-text-default, #384248));
+      color: var(--project-color-primary, var(--color-text-default, #384248));
       font-size: 15px;
       font-weight: 600;
       margin-right: 15px;


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes
- use project color primary for tabs

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
