### PR TITLE
fix: allow configurable theme

### DIFF
--- a/components/TailwindStyle/index.tsx
+++ b/components/TailwindStyle/index.tsx
@@ -13,7 +13,7 @@ const traverse = (node: Node, callback: (element: Node) => void) => {
 
 interface Props {
   children: React.ReactNode;
-  darkModeDataAttribute?: boolean;
+  darkModeDataAttribute?: string | null;
 }
 
 const TailwindStyle = ({ children, darkModeDataAttribute }: Props) => {

--- a/example/Doc.tsx
+++ b/example/Doc.tsx
@@ -99,7 +99,7 @@ const Doc = () => {
         {!ci && <h2 className="rdmd-demo--markdown-header">{name}</h2>}
         <div id="content-container">
           <RenderError error={error}>
-            <TailwindStyle darkModeDataAttribute={darkModeDataAttribute}>
+            <TailwindStyle darkModeDataAttribute={darkModeDataAttribute ? 'data-theme' : null}>
               <div className="markdown-body">{Content && <Content />}</div>
             </TailwindStyle>
           </RenderError>

--- a/example/components.ts
+++ b/example/components.ts
@@ -48,7 +48,7 @@ export const DarkMode = () => {
   const [mode, setMode] = useState('dark');
 
   return (
-    <div data-color-mode={mode}>
+    <div data-theme={mode}>
       <button
         className="text-white bg-blue-700 hover:bg-blue-800 focus:outline-none focus:ring-1 focus:ring-blue-300 font-medium rounded-full text-sm px-5 py-2.5 text-center mb-2 dark:bg-yellow-300 dark:hover:bg-yellow-400 dark:focus:ring-yellow-900 dark:text-black"
         onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}

--- a/utils/tailwind-compiler.ts
+++ b/utils/tailwind-compiler.ts
@@ -50,7 +50,7 @@ async function loadModule(): Promise<never> {
   throw new Error('The browser build does not support plugins or config files.');
 }
 
-async function createCompiler({ darkModeDataAttribute }: { darkModeDataAttribute?: boolean }) {
+async function createCompiler({ darkModeDataAttribute }: { darkModeDataAttribute?: string | null }) {
   let css = `
 @layer theme, base, components, utilities;
 
@@ -61,7 +61,7 @@ async function createCompiler({ darkModeDataAttribute }: { darkModeDataAttribute
   if (darkModeDataAttribute) {
     css += `
 
-@custom-variant dark (&:where([data-color-mode=dark], [data-color-mode=dark] *));`;
+@custom-variant dark (&:where([${darkModeDataAttribute}=dark], [${darkModeDataAttribute}=dark] *));`;
   }
 
   return tailwindcss.compile(css, {
@@ -73,7 +73,7 @@ async function createCompiler({ darkModeDataAttribute }: { darkModeDataAttribute
 
 export async function tailwindCompiler(
   classes: string[],
-  { prefix, darkModeDataAttribute }: { darkModeDataAttribute?: boolean; prefix: string },
+  { prefix, darkModeDataAttribute }: { darkModeDataAttribute?: string | null; prefix: string },
 ) {
   const compiler = await createCompiler({ darkModeDataAttribute });
   const css = compiler.build(Array.from(classes));


### PR DESCRIPTION
| [![PR App][icn]][demo] | Ref RM-12311 |
| :--------------------: | :----------: |

## 🧰 Changes

Allows the tailwind dark mode attribute to be configurable.

My last attempts were too hasty. Prior to this, if there was no data attribute param, dark mode would fall back to the system preference. Then you could turn on using the data attribute, which would be the same as the readme app's. This works for the standard view mode. But, in the preview, we want it to be seperately configurable from main theme.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
