### PR TITLE
fix: compiling emoji

### DIFF
--- a/__tests__/compilers/gemoji.test.ts
+++ b/__tests__/compilers/gemoji.test.ts
@@ -6,4 +6,16 @@ describe('gemoji compiler', () => {
 
     expect(mdx(mdast(markdown)).trimEnd()).toEqual(markdown);
   });
+
+  it('should compile owlmoji back to a shortcode', () => {
+    const markdown = `:owlbert:`;
+
+    expect(mdx(mdast(markdown)).trimEnd()).toEqual(markdown);
+  });
+
+  it('should compile font-awsome emojis back to a shortcode', () => {
+    const markdown = `:fa-readme:`;
+
+    expect(mdx(mdast(markdown)).trimEnd()).toEqual(markdown);
+  });
 });

--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -45,7 +45,13 @@ const readmeToMdx = (): Transform => tree => {
     if ('url' in image) image.data.hProperties.src = image.url;
     const attributes = toAttributes(image.data.hProperties, imageAttrs);
 
-    if (hasExtra(attributes)) {
+    if (image.data.hProperties.className === 'emoji') {
+      parent.children.splice(index, 1, {
+        type: NodeTypes.emoji,
+        name: image.title.replace(/^:(.*):$/, '$1'),
+        value: image.title,
+      });
+    } else if (hasExtra(attributes)) {
       parent.children.splice(index, 1, {
         type: 'mdxJsxFlowElement',
         name: 'Image',


### PR DESCRIPTION
[![PR App][icn]][demo] | Ref RM-10740
:-------------------:|---

## 🧰 Changes

Compiles 'owlmoji' (:owlbert:) back to shortcodes.

I noticed while investigating frozen properties, that we weren't saving owlmoji's back to shortcodes.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
