### PR TITLE
fix: dont treat escapes as flow

### DIFF
--- a/__tests__/migration/tables.test.ts
+++ b/__tests__/migration/tables.test.ts
@@ -486,4 +486,21 @@ ${JSON.stringify(
       "
     `);
   });
+
+  it('compiles tables with leading escapes', () => {
+    const md = `
+| Col 1     | Col 2 |
+| --------- | ----- |
+| \\_foo_\\ | bar   |
+`;
+
+    const mdx = migrate(md);
+
+    expect(mdx).toMatchInlineSnapshot(`
+      "| Col 1     | Col 2 |
+      | --------- | ----- |
+      | \\_foo\\_\\  | bar   |
+      "
+    `);
+  });
 });

--- a/processor/migration/index.ts
+++ b/processor/migration/index.ts
@@ -3,12 +3,6 @@ import imagesTransformer from './images';
 import linkReferenceTransformer from './linkReference';
 import tableCellTransformer from './table-cell';
 
-const transformers = [
-  emphasisTransformer,
-  imagesTransformer,
-  linkReferenceTransformer,
-  tableCellTransformer,
-];
+const transformers = [emphasisTransformer, imagesTransformer, linkReferenceTransformer, tableCellTransformer];
 
-export default transformers
-
+export default transformers;

--- a/processor/transform/tables-to-jsx.ts
+++ b/processor/transform/tables-to-jsx.ts
@@ -36,7 +36,7 @@ const visitor = (table: Table, index: number, parent: Parents) => {
       parent.children.splice(index, 1, { type: 'text', value: '\n' });
     });
 
-    if (!phrasing(content)) {
+    if (!phrasing(content) && content.type !== 'escape') {
       hasFlowContent = true;
       return EXIT;
     }


### PR DESCRIPTION
[![PR App][icn]][demo] | Ref CX-1610
:-------------------:|:----------:

## 🧰 Changes

Fixes migrating tables with leading escapes.

The `phrasing` util is not aware of the `escape` node type, as it is from a previous version of `mdast`. This was confusing our `tables-to-jsx` transformer. It would look at tables and decide if it could be compiled to markdown format, eg:
```
| a | b |
|---|---|
| 1 | 2 |
```
or if it should be compiled to JSX format, eg:
```jsx
<Table>
  <TableHead>
    <TableRow>
      <TableCell>a</TableCell>
      <TableCell>b</TableCell>
    </TableRow>
  </TableHead>
  <TableBody>
    <TableRow>
      <TableCell>1</TableCell>
      <TableCell>2</TableCell>
    </TableRow>
  </TableBody>
</Table>
```

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
