### PR TITLE
fix: frozen owlmoji

### DIFF
--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -42,8 +42,10 @@ const readmeToMdx = (): Transform => tree => {
   visit(tree, 'image', (image, index, parent) => {
     if (!('data' in image)) return;
 
-    if ('url' in image) image.data.hProperties.src = image.url;
-    const attributes = toAttributes(image.data.hProperties, imageAttrs);
+    const attributes = toAttributes(
+      { ...image.data.hProperties, ...('url' in image && { src: image.url }) },
+      imageAttrs,
+    );
 
     if (hasExtra(attributes)) {
       parent.children.splice(index, 1, {


### PR DESCRIPTION
[![PR App][icn]][demo] | Ref RM-10740
:-------------------:|:----------:

## 🧰 Changes

Fix loading owlmoji's.

The `ast` appears to be frozen, but I'm not sure where that's happening. The `image` doesn't strictly need the `src` on the `hProperties` since `rehype` will add it later, so this should be fine still.

## 🧬 QA & Testing

Not sure how to reproduce this yet.

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
