### PR TITLE
fix: margin element selector

### DIFF
--- a/styles/gfm.scss
+++ b/styles/gfm.scss
@@ -234,8 +234,8 @@
     margin-top: 0 !important;
   }
 
-  // for mdx pages, select the next element after <style>
-  & > style + :nth-child(2) {
+  // for mdx pages, select the first markdown element after the style tags
+  & > :nth-child(1 of :not(style)) {
     margin-top: 0 !important;
   }
 


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-12490, [Thread](https://readmeio.slack.com/archives/C089VLEECKC/p1744905351133679)
:-------------------:|:----------:

## 🧰 Changes

before we were setting `margin-top: 0` to the 2nd child element in a page, which should have been the first markdown element after the `<style>` tag but we have since then added another `<style>`

this updates the selector to target the first child element that is _not_ a `<style>` ([TIL](https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-child#the_of_selector_syntax))

should look like this:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/5e0f79ed-b19b-4865-9a00-14f8a9bb3bb4" />


## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
