### PR TITLE
fix: handle named exports

### DIFF
--- a/__tests__/lib/mdast/index.test.ts
+++ b/__tests__/lib/mdast/index.test.ts
@@ -72,6 +72,15 @@ describe('mdast transformer', () => {
     );
   });
 
+  it('does not throw an error when a component is defined as a named export and missingComponents === "throw"', () => {
+    const mdx = '<NamedExport />';
+    const Component = 'export const NamedExport = () => "It works?!"';
+
+    expect(() => {
+      mdast(mdx, { missingComponents: 'throw', components: { Component } });
+    }).not.toThrow();
+  });
+
   it('does not throw an error when a component is defined in the page and missingComponents === "throw"', () => {
     const mdx = `
 export const Inlined = () => <div>Inlined</div>;

--- a/processor/transform/handle-missing-components.ts
+++ b/processor/transform/handle-missing-components.ts
@@ -1,3 +1,4 @@
+import type { CompileOpts } from '../../lib/compile';
 import type { Parents } from 'mdast';
 import type { Transform } from 'mdast-util-from-markdown';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
@@ -5,15 +6,19 @@ import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
 import { visit } from 'unist-util-visit';
 
 import * as Components from '../../components';
+import mdast from '../../lib/mdast';
 import { getExports, isMDXElement } from '../utils';
 
+type HandleMissingComponentsProps = Pick<CompileOpts, 'components' | 'missingComponents'>;
+
 const handleMissingComponents =
-  ({ components, missingComponents }): Transform =>
+  ({ components, missingComponents }: HandleMissingComponentsProps): Transform =>
   tree => {
     const allComponents = new Set([
       ...getExports(tree),
       ...Object.keys(Components),
       ...Object.keys(components),
+      ...Object.values(components).flatMap(doc => getExports(mdast(doc))),
       'Variable',
     ]);
 


### PR DESCRIPTION
| [![PR App][icn]][demo] | Ref RM-12428 |
| :--------------------: | :----------: |

## 🧰 Changes

Fixes a validation check for named exports.

In a prior PR, I added a transformer to either remove or throw if a component is missing. But it wasn't checking against named exports. This updates the transformer to pull named exports out of the passed in components.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
