### PR TITLE
fix: dont render markdown in toc

### DIFF
--- a/__tests__/plugins/toc.test.tsx
+++ b/__tests__/plugins/toc.test.tsx
@@ -46,4 +46,16 @@ describe('toc transformer', () => {
     expect(screen.findByText('Common Heading')).toBeDefined();
     expect(screen.findByText('Subheading')).toBeDefined();
   });
+
+  it.only('parses out a toc and only uses plain text', async () => {
+    const md = `
+# [Title](http://example.com)
+`;
+    const { Toc } = await run(compile(md));
+
+    render(<Toc />);
+
+    expect(screen.findByText('Title')).toBeDefined();
+    expect(screen.queryByText('[', { exact: false })).toBeNull();
+  });
 });

--- a/__tests__/plugins/toc.test.tsx
+++ b/__tests__/plugins/toc.test.tsx
@@ -47,7 +47,7 @@ describe('toc transformer', () => {
     expect(screen.findByText('Subheading')).toBeDefined();
   });
 
-  it.only('parses out a toc and only uses plain text', async () => {
+  it('parses out a toc and only uses plain text', async () => {
     const md = `
 # [Title](http://example.com)
 `;

--- a/processor/plugin/toc.ts
+++ b/processor/plugin/toc.ts
@@ -5,7 +5,7 @@ import { h } from 'hastscript';
 
 import { CustomComponents, HastHeading, IndexableElements, TocList, TocListItem } from '../../types';
 import { visit } from 'unist-util-visit';
-import { mdx } from '../../lib';
+import { mdx, plain } from '../../lib';
 
 interface Options {
   components?: Record<string, any>;
@@ -74,10 +74,13 @@ const tocToHast = (headings: HastHeading[] = []): TocList => {
       stack.pop();
     }
 
-    if (heading.properties)
+    if (heading.properties) {
+      const content = plain({ type: 'root', children: heading.children });
+
       stack[stack.length - 1].children.push(
-        h('li', null, h('a', { href: `#${heading.properties.id}` }, heading.children)) as TocListItem,
+        h('li', null, h('a', { href: `#${heading.properties.id}` }, content)) as TocListItem,
       );
+    }
   });
 
   return ast;

--- a/processor/plugin/toc.ts
+++ b/processor/plugin/toc.ts
@@ -75,7 +75,7 @@ const tocToHast = (headings: HastHeading[] = []): TocList => {
     }
 
     if (heading.properties) {
-      const content = plain({ type: 'root', children: heading.children });
+      const content = plain({ type: 'root', children: heading.children }) as string;
 
       stack[stack.length - 1].children.push(
         h('li', null, h('a', { href: `#${heading.properties.id}` }, content)) as TocListItem,


### PR DESCRIPTION
[![PR App][icn]][demo] | Ref RM-10928
:-------------------:|:----------:

## 🧰 Changes

Prevents rendering markdown in the ToC

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
