### PR TITLE
fix: margin on style tag

### DIFF
--- a/styles/gfm.scss
+++ b/styles/gfm.scss
@@ -234,6 +234,11 @@
     margin-top: 0 !important;
   }
 
+  // for mdx pages, select the next element after <style>
+  & > style + :nth-child(2) {
+    margin-top: 0 !important;
+  }
+
   & > :last-child {
     margin-bottom: 0 !important;
   }


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix CX-1800
:-------------------:|:----------:

## 🧰 Changes
- We weren't overriding the `margin-top` of the first element in superhub pages because of the `<style>` tag
- Does this selector make the most sense ?

<img width="500" alt="image" src="https://github.com/user-attachments/assets/646c582a-f256-45d5-895b-4703c3cac586" />

<img width="500" alt="image" src="https://github.com/user-attachments/assets/bae44537-352d-4f70-a4e1-098674f34a64" />



## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
