### PR TITLE
fix: missing code copy

### DIFF
--- a/components/Code/index.tsx
+++ b/components/Code/index.tsx
@@ -56,7 +56,7 @@ interface CodeProps {
 const Code = (props: CodeProps) => {
   const { children, lang, value } = props;
   const theme = useContext(ThemeContext);
-  const copyButtons = useContext(CodeOptsContext);
+  const copyButtons = useContext(CodeOptsContext) || props.copyButtons;
 
   const language = canonicalLanguage(lang);
 

--- a/components/Code/index.tsx
+++ b/components/Code/index.tsx
@@ -1,6 +1,7 @@
 import copy from 'copy-to-clipboard';
 import React, { createRef, useContext } from 'react';
 
+import CodeOptsContext from '../../contexts/CodeOpts';
 import ThemeContext from '../../contexts/Theme';
 
 // Only load CodeMirror in the browser, for SSR
@@ -53,8 +54,9 @@ interface CodeProps {
 }
 
 const Code = (props: CodeProps) => {
-  const { children, copyButtons, lang, value } = props;
+  const { children, lang, value } = props;
   const theme = useContext(ThemeContext);
+  const copyButtons = useContext(CodeOptsContext);
 
   const language = canonicalLanguage(lang);
 

--- a/contexts/CodeOpts.ts
+++ b/contexts/CodeOpts.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
 
+// used for the copyButtons prop
 const CodeOptsContext = createContext<boolean>(false);
 
 export default CodeOptsContext;

--- a/contexts/CodeOpts.ts
+++ b/contexts/CodeOpts.ts
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+
+const CodeOptsContext = createContext<boolean>(false);
+
+export default CodeOptsContext;

--- a/contexts/index.tsx
+++ b/contexts/index.tsx
@@ -4,10 +4,11 @@ import { VariablesContext } from '@readme/variable';
 import React from 'react';
 
 import BaseUrlContext from './BaseUrl';
+import CodeOptsContext from './CodeOpts';
 import GlossaryContext from './GlossaryTerms';
 import ThemeContext from './Theme';
 
-type Props = Pick<RunOpts, 'baseUrl' | 'terms' | 'theme' | 'variables'> & React.PropsWithChildren;
+type Props = Pick<RunOpts, 'baseUrl' | 'copyButtons' | 'terms' | 'theme' | 'variables'> & React.PropsWithChildren;
 
 const compose = (
   children: React.ReactNode,
@@ -18,8 +19,8 @@ const compose = (
   }, children);
 };
 
-const Contexts = ({ children, terms = [], variables = { user: {}, defaults: [] }, baseUrl = '/', theme }: Props) => {
-  return compose(children, [GlossaryContext, terms], [VariablesContext, variables], [BaseUrlContext, baseUrl], [ThemeContext, theme]);
+const Contexts = ({ children, terms = [], variables = { user: {}, defaults: [] }, baseUrl = '/', theme, copyButtons }: Props) => {
+  return compose(children, [GlossaryContext, terms], [VariablesContext, variables], [BaseUrlContext, baseUrl], [ThemeContext, theme], [CodeOptsContext, copyButtons]);
 };
 
 export default Contexts;

--- a/lib/run.tsx
+++ b/lib/run.tsx
@@ -19,6 +19,7 @@ import makeUseMDXComponents from './utils/makeUseMdxComponents';
 export type RunOpts = Omit<RunOptions, 'Fragment'> & {
   baseUrl?: string;
   components?: CustomComponents;
+  copyButtons?: boolean;
   imports?: Record<string, unknown>;
   terms?: GlossaryTerm[];
   theme?: 'dark' | 'light';
@@ -27,7 +28,7 @@ export type RunOpts = Omit<RunOptions, 'Fragment'> & {
 
 const run = async (string: string, _opts: RunOpts = {}) => {
   const { Fragment } = runtime;
-  const { components = {}, terms, variables, baseUrl, imports = {}, theme, ...opts } = _opts;
+  const { components = {}, terms, variables, baseUrl, imports = {}, theme, copyButtons, ...opts } = _opts;
 
   const tocsByTag: Record<string, RMDXModule['toc']> = {};
   const exportedComponents = Object.entries(components).reduce((memo, [tag, mod]) => {
@@ -70,7 +71,7 @@ const run = async (string: string, _opts: RunOpts = {}) => {
 
   return {
     default: (props: MDXProps) => (
-      <Contexts baseUrl={baseUrl} terms={terms} theme={theme} variables={variables}>
+      <Contexts baseUrl={baseUrl} copyButtons={copyButtons} terms={terms} theme={theme} variables={variables}>
         <Content {...props} />
       </Contexts>
     ),


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix CX-1879
:-------------------:|:----------:

## 🧰 Changes
- Enable passing in `CopyButton` prop for code blocks

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
