### PR TITLE
fix: emphasis with links

### DIFF
--- a/__tests__/migration/emphasis.test.ts
+++ b/__tests__/migration/emphasis.test.ts
@@ -23,11 +23,11 @@ describe('migrating emphasis', () => {
 
   it('migrates a complex case', () => {
     const md =
-      '*the recommended initial action is to**initiate a[reversal operation (rollback)](https://docs.jupico.com/reference/ccrollback)**. *';
+      '*the recommended initial action is to**initiate a [reversal operation (rollback)](https://docs.jupico.com/reference/ccrollback) test**. *';
 
     const mdx = rmdx.mdx(rmdx.mdastV6(md));
     expect(mdx).toMatchInlineSnapshot(`
-      "*the recommended initial action is to**initiate a[reversal operation (rollback)](https://docs.jupico.com/reference/ccrollback)**.*
+      "*the recommended initial action is to**initiate a [reversal operation (rollback)](https://docs.jupico.com/reference/ccrollback) test**.*
       "
     `);
   });


### PR DESCRIPTION
[![PR App][icn]][demo] | Ref CX-1238
:-------------------:|:----------:

## 🧰 Changes

Fixes emphasis with links in it.

The original implementation of this was naively assuming there would only be one child node. Ope.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
