### PR TITLE
fix: crash when compiling empty table cells

### DIFF
--- a/__tests__/compilers/tables.test.js
+++ b/__tests__/compilers/tables.test.js
@@ -325,4 +325,17 @@ describe('table compiler', () => {
       </Table>"
     `);
   });
+
+  it('compiles tables with empty cells', () => {
+    const doc = `
+| col1 | col2 | col3                     |
+| :--- | :--: | :----------------------- |
+| →    |      | ← empty cell to the left |
+`;
+    const ast = mdast(doc);
+
+    expect(() => {
+      mdx(ast);
+    }).not.toThrow();
+  });
 });

--- a/processor/transform/tables-to-jsx.ts
+++ b/processor/transform/tables-to-jsx.ts
@@ -27,6 +27,8 @@ const visitor = (table: Table, index: number, parent: Parents) => {
   let hasFlowContent = false;
 
   const tableCellVisitor = (cell: TableCell) => {
+    if (cell.children.length === 0) return EXIT;
+
     const content =
       cell.children.length === 1 && cell.children[0].type === 'paragraph'
         ? (cell.children[0] as unknown as Paragraph).children[0]


### PR DESCRIPTION
| [![PR App][icn]][demo] | Part of CX-1934 |
| :--------------------: | :-------------: |

## 🧰 Changes

Fixes a crash when compiling empty table cells

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
