### PR TITLE
feat: external large deps

### DIFF
--- a/components/HTMLBlock/index.tsx
+++ b/components/HTMLBlock/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 
 const MATCH_SCRIPT_TAGS = /<script\b[^>]*>([\s\S]*?)<\/script *>\n?/gim;
 
@@ -21,11 +20,14 @@ interface Props {
 }
 
 const HTMLBlock = ({ children = '', runScripts, safeMode = false }: Props) => {
-  let html = children;
+  if (typeof children !== 'string') {
+    throw new TypeError('HTMLBlock: children must be a string');
+  }
+
+  const html = children;
   // eslint-disable-next-line no-param-reassign
   runScripts = typeof runScripts !== 'boolean' ? runScripts === 'true' : runScripts;
 
-  if (typeof html !== 'string') html = renderToStaticMarkup(html);
   const [cleanedHtml, exec] = extractScripts(html);
 
   useEffect(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@readme/emojis": "^6.0.0",
-        "@readme/syntax-highlighter": "^13.1.0",
         "copy-to-clipboard": "^3.3.2",
         "core-js": "^3.36.1",
         "debug": "^4.3.4",
@@ -117,8 +116,10 @@
       },
       "peerDependencies": {
         "@mdx-js/react": "^3.0.0",
+        "@readme/syntax-highlighter": "^13.1.0",
         "@readme/variable": "^16.1.0",
         "@tippyjs/react": "^4.1.0",
+        "acorn": "v8.12.1",
         "react": "16.x || 17.x || 18.x",
         "react-dom": "16.x || 17.x || 18.x"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@mdx-js/mdx": "^3.0.0",
     "@readme/emojis": "^6.0.0",
-    "@readme/syntax-highlighter": "^13.1.0",
     "copy-to-clipboard": "^3.3.2",
     "core-js": "^3.36.1",
     "debug": "^4.3.4",
@@ -65,8 +64,10 @@
   },
   "peerDependencies": {
     "@mdx-js/react": "^3.0.0",
+    "@readme/syntax-highlighter": "^13.1.0",
     "@readme/variable": "^16.1.0",
     "@tippyjs/react": "^4.1.0",
+    "acorn": "v8.12.1",
     "react": "16.x || 17.x || 18.x",
     "react-dom": "16.x || 17.x || 18.x"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,8 +83,10 @@ const getConfig = ({ target }) => ({
 
 const browserConfig = merge(getConfig({ target: 'web' }), {
   externals: {
+    '@readme/syntax-highlighter': '@readme/syntax-highlighter',
     '@readme/variable': '@readme/variable',
     '@tippyjs/react': '@tippyjs/react',
+    acorn: 'acorn',
     mermaid: 'mermaid',
     react: {
       amd: 'react',


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

Externalizes `@readme/syntax-highlighter` and `acorn`.

Those deps are duplicated across the main readme app, and definitely do not need to be bundled.

It also removes an import of `react-dom/server` which seems fairly extraneous. The `HTMLBlock` component was checking if you passed in react components as children, and converting them to a string. I don't think that's something we should support.

### Webpack Bundle Analyzer

**Before** (parsed size of 4.05MB)
![image](https://github.com/user-attachments/assets/83dccdb6-920b-4239-aabf-6392356655fa)

**After** (parsed size of 2.5MB)
![image](https://github.com/user-attachments/assets/e5dddf90-c7dc-49ae-bbb1-65c399333670)



## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
