### PR TITLE
fix: migrating callouts

### DIFF
--- a/__tests__/compilers/compatability.test.tsx
+++ b/__tests__/compilers/compatability.test.tsx
@@ -392,4 +392,20 @@ ${JSON.stringify(
       "
     `);
   });
+
+  it('compiles callouts without a title', () => {
+    const md = `
+> 🥈
+>
+> Lorem ipsum dolor sit amet consectetur adipisicing elit. Error eos animi obcaecati quod repudiandae aliquid nemo veritatis ex, quos delectus minus sit omnis vel dolores libero, recusandae ea dignissimos iure?
+`;
+
+    const rmdx = mdx(rdmd.mdast(md));
+    expect(rmdx).toMatchInlineSnapshot(`
+      "> 🥈
+      >
+      > Lorem ipsum dolor sit amet consectetur adipisicing elit. Error eos animi obcaecati quod repudiandae aliquid nemo veritatis ex, quos delectus minus sit omnis vel dolores libero, recusandae ea dignissimos iure?
+      "
+    `);
+  });
 });

--- a/processor/compile/callout.ts
+++ b/processor/compile/callout.ts
@@ -8,6 +8,11 @@ const callout = (node: Callout, _, state, info) => {
   tracker.move('> ');
   tracker.shift(2);
 
+  // @note: compatability
+  if (node.data.hProperties.title === '') {
+    node.children.unshift({ type: 'paragraph', children: [{ type: 'text', value: '' }] });
+  }
+
   const map = (line: string, index: number, blank: boolean) => {
     return `>${index === 0 ? ` ${node.data.hProperties.icon}` : ''}${blank ? '' : ' '}${line}`;
   };


### PR DESCRIPTION
[![PR App][icn]][demo] | Ref CX-1067
:-------------------:|:----------:

## 🧰 Changes

Fixes migrating callouts with no title.

I completely missed the fact that RDMD callouts use `title` and `value` for rendering. The new MDX transformers just use `children`. Oops!

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
