### PR TITLE
fix: tables with inline code with newlines

### DIFF
--- a/__tests__/compilers/compatability.test.tsx
+++ b/__tests__/compilers/compatability.test.tsx
@@ -409,4 +409,59 @@ ${JSON.stringify(
       "
     `);
   });
+
+  it.only('compiles tables with inline code with newlines', () => {
+    const md = `
+[block:parameters]
+${JSON.stringify(
+  {
+    data: {
+      'h-0': 'Field',
+      'h-1': 'Description',
+      '0-0': 'orderby',
+      '0-1': '`{\n "field": "ID",\n "type": "ASC"\n }`',
+    },
+    cols: 2,
+    rows: 1,
+    align: ['left', 'left'],
+  },
+  null,
+  2,
+)}
+[/block]
+    `;
+
+    const rmdx = mdx(rdmd.mdast(md));
+    expect(rmdx).toMatchInlineSnapshot(`
+      "<Table align={["left","left"]}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: "left" }}>
+              Field
+            </th>
+
+            <th style={{ textAlign: "left" }}>
+              Description
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td style={{ textAlign: "left" }}>
+              orderby
+            </td>
+
+            <td style={{ textAlign: "left" }}>
+              \`{
+               "field": "ID",
+               "type": "ASC"
+               }\`
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+      "
+    `);
+  });
 });

--- a/__tests__/compilers/compatability.test.tsx
+++ b/__tests__/compilers/compatability.test.tsx
@@ -410,7 +410,7 @@ ${JSON.stringify(
     `);
   });
 
-  it.only('compiles tables with inline code with newlines', () => {
+  it('compiles tables with inline code with newlines', () => {
     const md = `
 [block:parameters]
 ${JSON.stringify(

--- a/processor/transform/tables-to-jsx.ts
+++ b/processor/transform/tables-to-jsx.ts
@@ -1,4 +1,4 @@
-import { Node, Paragraph, Parents, Table, TableCell, Text } from 'mdast';
+import { Literal, Node, Paragraph, Parents, Table, TableCell, Text } from 'mdast';
 import { visit, EXIT } from 'unist-util-visit';
 import { Transform } from 'mdast-util-from-markdown';
 
@@ -18,6 +18,8 @@ const alignToStyle = (align: 'left' | 'center' | 'right' | null) => {
 };
 
 const isTableCell = (node: Node) => ['tableHead', 'tableCell'].includes(node.type);
+
+const isLiteral = (node: Node): node is Literal => 'value' in node;
 
 const visitor = (table: Table, index: number, parent: Parents) => {
   let hasFlowContent = false;
@@ -39,8 +41,8 @@ const visitor = (table: Table, index: number, parent: Parents) => {
       return EXIT;
     }
 
-    visit(cell, 'text', (text: Text) => {
-      if (text.value.match(/\n/)) {
+    visit(cell, isLiteral, (node: Literal) => {
+      if (node.value.match(/\n/)) {
         hasFlowContent = true;
         return EXIT;
       }


### PR DESCRIPTION
[![PR App][icn]][demo] | Ref RM-10616
:-------------------:|:----------:

## 🧰 Changes

Fixes migrating tables with inline code with newlines.

Our previous check for converting markdown tables to JSX only scanned text nodes. That would skip inline code and inline html. Uh oh.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
