### PR TITLE
fix: dont initialize mermaid

### DIFF
--- a/components/CodeTabs/index.tsx
+++ b/components/CodeTabs/index.tsx
@@ -14,11 +14,11 @@ interface Props {
 const CodeTabs = (props: Props) => {
   const { children } = props;
   const theme = useContext(ThemeContext);
-
+  const hasMermaid = !Array.isArray(children) && children.props?.children.props.lang === 'mermaid';
 
   // render Mermaid diagram
   useEffect(() => {
-    if (typeof window !== 'undefined') {
+    if (typeof window !== 'undefined' && hasMermaid) {
       import('mermaid').then(module => {
         mermaid = module.default;
         mermaid.initialize({
@@ -27,7 +27,7 @@ const CodeTabs = (props: Props) => {
         mermaid.contentLoaded();
       });
     }
-  }, [theme]);
+  }, [hasMermaid, theme]);
 
   function handleClick({ target }, index: number) {
     const $wrap = target.parentElement.parentElement;
@@ -42,7 +42,7 @@ const CodeTabs = (props: Props) => {
   }
 
   // render single Mermaid diagram
-  if (!Array.isArray(children) && children.props?.children.props.lang === 'mermaid') {
+  if (hasMermaid) {
     const value = children.props.children.props.value;
     return <pre className="mermaid mermaid_single">{value}</pre>;
   }


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-12558 |
| :--------------------: | :----------: |

## 🧰 Changes

Only initializes mermaid if a mermaid element is present in the DOM.

**flamegraphs are cool**

THe first big spike is react, the second is mermaid. The rest of the smaller is each diagram (I believe)
![image](https://github.com/user-attachments/assets/095fac68-cc93-4ad8-ae23-337db1d05f8f)


## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
