### PR TITLE
fix: removing our dependency on `trim`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "remark-gfm": "^4.0.0",
         "remark-mdx": "^3.0.0",
         "remark-parse": "^11.0.0",
-        "trim": "^1.0.1",
         "unified": "^11.0.4",
         "unist-util-flatmap": "^1.0.0",
         "unist-util-visit": "^5.0.0",
@@ -32091,12 +32090,6 @@
       "bin": {
         "tree-kill": "cli.js"
       }
-    },
-    "node_modules/trim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-1.0.1.tgz",
-      "integrity": "sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w==",
-      "deprecated": "Use String.prototype.trim() instead"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "remark-gfm": "^4.0.0",
     "remark-mdx": "^3.0.0",
     "remark-parse": "^11.0.0",
-    "trim": "^1.0.1",
     "unified": "^11.0.4",
     "unist-util-flatmap": "^1.0.0",
     "unist-util-visit": "^5.0.0",


### PR DESCRIPTION
[![PR App][icn]][demo] |
:-------------------:|

## 🧰 Changes

Installing the markdown package throws these warnings from NPM for the `trim` package:

```
npm warn deprecated trim@1.0.1: Use String.prototype.trim() instead
npm warn deprecated trim@0.0.1: Use String.prototype.trim() instead
npm warn deprecated trim@0.0.1: Use String.prototype.trim() instead
```

It seems that we're no longer using `trim` anymore(?) so I'm removing it from being a dependency.

##### Before

```
> npm ls trim
@readme/markdown@7.9.0
├─┬ @readme/markdown-legacy@npm:@readme/markdown@6.87.1
│ └─┬ remark-parse@8.0.3
│   └── trim@0.0.1
└── trim@1.0.1
```

##### After

```
@readme/markdown@7.9.0
└─┬ @readme/markdown-legacy@npm:@readme/markdown@6.87.1
  └─┬ remark-parse@8.0.3
    └── trim@0.0.1
```

## 🧬 QA & Testing

All tests were still passing and the dist still gets built fine with `npm run build`.


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
