### PR TITLE
fix: bold in tables

### DIFF
--- a/__tests__/migration/tables.test.ts
+++ b/__tests__/migration/tables.test.ts
@@ -334,4 +334,71 @@ ${JSON.stringify(
       "
     `);
   });
+
+  it('compiles tables with emphasis without converting them to lists', () => {
+    const md = `
+[block:parameters]
+{
+  "data": {
+    "h-0": "**Shortcut Name**",
+    "h-1": "**WindowsOS**",
+    "h-2": "_Apple - macOS_",
+    "0-0": "*Cut selection*",
+    "0-1": "__also__\\n\\n_no!_\\n\\n__no no no__",
+    "0-2": "!BAD"
+  },
+  "cols": 3,
+  "rows": 1,
+  "align": [
+    "left",
+    "left",
+    "left"
+  ]
+}
+[/block]
+    `;
+
+    const mdx = rmdx.mdx(rmdx.mdastV6(md));
+
+    expect(mdx).toMatchInlineSnapshot(`
+      "<Table align={["left","left","left"]}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: "left" }}>
+              **Shortcut Name**
+            </th>
+
+            <th style={{ textAlign: "left" }}>
+              **WindowsOS**
+            </th>
+
+            <th style={{ textAlign: "left" }}>
+              *Apple - macOS*
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td style={{ textAlign: "left" }}>
+              *Cut selection*
+            </td>
+
+            <td style={{ textAlign: "left" }}>
+              **also**
+
+              *no!*
+
+              **no no no**
+            </td>
+
+            <td style={{ textAlign: "left" }}>
+              !BAD
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+      "
+    `);
+  });
 });

--- a/__tests__/migration/tables.test.ts
+++ b/__tests__/migration/tables.test.ts
@@ -401,4 +401,61 @@ ${JSON.stringify(
       "
     `);
   });
+
+  it('compiles more examples of emphasis', () => {
+    const md = `
+    [block:parameters]
+{
+  "data": {
+    "h-0": "Action",
+    "h-1": "Description",
+    "0-0": "Details",
+    "0-1": "View additional details such as:  \\n_Type_  \\n_Owner_  \\n_Created On_  \\n_Last Modified_  \\n_Last Run_"
+  },
+  "cols": 2,
+  "rows": 1,
+  "align": [
+    "left",
+    "left"
+  ]
+}
+[/block]
+    `;
+
+    const mdx = rmdx.mdx(rmdx.mdastV6(md));
+
+    expect(mdx).toMatchInlineSnapshot(`
+      "<Table align={["left","left"]}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: "left" }}>
+              Action
+            </th>
+
+            <th style={{ textAlign: "left" }}>
+              Description
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          <tr>
+            <td style={{ textAlign: "left" }}>
+              Details
+            </td>
+
+            <td style={{ textAlign: "left" }}>
+              View additional details such as:\\
+              *Type*\\
+              *Owner*\\
+              *Created On*\\
+              *Last Modified*\\
+              *Last Run*
+            </td>
+          </tr>
+        </tbody>
+      </Table>
+      "
+    `);
+  });
 });

--- a/processor/migration/table-cell.ts
+++ b/processor/migration/table-cell.ts
@@ -27,7 +27,7 @@ const magicIndex = (i: number, j: number) => `${i === 0 ? 'h' : `${i - 1}`}-${j}
 //
 // The following regex attempts to detect this pattern, and we'll convert it to
 // something more standard.
-const psuedoListRegex = /^(?!([*_]+).*\1$)(?<ws>[ \t]*)\\?([*_])\s*(?<item>.*)$/gm;
+const psuedoListRegex = /^(?![ \t]*([*_]+).*\1[ \t]*$)(?<ws>[ \t]*)\\?([*_])\s*(?<item>.*)$/gm;
 
 const migrateTableCells = (vfile: VFile) => (table: Table) => {
   let json;


### PR DESCRIPTION
[![PR App][icn]][demo] | CX-1153
:-------------------:|:----------:

## 🧰 Changes

Fixes a regression when migrating tables with emphasis.

The context for this is a bit long, but here's a summary:

1. magic block tables permitted block content
2. gfm tables did not
3. we dropped support for block content because the magic block implementation was problematic
4. users really want block content in tables, so we allowed breaks, `\n`
5. somewhere a long the line, the editor mucked up list like syntax in tables
6. I added a regex to look for that instance and correct it for the migration
7. that regex was not careful enough, and started matching emphasis
8. this PR fixes that to better not-match emphasis

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
