### PR TITLE
fix: externalize mermaid

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,6 +84,7 @@ const browserConfig = merge(getConfig({ target: 'web' }), {
   externals: {
     '@readme/variable': '@readme/variable',
     '@tippyjs/react': '@tippyjs/react',
+    mermaid: 'mermaid',
     react: {
       amd: 'react',
       commonjs: 'react',


### PR DESCRIPTION
[![PR App][icn]][demo] |
:-------------------:|

## 🧰 Changes

Configures webpack to externalize `mermaid`

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
