### PR TITLE
fix: pass theme via runopts

### DIFF
--- a/contexts/index.tsx
+++ b/contexts/index.tsx
@@ -1,4 +1,4 @@
-import type { RMDXModuleProps, RunOpts } from '../lib/run';
+import type {  RunOpts } from '../lib/run';
 
 import { VariablesContext } from '@readme/variable';
 import React from 'react';
@@ -7,7 +7,7 @@ import BaseUrlContext from './BaseUrl';
 import GlossaryContext from './GlossaryTerms';
 import ThemeContext from './Theme';
 
-type Props = Pick<RMDXModuleProps, 'theme'> & Pick<RunOpts, 'baseUrl' | 'terms' | 'variables'> & React.PropsWithChildren;
+type Props = Pick<RunOpts, 'baseUrl' | 'terms' | 'theme' | 'variables'> & React.PropsWithChildren;
 
 const compose = (
   children: React.ReactNode,

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -22,12 +22,9 @@ export type RunOpts = Omit<RunOptions, 'Fragment'> & {
   components?: CustomComponents;
   imports?: Record<string, unknown>;
   terms?: GlossaryTerm[];
+  theme?: 'dark' | 'light';
   variables?: Variables;
 };
-
-export type RMDXModuleProps = MDXProps & {
-  theme: 'dark' | 'light';
-}
 
 const makeUseMDXComponents = (more: ReturnType<UseMdxComponents> = {}): UseMdxComponents => {
   const headings = Array.from({ length: 6 }).reduce((map, _, index) => {
@@ -57,7 +54,7 @@ const makeUseMDXComponents = (more: ReturnType<UseMdxComponents> = {}): UseMdxCo
 
 const run = async (string: string, _opts: RunOpts = {}) => {
   const { Fragment } = runtime;
-  const { components = {}, terms, variables, baseUrl, imports = {}, ...opts } = _opts;
+  const { components = {}, terms, variables, baseUrl, imports = {}, theme, ...opts } = _opts;
 
   const tocsByTag: Record<string, RMDXModule['toc']> = {};
   const exportedComponents = Object.entries(components).reduce((memo, [tag, mod]) => {
@@ -99,8 +96,8 @@ const run = async (string: string, _opts: RunOpts = {}) => {
   }
 
   return {
-    default: (props: RMDXModuleProps) => (
-      <Contexts baseUrl={baseUrl} terms={terms} theme={props.theme} variables={variables}>
+    default: (props: MDXProps) => (
+      <Contexts baseUrl={baseUrl} terms={terms} theme={theme} variables={variables}>
         <Content {...props} />
       </Contexts>
     ),


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-12348
:-------------------:|:----------:

## 🧰 Changes

We had hoped to not need to re-run the run function when the theme changes, but in order to accurately toggle the theme of our components (Mermaid diagrams, in this case), we need to pass the theme as a `RunOpts` prop. 

### See broken behavior
https://github.com/user-attachments/assets/d8ef110f-a6f3-4e57-a578-89fc0d23809d


## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
