### PR TITLE
fix: better tag handling

### DIFF
--- a/__tests__/compilers/compatability.test.tsx
+++ b/__tests__/compilers/compatability.test.tsx
@@ -504,4 +504,14 @@ ${JSON.stringify(
       "
     `);
   });
+
+  it('compiles tag-like syntax', () => {
+    const md = `Inline: <what even is this>`;
+
+    const rmdx = mdx(rdmd.mdast(md));
+    expect(rmdx).toMatchInlineSnapshot(`
+      "Inline: <what even is this>
+      "
+    `);
+  });
 });

--- a/__tests__/compilers/compatability.test.tsx
+++ b/__tests__/compilers/compatability.test.tsx
@@ -332,7 +332,6 @@ This is an image: <img src="http://example.com/#\\>" >
     `);
   });
 
-
   it('correctly parses and transforms image magic block with legacy data', () => {
     const md = `
 [block:image]
@@ -492,6 +491,16 @@ ${JSON.stringify(
           </tr>
         </tbody>
       </Table>
+      "
+    `);
+  });
+
+  it('compiles inline html', () => {
+    const md = `Inline html: <small>_string_</small>`;
+
+    const rmdx = mdx(rdmd.mdast(md));
+    expect(rmdx).toMatchInlineSnapshot(`
+      "Inline html: <small>*string*</small>
       "
     `);
   });

--- a/processor/compile/compatibility.ts
+++ b/processor/compile/compatibility.ts
@@ -79,7 +79,16 @@ const compatibility = (node: CompatNodes) => {
     case NodeTypes.reusableContent:
       return `<${node.tag} />`;
     case 'html':
-      return html(node);
+      // @note: We can't do anything about inline spans. remark only parses the
+      // tags as html, so we can't tell where the html starts or stops. But, we
+      // can still fix void nodes and comments.
+      //
+      // @ts-expect-error
+      return node.block ||
+        node.value.match(/<!--.*-->/) ||
+        node.value.match(/<(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\b/)
+        ? html(node)
+        : node.value;
     case 'escape':
       return `\\${node.value}`;
     case 'figure':

--- a/processor/compile/compatibility.ts
+++ b/processor/compile/compatibility.ts
@@ -85,7 +85,7 @@ const compatibility = (node: CompatNodes) => {
       //
       // @ts-expect-error
       return node.block ||
-        node.value.match(/<!--.*-->/) ||
+        node.value.match(/<!--.*-->/s) ||
         node.value.match(/<(area|base|br|col|embed|hr|img|input|link|meta|param|source|track|wbr)\b/)
         ? html(node)
         : node.value;


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

Don't attempt to migrate inline html tags.

1. `remark` only parses the tags, so something like:
  ```
  <span>OH no!</span>
  ```
  becomes:
  ```
  <span />OH no!<span />
  ```

2. This will prevent migrating custom inline tags as a side effect.

## 🧬 QA & Testing

This shouldn't effect production code directly, only the migration. I think it's best to test directly in the migration?

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
