### PR TITLE
fix: accordion toggle icon

### DIFF
--- a/components/Accordion/index.tsx
+++ b/components/Accordion/index.tsx
@@ -8,7 +8,7 @@ const Accordion = ({ children, icon, iconColor, title }) => {
   return (
     <details className="Accordion" onToggle={() => setIsOpen(!isOpen)}>
       <summary className="Accordion-title">
-        <i className={`Accordion-toggleIcon${isOpen ? '_opened' : ''} <i class="fa fa-regular fa-chevron-right"></i>`}></i>
+        <i className={`Accordion-toggleIcon${isOpen ? '_opened' : ''} fa fa-regular fa-chevron-right`}></i>
         {icon && <i className={`Accordion-icon fa-duotone fa-solid ${icon}`} style={{ color: `${iconColor}` }}></i>}
         {title}
       </summary>

--- a/components/Accordion/style.scss
+++ b/components/Accordion/style.scss
@@ -38,7 +38,7 @@
 
   &-toggleIcon,
   &-toggleIcon_opened {
-    color: var(--color-text-default, #384248);
+    color: var(--color-text-minimum, #637288);
     font-size: 14px;
     margin-left: 5px;
     margin-right: 10px;


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes
- Render accordion toggle fa icon correctly (reverted from this [change](https://github.com/readmeio/markdown/pull/969/files#diff-909b2e4084c67e1c9a9d120d5421457bc8d4bd0d822396205a76e4eff3439841))
 
<img width="400" alt="image" src="https://github.com/user-attachments/assets/de9c59ad-a041-44a7-9ac8-30c2032256ab">


## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
