### PR TITLE
fix: migrate tables with html

### DIFF
--- a/__tests__/migration/tables.test.ts
+++ b/__tests__/migration/tables.test.ts
@@ -214,6 +214,36 @@ ${JSON.stringify(
     `);
   });
 
+  it('compiles tables with html', () => {
+    const md = `
+| Teléfono                                                           |
+| ------------------------------------------------------------------ |
+| <p>¿Necesitas ayuda?</p><p>‍</p><p>Llámanos al +52 33 11224455</p> |
+      `;
+    const mdx = rmdx.mdx(rmdx.mdastV6(md));
+
+    expect(mdx).toMatchInlineSnapshot(`
+      "<Table>
+        <thead>
+          <tr>
+            <th>
+              Teléfono
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td>
+              <p>¿Necesitas ayuda?</p><p>‍</p><p>Llámanos al +52 33 11224455</p>
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+      "
+    `);
+  });
+
   it('does not muck with regular emphasis in tables', () => {
     const md = `
 [block:parameters]

--- a/processor/migration/table-cell.ts
+++ b/processor/migration/table-cell.ts
@@ -5,6 +5,7 @@ import * as rdmd from '@readme/markdown-legacy';
 import { visit, SKIP } from 'unist-util-visit';
 
 const magicIndex = (i: number, j: number) => `${i === 0 ? 'h' : `${i - 1}`}-${j}`;
+const isInlineHtml = (node: $TSFixMe) => node.type === 'html' && !node.block;
 
 // @note: This regex is detect malformed lists that were created by the
 // markdown editor. Consider the following markdown:
@@ -62,8 +63,10 @@ const migrateTableCells = (vfile: VFile) => (table: Table) => {
         children = rdmd.mdast(string).children;
       }
 
-      // eslint-disable-next-line no-param-reassign
-      cell.children = children.length > 1 ? children : [{ type: 'paragraph', children } as PhrasingContent];
+      cell.children =
+        children.length > 1 && !children.some(isInlineHtml)
+          ? children
+          : ([{ type: 'paragraph', children }] as PhrasingContent[]);
 
       return SKIP;
     });

--- a/processor/migration/table-cell.ts
+++ b/processor/migration/table-cell.ts
@@ -5,7 +5,7 @@ import * as rdmd from '@readme/markdown-legacy';
 import { visit, SKIP } from 'unist-util-visit';
 
 const magicIndex = (i: number, j: number) => `${i === 0 ? 'h' : `${i - 1}`}-${j}`;
-const isInlineHtml = (node: $TSFixMe) => node.type === 'html' && !node.block;
+const isInlineHtml = node => node.type === 'html' && !node.block;
 
 // @note: This regex is detect malformed lists that were created by the
 // markdown editor. Consider the following markdown:


### PR DESCRIPTION
[![PR App][icn]][demo] | CX-1192
:-------------------:|:----------:

## 🧰 Changes

Fixes migrating tables with html.

We're doing some shenanigans with table cells so that they support block content. We basically reparse each cell as if it's a root markdown doc and then re-insert it into the tree.

This adds block level html as a condition for wrapping said content in a paragraph. Wrapping it in a paragraph seems to be required to get remark to compile newlines correctly. :shrug:


## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
