### PR TITLE
fix: dont externalize mermaid

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,9 +119,6 @@ const serverConfig = merge(getConfig({ target: 'node' }), {
     filename: '[name].node.js',
   },
   externals: {
-    '@readme/variable': '@readme/variable',
-    '@tippyjs/react': '@tippyjs/react',
-    mermaid: 'mermaid',
     react: {
       amd: 'react',
       commonjs: 'react',


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

Don't externalize `mermaid` for the node build.

In `mdx-renderer` it's dynamically imported, so it doesn't usually get executed. If we externalize it, we either have to specifically include it in the execution environment, or configure rollup to inline it. The former is an unnecessary hassle, and the latter appears to execute the code immediatelly and slow down the build. So lets go back to bundling it, but dynamically importing it.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
