### PR TITLE
fix: fallback for 5

### DIFF
--- a/components/Callout/style.scss
+++ b/components/Callout/style.scss
@@ -102,7 +102,7 @@
 }
 @mixin calloutCustomIcons($R: callout) {
   --emoji: 1em;
-  --icon-font: var(--fa-style-family, 'Font Awesome 6 Pro');
+  --icon-font: var(--fa-style-family, 'Font Awesome 6 Pro', FontAwesome);
   &-icon {
     font-size: var(--emoji, 0);
     color: var(--icon-color, inherit) !important;


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

Using this CSS to replace emojis with Font Awesome:

```.callout[theme='📷'] {
  --emoji: unset;
  --icon: '\f030'; /* https://fontawesome.com/icons/camera?f=classic&s=solid */
  --icon-color: #c50a50;
}
```

This syntax:

```
> 📷 Cool pix!
>
> Vitae reprehenderit at aliquid error voluptates eum dignissimos.
```

Results in no icon:
![Markdown Demo-20241001-120459@2x](https://github.com/user-attachments/assets/6c81056c-ca62-402e-a33e-7f09d579f02f)


This happens because I removed the FontAwesome font name with Font Awesome 6 (which not merged in yet). This allows Font Awesome 4 to work as a fallback until we merge in 6.


## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
