### PR TITLE
fix: pass through props

### DIFF
--- a/__tests__/custom-components/index.test.tsx
+++ b/__tests__/custom-components/index.test.tsx
@@ -37,4 +37,13 @@ export const Second = () => <div>Second</div>;
     expect(screen.getByText('First')).toBeVisible();
     expect(screen.getByText('Second')).toBeVisible();
   });
+
+  it('renders the default export of a custom component and passes through props', async () => {
+    const Test = await execute(`{props.attr}`, {}, {}, { getDefault: true });
+    const doc = `<Test attr="Hello" />`;
+    const Page = await execute(doc, undefined, { components: { Test } });
+    render(<Page />);
+
+    expect(screen.getByText('Hello')).toBeVisible();
+  });
 });

--- a/__tests__/custom-components/index.test.tsx
+++ b/__tests__/custom-components/index.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { render, screen } from '@testing-library/react';
 import { execute } from '../helpers';
+import { compile, run } from '../../lib';
+import { RMDXModule } from '../../types';
 
 describe('Custom Components', async () => {
   const Example = await execute(`It works!`, {}, {}, { getDefault: false });
@@ -39,10 +41,10 @@ export const Second = () => <div>Second</div>;
   });
 
   it('renders the default export of a custom component and passes through props', async () => {
-    const Test = await execute(`{props.attr}`, {}, {}, { getDefault: true });
+    const Test = (await run(await compile(`{props.attr}`))) as RMDXModule;
     const doc = `<Test attr="Hello" />`;
-    const Page = await execute(doc, undefined, { components: { Test } });
-    render(<Page />);
+    const Page = await run(await compile(doc), { components: { Test } });
+    render(<Page.default />);
 
     expect(screen.getByText('Hello')).toBeVisible();
   });

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -86,17 +86,17 @@ const run = async (string: string, _opts: RunOpts = {}) => {
   }
 
   return {
-    default: () => (
+    default: props => (
       <Contexts terms={terms} baseUrl={baseUrl} variables={variables}>
         <Components.Style stylesheet={stylesheet} />
-        <Content />
+        <Content {...props} />
       </Contexts>
     ),
     toc,
-    Toc: () =>
+    Toc: props =>
       Toc ? (
         <Components.TableOfContents>
-          <Toc />
+          <Toc {...props} />
         </Components.TableOfContents>
       ) : null,
     stylesheet,


### PR DESCRIPTION
| [![PR App][icn]][demo] | Ref RM-11968 |
| :--------------------: | :-: |

## 🧰 Changes

Passes through props to the default components.

Prior to this, we were ignoring any props that we're being passed to the default exports, oops!

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
