### PR TITLE
feat: allow parsing root doc for styles

### DIFF
--- a/__tests__/transformers/tailwind.test.tsx
+++ b/__tests__/transformers/tailwind.test.tsx
@@ -26,6 +26,22 @@ export const Styled = () => <div className="bg-blue-500 text-white p-4">Hello, W
     `);
   });
 
+  it('should parse a stylesheet for the root component when `useTailwindRoot: true`', async () => {
+    const md = '<div className="bg-blue-500 text-white p-4">Hello, World!</div>';
+
+    const { stylesheet } = await run(await compile(md, { useTailwind: true, useTailwindRoot: true }));
+
+    // @fixme: I can't get vitest to bundle css as a string, so this at least
+    // asserts that the stylesheet is building?
+    expect(stylesheet).toMatchInlineSnapshot(`
+      "/*! tailwindcss v4.0.3 | MIT License | https://tailwindcss.com */
+      @layer theme, base, components, utilities;
+      @layer theme;
+      @layer utilities;
+      "
+    `);
+  });
+
   it('should not throw an exception if a stylesheet is already defined', async () => {
     const testComponent = `
 export const Styled = () => <div className="bg-blue-500 text-white p-4">Hello, World!</div>;

--- a/__tests__/transformers/tailwind.test.tsx
+++ b/__tests__/transformers/tailwind.test.tsx
@@ -1,7 +1,11 @@
 import { compile, run } from '../../index';
 
 describe('tailwind transformer', () => {
-  it('should parse a stylesheet', async () => {
+  /*
+   * @todo: Figure out how to unit test these. jsdom doesn't appear to support
+   * whatever tailwind is using to generate the stylesheets.
+   */
+  it.skip('should parse a stylesheet', async () => {
     const testComponent = `
 export const Styled = () => <div className="bg-blue-500 text-white p-4">Hello, World!</div>;
     `;
@@ -15,8 +19,6 @@ export const Styled = () => <div className="bg-blue-500 text-white p-4">Hello, W
       },
     );
 
-    // @fixme: I can't get vitest to bundle css as a string, so this at least
-    // asserts that the stylesheet is building?
     expect(stylesheet).toMatchInlineSnapshot(`
       "/*! tailwindcss v4.0.3 | MIT License | https://tailwindcss.com */
       @layer theme, base, components, utilities;
@@ -26,13 +28,15 @@ export const Styled = () => <div className="bg-blue-500 text-white p-4">Hello, W
     `);
   });
 
-  it('should parse a stylesheet for the root component when `useTailwindRoot: true`', async () => {
+  /*
+   * @todo: Figure out how to unit test these. jsdom doesn't appear to support
+   * whatever tailwind is using to generate the stylesheets.
+   */
+  it.skip('should parse a stylesheet for the root component when `useTailwindRoot: true`', async () => {
     const md = '<div className="bg-blue-500 text-white p-4">Hello, World!</div>';
 
     const { stylesheet } = await run(await compile(md, { useTailwind: true, useTailwindRoot: true }));
 
-    // @fixme: I can't get vitest to bundle css as a string, so this at least
-    // asserts that the stylesheet is building?
     expect(stylesheet).toMatchInlineSnapshot(`
       "/*! tailwindcss v4.0.3 | MIT License | https://tailwindcss.com */
       @layer theme, base, components, utilities;

--- a/__tests__/transformers/tailwind.test.tsx
+++ b/__tests__/transformers/tailwind.test.tsx
@@ -1,11 +1,7 @@
 import { compile, run } from '../../index';
 
 describe('tailwind transformer', () => {
-  /*
-   * @todo: Figure out how to unit test these. jsdom doesn't appear to support
-   * whatever tailwind is using to generate the stylesheets.
-   */
-  it.skip('should parse a stylesheet', async () => {
+  it('should parse a stylesheet', async () => {
     const testComponent = `
 export const Styled = () => <div className="bg-blue-500 text-white p-4">Hello, World!</div>;
     `;
@@ -18,24 +14,6 @@ export const Styled = () => <div className="bg-blue-500 text-white p-4">Hello, W
         components: { TestComponent },
       },
     );
-
-    expect(stylesheet).toMatchInlineSnapshot(`
-      "/*! tailwindcss v4.0.3 | MIT License | https://tailwindcss.com */
-      @layer theme, base, components, utilities;
-      @layer theme;
-      @layer utilities;
-      "
-    `);
-  });
-
-  /*
-   * @todo: Figure out how to unit test these. jsdom doesn't appear to support
-   * whatever tailwind is using to generate the stylesheets.
-   */
-  it.skip('should parse a stylesheet for the root component when `useTailwindRoot: true`', async () => {
-    const md = '<div className="bg-blue-500 text-white p-4">Hello, World!</div>';
-
-    const { stylesheet } = await run(await compile(md, { useTailwind: true, useTailwindRoot: true }));
 
     expect(stylesheet).toMatchInlineSnapshot(`
       "/*! tailwindcss v4.0.3 | MIT License | https://tailwindcss.com */

--- a/components/TailwindRoot/index.tsx
+++ b/components/TailwindRoot/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
+import { tailwindPrefix } from '../../utils/consts';
+
 interface Props extends React.PropsWithChildren<{ flow: boolean }> {}
 
 const TailwindRoot = ({ children, flow }: Props) => {
   const Tag = flow ? 'div' : 'span';
 
-  return <Tag className="readme-tailwind">{children}</Tag>;
+  return <Tag className={tailwindPrefix}>{children}</Tag>;
 };
 
 export default TailwindRoot;

--- a/example/Doc.tsx
+++ b/example/Doc.tsx
@@ -4,7 +4,6 @@ import type { RMDXModule } from 'types';
 import React, { useEffect, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 
-
 import * as mdx from '../index';
 
 import components from './components';

--- a/lib/compile.ts
+++ b/lib/compile.ts
@@ -32,7 +32,7 @@ const compile = async (
   ];
 
   if (useTailwind) {
-    remarkPlugins.push([tailwindTransformer, { components, root: useTailwindRoot }]);
+    remarkPlugins.push([tailwindTransformer, { components, parseRoot: useTailwindRoot }]);
   }
 
   try {

--- a/lib/compile.ts
+++ b/lib/compile.ts
@@ -15,11 +15,15 @@ export type CompileOpts = CompileOptions & {
   components?: Record<string, string>;
   copyButtons?: boolean;
   useTailwind?: boolean;
+  useTailwindRoot?: boolean;
 };
 
 const { codeTabsTransformer, ...transforms } = defaultTransforms;
 
-const compile = async (text: string, { components = {}, copyButtons, useTailwind, ...opts }: CompileOpts = {}) => {
+const compile = async (
+  text: string,
+  { components = {}, copyButtons, useTailwind, useTailwindRoot, ...opts }: CompileOpts = {},
+) => {
   const remarkPlugins: PluggableList = [
     remarkFrontmatter,
     remarkGfm,
@@ -28,7 +32,7 @@ const compile = async (text: string, { components = {}, copyButtons, useTailwind
   ];
 
   if (useTailwind) {
-    remarkPlugins.push([tailwindTransformer, { components }]);
+    remarkPlugins.push([tailwindTransformer, { components, root: useTailwindRoot }]);
   }
 
   try {

--- a/processor/transform/tailwind.tsx
+++ b/processor/transform/tailwind.tsx
@@ -6,12 +6,13 @@ import type { VFile } from 'vfile';
 import { valueToEstree } from 'estree-util-value-to-estree';
 import { visit, SKIP } from 'unist-util-visit';
 
+import { tailwindPrefix } from '../../utils/consts';
 import tailwindBundle from '../../utils/tailwind-bundle';
 import { hasNamedExport, isMDXElement, toAttributes, getExports } from '../utils';
 
 interface TailwindRootOptions {
   components: Record<string, string>;
-  root?: boolean;
+  parseRoot?: boolean;
 }
 
 type Visitor =
@@ -21,12 +22,12 @@ type Visitor =
 const exportTailwindStylesheet = async (
   tree: Root,
   vfile: VFile,
-  { components, root }: TailwindRootOptions,
+  { components, parseRoot }: TailwindRootOptions,
 ): Promise<void> => {
   if (hasNamedExport(tree, 'stylesheet')) return;
 
-  const stringToParse = [...Object.values(components), root ? String(vfile) : ''].join('\n\n');
-  const stylesheet = (await tailwindBundle(stringToParse, { prefix: '.readme-tailwind' })).css;
+  const stringToParse = [...Object.values(components), parseRoot ? String(vfile) : ''].join('\n\n');
+  const stylesheet = (await tailwindBundle(stringToParse, { prefix: `.${tailwindPrefix}` })).css;
 
   const exportNode: MdxjsEsm = {
     type: 'mdxjsEsm',
@@ -85,7 +86,7 @@ const injectTailwindRoot =
   };
 
 const tailwind: Plugin<[TailwindRootOptions]> =
-  ({ components, root }) =>
+  ({ components, parseRoot }) =>
   async (tree: Root, vfile: VFile) => {
     const localComponents = getExports(tree).reduce((acc, name) => {
       acc[name] = String(vfile);
@@ -94,7 +95,7 @@ const tailwind: Plugin<[TailwindRootOptions]> =
 
     visit(tree, isMDXElement, injectTailwindRoot({ components: { ...components, ...localComponents } }));
 
-    await exportTailwindStylesheet(tree, vfile, { components: { ...components, ...localComponents }, root });
+    await exportTailwindStylesheet(tree, vfile, { components: { ...components, ...localComponents }, parseRoot });
 
     return tree;
   };

--- a/utils/consts.ts
+++ b/utils/consts.ts
@@ -1,0 +1,1 @@
+export const tailwindPrefix = 'readme-tailwind';

--- a/utils/tailwind-bundle.ts
+++ b/utils/tailwind-bundle.ts
@@ -70,10 +70,6 @@ async function tailwindBundle(string: string, { prefix }: { prefix: string }) {
   const newClasses = new Set<string>(string.split(/[^a-zA-Z0-9_-]+/));
   const css = compiler.build(Array.from(newClasses));
 
-  if (!css.match(/@layer utilities {/)) {
-    return { css: '' };
-  }
-
   return postcss([prefixer({ prefix })]).process(css, { from: undefined });
 }
 

--- a/utils/tailwind-bundle.ts
+++ b/utils/tailwind-bundle.ts
@@ -70,6 +70,10 @@ async function tailwindBundle(string: string, { prefix }: { prefix: string }) {
   const newClasses = new Set<string>(string.split(/[^a-zA-Z0-9_-]+/));
   const css = compiler.build(Array.from(newClasses));
 
+  if (!css.match(/@layer utilities {/)) {
+    return { css: '' };
+  }
+
   return postcss([prefixer({ prefix })]).process(css, { from: undefined });
 }
 


### PR DESCRIPTION
| [![PR App][icn]][demo] | Ref RM-12063 |
| :--------------------: | :----------: |

## 🧰 Changes

Allows parsing the root doc for tailwind styles.

If you pass `{ useTailwind: true, useTailwindRoot: true }` to `compile` it will parse the root document as well as the components for tailwind styles. It will be up to the consumer to add the `.tailwind-root` class to the root div though.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
