### PR TITLE
fix: pass through theme prop to CodeTabs from RunOpts

### DIFF
--- a/components/Callout/index.tsx
+++ b/components/Callout/index.tsx
@@ -25,7 +25,7 @@ const themes: Record<string, string> = {
 const Callout = (props: Props) => {
   const { attributes, children, icon, empty } = props;
   const theme = props.theme || themes[icon] || 'default';
-
+  
   return (
     // @ts-expect-error -- theme is not a valid attribute
     // eslint-disable-next-line react/jsx-props-no-spreading, react/no-unknown-property

--- a/components/Code/index.tsx
+++ b/components/Code/index.tsx
@@ -1,5 +1,7 @@
 import copy from 'copy-to-clipboard';
-import React, { createRef } from 'react';
+import React, { createRef, useContext } from 'react';
+
+import ThemeContext from '../../contexts/Theme';
 
 // Only load CodeMirror in the browser, for SSR
 // apps. Necessary because of people like this:
@@ -51,7 +53,8 @@ interface CodeProps {
 }
 
 const Code = (props: CodeProps) => {
-  const { children, copyButtons, lang, theme, value } = props;
+  const { children, copyButtons, lang, value } = props;
+  const theme = useContext(ThemeContext);
 
   const language = canonicalLanguage(lang);
 

--- a/components/CodeTabs/index.tsx
+++ b/components/CodeTabs/index.tsx
@@ -1,17 +1,20 @@
 import type { Mermaid } from 'mermaid';
 
 import { uppercase } from '@readme/syntax-highlighter';
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
+
+import ThemeContext from 'contexts/Theme';
 
 let mermaid: Mermaid;
 
 interface Props {
   children: JSX.Element | JSX.Element[];
-  theme: 'dark' | 'light';
 }
 
 const CodeTabs = (props: Props) => {
-  const { children, theme } = props;
+  const { children } = props;
+  const theme = useContext(ThemeContext);
+
 
   // render Mermaid diagram
   useEffect(() => {

--- a/components/CodeTabs/index.tsx
+++ b/components/CodeTabs/index.tsx
@@ -3,7 +3,7 @@ import type { Mermaid } from 'mermaid';
 import { uppercase } from '@readme/syntax-highlighter';
 import React, { useContext, useEffect } from 'react';
 
-import ThemeContext from 'contexts/Theme';
+import ThemeContext from '../../contexts/Theme';
 
 let mermaid: Mermaid;
 

--- a/components/CodeTabs/index.tsx
+++ b/components/CodeTabs/index.tsx
@@ -7,7 +7,7 @@ let mermaid: Mermaid;
 
 interface Props {
   children: JSX.Element | JSX.Element[];
-  theme: 'dark' | 'default' | 'light';
+  theme: 'dark' | 'light';
 }
 
 const CodeTabs = (props: Props) => {

--- a/contexts/Theme.ts
+++ b/contexts/Theme.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const ThemeContext = createContext<'dark' | 'light'>('light');
+
+export default ThemeContext;

--- a/contexts/index.tsx
+++ b/contexts/index.tsx
@@ -1,4 +1,4 @@
-import type { RunOpts } from '../lib/run';
+import type { RMDXModuleProps, RunOpts } from '../lib/run';
 
 import { VariablesContext } from '@readme/variable';
 import React from 'react';
@@ -7,7 +7,7 @@ import BaseUrlContext from './BaseUrl';
 import GlossaryContext from './GlossaryTerms';
 import ThemeContext from './Theme';
 
-type Props = Pick<RunOpts, 'baseUrl' | 'terms' | 'theme' | 'variables'> & React.PropsWithChildren;
+type Props = Pick<RMDXModuleProps, 'theme'> & Pick<RunOpts, 'baseUrl' | 'terms' | 'variables'> & React.PropsWithChildren;
 
 const compose = (
   children: React.ReactNode,

--- a/contexts/index.tsx
+++ b/contexts/index.tsx
@@ -5,20 +5,21 @@ import React from 'react';
 
 import BaseUrlContext from './BaseUrl';
 import GlossaryContext from './GlossaryTerms';
+import ThemeContext from './Theme';
 
-type Props = Pick<RunOpts, 'baseUrl' | 'terms' | 'variables'> & React.PropsWithChildren;
+type Props = Pick<RunOpts, 'baseUrl' | 'terms' | 'theme' | 'variables'> & React.PropsWithChildren;
 
 const compose = (
   children: React.ReactNode,
-  ...contexts: [React.Context<typeof GlossaryContext | typeof VariablesContext>, unknown][]
+  ...contexts: [React.Context<typeof GlossaryContext | typeof ThemeContext | typeof VariablesContext>, unknown][]
 ) => {
   return contexts.reduce((content, [Context, value]) => {
     return <Context.Provider value={value}>{content}</Context.Provider>;
   }, children);
 };
 
-const Contexts = ({ children, terms = [], variables = { user: {}, defaults: [] }, baseUrl = '/' }: Props) => {
-  return compose(children, [GlossaryContext, terms], [VariablesContext, variables], [BaseUrlContext, baseUrl]);
+const Contexts = ({ children, terms = [], variables = { user: {}, defaults: [] }, baseUrl = '/', theme }: Props) => {
+  return compose(children, [GlossaryContext, terms], [VariablesContext, variables], [BaseUrlContext, baseUrl], [ThemeContext, theme]);
 };
 
 export default Contexts;

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -54,7 +54,7 @@ const makeUseMDXComponents = (more: ReturnType<UseMdxComponents> = {}): UseMdxCo
 
 const run = async (string: string, _opts: RunOpts = {}) => {
   const { Fragment } = runtime;
-  const { components = {}, terms, variables, baseUrl, imports = {}, ...opts } = _opts;
+  const { components = {}, terms, variables, baseUrl, imports = {}, theme, ...opts } = _opts;
 
   const tocsByTag: Record<string, RMDXModule['toc']> = {};
   const exportedComponents = Object.entries(components).reduce((memo, [tag, mod]) => {
@@ -97,7 +97,7 @@ const run = async (string: string, _opts: RunOpts = {}) => {
 
   return {
     default: props => (
-      <Contexts baseUrl={baseUrl} terms={terms} variables={variables}>
+      <Contexts baseUrl={baseUrl} terms={terms} theme={theme} variables={variables}>
         <Content {...props} />
       </Contexts>
     ),

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -22,7 +22,6 @@ export type RunOpts = Omit<RunOptions, 'Fragment'> & {
   components?: CustomComponents;
   imports?: Record<string, unknown>;
   terms?: GlossaryTerm[];
-  theme?: 'dark' | 'light';
   variables?: Variables;
 };
 
@@ -54,7 +53,7 @@ const makeUseMDXComponents = (more: ReturnType<UseMdxComponents> = {}): UseMdxCo
 
 const run = async (string: string, _opts: RunOpts = {}) => {
   const { Fragment } = runtime;
-  const { components = {}, terms, variables, baseUrl, imports = {}, theme, ...opts } = _opts;
+  const { components = {}, terms, variables, baseUrl, imports = {}, ...opts } = _opts;
 
   const tocsByTag: Record<string, RMDXModule['toc']> = {};
   const exportedComponents = Object.entries(components).reduce((memo, [tag, mod]) => {
@@ -97,7 +96,7 @@ const run = async (string: string, _opts: RunOpts = {}) => {
 
   return {
     default: (props: MDXProps) => (
-      <Contexts baseUrl={baseUrl} terms={terms} theme={theme} variables={variables}>
+      <Contexts baseUrl={baseUrl} terms={terms} theme={props.theme} variables={variables}>
         <Content {...props} />
       </Contexts>
     ),

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -3,7 +3,7 @@ import type { GlossaryTerm } from '../contexts/GlossaryTerms';
 import type { CustomComponents, RMDXModule } from '../types';
 import type { Variables } from '../utils/user';
 import type { RunOptions, UseMdxComponents } from '@mdx-js/mdx';
-import type { MDXComponents } from 'mdx/types';
+import type { MDXComponents, MDXProps } from 'mdx/types';
 
 import { run as mdxRun } from '@mdx-js/mdx';
 import Variable from '@readme/variable';
@@ -96,7 +96,7 @@ const run = async (string: string, _opts: RunOpts = {}) => {
   }
 
   return {
-    default: props => (
+    default: (props: MDXProps) => (
       <Contexts baseUrl={baseUrl} terms={terms} theme={theme} variables={variables}>
         <Content {...props} />
       </Contexts>

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -22,6 +22,7 @@ export type RunOpts = Omit<RunOptions, 'Fragment'> & {
   components?: CustomComponents;
   imports?: Record<string, unknown>;
   terms?: GlossaryTerm[];
+  theme?: 'dark' | 'light';
   variables?: Variables;
 };
 

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -25,6 +25,10 @@ export type RunOpts = Omit<RunOptions, 'Fragment'> & {
   variables?: Variables;
 };
 
+export type RMDXModuleProps = MDXProps & {
+  theme: 'dark' | 'light';
+}
+
 const makeUseMDXComponents = (more: ReturnType<UseMdxComponents> = {}): UseMdxComponents => {
   const headings = Array.from({ length: 6 }).reduce((map, _, index) => {
     map[`h${index + 1}`] = Components.Heading((index + 1) as Depth);
@@ -95,7 +99,7 @@ const run = async (string: string, _opts: RunOpts = {}) => {
   }
 
   return {
-    default: (props: MDXProps) => (
+    default: (props: RMDXModuleProps) => (
       <Contexts baseUrl={baseUrl} terms={terms} theme={props.theme} variables={variables}>
         <Content {...props} />
       </Contexts>


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-12348
:-------------------:|:----------:

## 🧰 Changes
We weren't including the `theme` in `RunOpts`, and no props are being exclusively passed in to the components. This meant Mermaid Diagrams would always fallback to the `default` theme and not appropriately match the project theme. 

I added a `ThemeContext` through which we can set and access the project theme that's passed in via the `RunOpts`.

## 🧬 QA & Testing

Note: I can't figure out how to test these changes locally linked with the `readme` repo 😭 . Without sinking too much time in it, may just want to try to get this published in order to test via `readme`. 

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
