### PR TITLE
fix: allow spaces in variables

### DIFF
--- a/__tests__/lib/mdast/variables/in.mdx
+++ b/__tests__/lib/mdast/variables/in.mdx
@@ -1,1 +1,1 @@
-Hello, {user.name}
+Hello, { user.name }

--- a/__tests__/lib/mdast/variables/out.json
+++ b/__tests__/lib/mdast/variables/out.json
@@ -38,7 +38,7 @@
             }
           },
           "type": "readme-variable",
-          "value": "{user.name}"
+          "value": "{ user.name }"
         }
       ],
       "position": {

--- a/processor/transform/variables.ts
+++ b/processor/transform/variables.ts
@@ -12,7 +12,7 @@ const variables =
     visit(tree, (node, index, parent) => {
       if (!['mdxFlowExpression', 'mdxTextExpression'].includes(node.type) || !('value' in node)) return;
 
-      const match = node.value.match(/^user\.(?<value>.*)$/);
+      const match = node.value.match(/^\s*user\.(?<value>\S*)\s*$/);
       if (!match) return;
 
       let variable = asMdx


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

Allos spaces in user variables.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
