### PR TITLE
feat: global vars

### DIFF
--- a/__tests__/variables/index.test.tsx
+++ b/__tests__/variables/index.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { execute } from '../helpers';
+
+describe('variables', () => {
+  it('renders a variable', async () => {
+    const md = `{user.name}`;
+    const Content = await execute(md, {}, { variables: { user: { name: 'Testing' } } });
+
+    render(<Content />);
+
+    expect(screen.getByText('Testing')).toBeVisible();
+  });
+
+  it('renders a default value', async () => {
+    const md = `{user.name}`;
+    const Content = await execute(md);
+
+    render(<Content />);
+
+    expect(screen.getByText('NAME')).toBeVisible();
+  });
+
+  it('supports user variables in ESM', async () => {
+    const md = `
+export const Hello = () => <p>{user.name}</p>;
+
+<Hello />
+`;
+    const Content = await execute(md, {}, { variables: { user: { name: 'Owlbert' } } });
+
+    render(<Content />);
+
+    expect(screen.getByText('Owlbert')).toBeVisible();
+  });
+});

--- a/contexts/index.tsx
+++ b/contexts/index.tsx
@@ -1,22 +1,16 @@
 import React from 'react';
 import GlossaryContext from './GlossaryTerms';
 import BaseUrlContext from './BaseUrl';
-import { VariablesContext } from '@readme/variable';
 import { RunOpts } from '../lib/run';
 
-type Props = React.PropsWithChildren & Pick<RunOpts, 'baseUrl' | 'terms' | 'variables'>;
+type Props = React.PropsWithChildren & Pick<RunOpts, 'baseUrl' | 'terms'>;
 
-const compose = (
-  children: React.ReactNode,
-  ...contexts: [React.Context<typeof VariablesContext | typeof GlossaryContext>, unknown][]
-) => {
-  return contexts.reduce((content, [Context, value]) => {
-    return <Context.Provider value={value}>{content}</Context.Provider>;
-  }, children);
-};
-
-const Contexts = ({ children, terms = [], variables = { user: {}, defaults: [] }, baseUrl = '/' }: Props) => {
-  return compose(children, [GlossaryContext, terms], [VariablesContext, variables], [BaseUrlContext, baseUrl]);
+const Contexts = ({ children, terms = [], baseUrl = '/' }: Props) => {
+  return (
+    <GlossaryContext.Provider value={terms}>
+      <BaseUrlContext.Provider value={baseUrl}>{children}</BaseUrlContext.Provider>
+    </GlossaryContext.Provider>
+  );
 };
 
 export default Contexts;

--- a/contexts/index.tsx
+++ b/contexts/index.tsx
@@ -1,16 +1,22 @@
 import React from 'react';
 import GlossaryContext from './GlossaryTerms';
 import BaseUrlContext from './BaseUrl';
+import { VariablesContext } from '@readme/variable';
 import { RunOpts } from '../lib/run';
 
-type Props = React.PropsWithChildren & Pick<RunOpts, 'baseUrl' | 'terms'>;
+type Props = React.PropsWithChildren & Pick<RunOpts, 'baseUrl' | 'terms' | 'variables'>;
 
-const Contexts = ({ children, terms = [], baseUrl = '/' }: Props) => {
-  return (
-    <GlossaryContext.Provider value={terms}>
-      <BaseUrlContext.Provider value={baseUrl}>{children}</BaseUrlContext.Provider>
-    </GlossaryContext.Provider>
-  );
+const compose = (
+  children: React.ReactNode,
+  ...contexts: [React.Context<typeof VariablesContext | typeof GlossaryContext>, unknown][]
+) => {
+  return contexts.reduce((content, [Context, value]) => {
+    return <Context.Provider value={value}>{content}</Context.Provider>;
+  }, children);
+};
+
+const Contexts = ({ children, terms = [], variables = { user: {}, defaults: [] }, baseUrl = '/' }: Props) => {
+  return compose(children, [GlossaryContext, terms], [VariablesContext, variables], [BaseUrlContext, baseUrl]);
 };
 
 export default Contexts;

--- a/lib/compile.ts
+++ b/lib/compile.ts
@@ -31,12 +31,9 @@ const compile = (text: string, { components, copyButtons, ...opts }: CompileOpts
       ...opts,
     });
 
-    return (
-      String(vfile).replace(
-        /await import\(_resolveDynamicMdxSpecifier\(('react'|"react")\)\)/,
-        'arguments[0].imports.React',
-      ).replace('"use strict";', '"use strict";\nconst { user } = arguments[0].imports;'),
-    );
+    return String(vfile)
+      .replace(/await import\(_resolveDynamicMdxSpecifier\(('react'|"react")\)\)/, 'arguments[0].imports.React')
+      .replace('"use strict";', '"use strict";\nconst { user } = arguments[0].imports;');
   } catch (error) {
     throw error.line ? new MdxSyntaxError(error, text) : error;
   }

--- a/lib/compile.ts
+++ b/lib/compile.ts
@@ -26,15 +26,16 @@ const compile = (text: string, { components, copyButtons, ...opts }: CompileOpts
         remarkGfm,
         ...Object.values(transforms),
         [codeTabsTransformer, { copyButtons }],
-        variablesTransformer,
       ],
       rehypePlugins: [...rehypePlugins, [rehypeToc, { components }]],
       ...opts,
     });
 
-    return String(vfile).replace(
-      /await import\(_resolveDynamicMdxSpecifier\(('react'|"react")\)\)/,
-      'arguments[0].imports.React',
+    return (
+      String(vfile).replace(
+        /await import\(_resolveDynamicMdxSpecifier\(('react'|"react")\)\)/,
+        'arguments[0].imports.React',
+      ).replace('"use strict";', '"use strict";\nconst { user } = arguments[0].imports;'),
     );
   } catch (error) {
     throw error.line ? new MdxSyntaxError(error, text) : error;

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -72,7 +72,7 @@ const run = async (string: string, _opts: RunOpts = {}) => {
 
   return {
     default: () => (
-      <Contexts terms={terms} baseUrl={baseUrl}>
+      <Contexts terms={terms} baseUrl={baseUrl} variables={variables}>
         <Content />
       </Contexts>
     ),

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -11,11 +11,7 @@ import { Depth } from '../components/Heading';
 import { tocToMdx } from '../processor/plugin/toc';
 import compile from './compile';
 import { CustomComponents, RMDXModule } from '../types';
-
-interface Variables {
-  user: Record<string, string>;
-  defaults: { name: string; default: string }[];
-}
+import User, { Variables } from '../utils/user';
 
 export type RunOpts = Omit<RunOptions, 'Fragment'> & {
   components?: CustomComponents;
@@ -63,7 +59,7 @@ const run = async (string: string, _opts: RunOpts = {}) => {
       ...runtime,
       Fragment,
       baseUrl: import.meta.url,
-      imports: { React },
+      imports: { React, user: User(variables) },
       useMDXComponents,
       ...opts,
     }) as Promise<RMDXModule>;
@@ -76,7 +72,7 @@ const run = async (string: string, _opts: RunOpts = {}) => {
 
   return {
     default: () => (
-      <Contexts terms={terms} variables={variables} baseUrl={baseUrl}>
+      <Contexts terms={terms} baseUrl={baseUrl}>
         <Content />
       </Contexts>
     ),

--- a/utils/user.ts
+++ b/utils/user.ts
@@ -1,0 +1,31 @@
+interface Default {
+  name: string;
+  default: string;
+}
+
+export interface Variables {
+  user: Record<string, string>;
+  defaults: Default[];
+}
+
+const User = (variables?: Variables) => {
+  const { user = {}, defaults = [] } = variables || {};
+
+  return new Proxy(user, {
+    get(target, attribute) {
+      if (typeof attribute === 'symbol') {
+        return '';
+      }
+
+      if (attribute in target) {
+        return target[attribute];
+      }
+
+      const def = defaults.find((d: Default) => d.name === attribute);
+
+      return def ? def.default : attribute.toUpperCase();
+    },
+  });
+};
+
+export default User;


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-11562
:-------------------:|:----------:

## 🧰 Changes

Allows user variables in esm code.

Prior to this, user variables (eg `{user.email}`) were being replaced with a JSX component (`<Variable name="email" />`) opaquely. The actual values were provided by the `VariableContext`. This mimiced how they were handled in pre-mdx versions of the library. This PR undoes that, and provides the `user` object as a top level import. The following was not possible before, but is possible now:
```
export const HelloWorld = () => {
  return <div>{user.email}</div>
}
```

We had talked about implementing it this way, and I somehow ignored/forgot that. Oops.

***

The `VariableContext` is still being used, because our custom wrapper around code blocks will also insert the `user` object into the scope of the code block. eg:
~~~
```
Why do we support this? {user.email}
```
~~~

Also, I've left the variable transformer `processor/transform/variable` in place, because it's still being used by the editor. When calling `mdast`, user variables such as `{user.email}` should show up as a `readme-variable` node type.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
