### PR TITLE
fix: compiling html-blocks to plaint text

### DIFF
--- a/__tests__/lib/plain/html-blocks.test.ts
+++ b/__tests__/lib/plain/html-blocks.test.ts
@@ -1,0 +1,23 @@
+import { hast, plain } from '../../../index';
+
+const Doc = `
+<HTMLBlock>{\`
+  <style>
+  .container {
+    display: flex;
+  }
+  </style>
+
+  <div class="container">
+    <div>Item 1</div>
+    <div>Item 2</div>
+  </div>
+\`}</HTMLBlock>
+`;
+
+describe('plain compiler', () => {
+  it('should parse html-blocks', () => {
+    const string = plain(hast(Doc));
+    expect(string).toBe('Item 1 Item 2');
+  });
+});

--- a/lib/plain.ts
+++ b/lib/plain.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import type { Nodes, Parents } from 'hast';
 
-import hast from './hast';
+import { fromHtml } from 'hast-util-from-html';
 
 /* @note: adapted from https://github.com/rehypejs/rehype-minify/blob/main/packages/hast-util-to-string/index.js
  */
@@ -25,7 +25,7 @@ function one(node: Nodes, opts: Options) {
     switch (node.tagName) {
       case 'html-block': {
         if (!node.properties.html) return '';
-        return all(hast(node.properties.html.toString()), opts);
+        return all(fromHtml(node.properties.html.toString()), opts);
       }
       case 'rdme-callout': {
         const { icon, title } = node.properties;


### PR DESCRIPTION
| [![PR App][icn]][demo] | Ref RM-12313 |
| :--------------------: | :----------: |

## 🧰 Changes

Fixes parsing `HTMLBlock` to plain text.

Prior to this, we were using our `hast` function to parse the html with-in htmlblocks. This will definitely break for a number of reasons, so we're going to use an html parser directly.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
