### PR TITLE
feat: pass through stringify options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ A module ([`RMDXModule`](#rmdxmodule)) of renderable components
 
 Compiles an ast to mdx.
 
+###### Parameters
+
+Extends [`remark-stringify` options](https://github.com/remarkjs/remark/tree/main/packages/remark-stringify#options).
+
+###### Returns
+
+An mdx string.
+
 #### `mdast`
 
 Parses mdx to an mdast.

--- a/lib/mdx.ts
+++ b/lib/mdx.ts
@@ -7,7 +7,7 @@ import remarkStringify from 'remark-stringify';
 import compilers from '../processor/compile';
 import { divTransformer, readmeToMdx, tablesToJsx } from '../processor/transform';
 
-export const mdx = (tree: any, { hast = false } = {}) => {
+export const mdx = (tree: any, { hast = false, ...opts } = {}) => {
   const processor = unified()
     .use(hast ? rehypeRemark : undefined)
     .use(remarkMdx)
@@ -16,7 +16,7 @@ export const mdx = (tree: any, { hast = false } = {}) => {
     .use(readmeToMdx)
     .use(tablesToJsx)
     .use(compilers)
-    .use(remarkStringify);
+    .use(remarkStringify, opts);
 
   return processor.stringify(processor.runSync(tree));
 };


### PR DESCRIPTION
[![PR App][icn]][demo] | RM-10779
:-------------------:|:----------:

## 🧰 Changes

Allows passing through options to `remark-stringify`. 

There are places in the main app where we'd like to be able control the formatting of mdx. 

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
