### PR TITLE
fix: image compiling

### DIFF
--- a/__tests__/compilers/compatability.test.ts
+++ b/__tests__/compilers/compatability.test.ts
@@ -199,4 +199,12 @@ This is an image: <img src="http://example.com/#\\>" >
 
     expect(mdx(rdmd.mdast(md))).toBe(`Contact me at {user.email}\n`);
   });
+
+  it.only('compiles user variables', () => {
+    const md = `export const year = 2024;
+
+# Welcome to {year}
+`;
+    expect(mdx(rdmd.mdast(md))).toBe(`Contact me at {user.email}\n`);
+  });
 });

--- a/__tests__/compilers/compatability.test.ts
+++ b/__tests__/compilers/compatability.test.ts
@@ -199,12 +199,4 @@ This is an image: <img src="http://example.com/#\\>" >
 
     expect(mdx(rdmd.mdast(md))).toBe(`Contact me at {user.email}\n`);
   });
-
-  it.only('compiles user variables', () => {
-    const md = `export const year = 2024;
-
-# Welcome to {year}
-`;
-    expect(mdx(rdmd.mdast(md))).toBe(`Contact me at {user.email}\n`);
-  });
 });

--- a/__tests__/compilers/images.test.ts
+++ b/__tests__/compilers/images.test.ts
@@ -18,4 +18,10 @@ describe('image compiler', () => {
 
     expect(mdx(mdast(doc))).toMatch(doc);
   });
+
+  it('correctly serializes an Image component with expression attributes back to MDX', () => {
+    const doc = '<Image src="/path/to/image.png" border={false} />';
+
+    expect(mdx(mdast(doc))).toMatch(doc);
+  });
 });

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -1,6 +1,6 @@
-import { Node } from 'mdast';
-import { MdxJsxFlowElement, MdxJsxTextElement, MdxFlowExpression } from 'mdast-util-mdx';
-import {
+import type { Node } from 'mdast';
+import type { MdxJsxFlowElement, MdxJsxTextElement, MdxFlowExpression } from 'mdast-util-mdx';
+import type {
   MdxJsxAttribute,
   MdxJsxAttributeValueExpression,
   MdxJsxAttributeValueExpressionData,
@@ -158,6 +158,17 @@ export const toAttributes = (object: Record<string, any>, keys: string[] = []): 
     if (typeof v === 'string') {
       value = v;
     } else {
+      /* values can be null, undefined, string, or a expression, eg:
+       *
+       * ```
+       * <Image src="..." border={false} size={width - 20} />
+       * ```
+       *
+       * Parsing the expression seems to only be done by the library
+       * `mdast-util-mdx-jsx`, and so the most straight forward way to parse
+       * the expression and get the appropriate AST is with our `mdast`
+       * function.
+       */
       const proxy = mdast(`{${v}}`);
       const data = proxy.children[0].data as MdxJsxAttributeValueExpressionData;
 


### PR DESCRIPTION
| [![PR App][icn]][demo] | RM-10691 |
| :--------------------: | :------: |

## 🧰 Changes

Fixes compiling images.

The problem was our naive transformer that could not handle non string attributes. For instance, using a `false` value would crash the compiler:

```
<Image border={false} />
```

This updates the `toAttributes` method to create the valid AST.

## 🧬 QA & Testing

Do the tests pass?

You could test it locally like:

```
npm i && npm run build
node
> const rmdx = require('./')
> rmdx.mdx(rmdx.mdast('<Image border={false} />'))
```

But that's roughly the same as the tests?

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
