### PR TITLE
fix: missing iframe title

### DIFF
--- a/components/Embed/index.tsx
+++ b/components/Embed/index.tsx
@@ -52,8 +52,7 @@ const Embed = ({
   }
 
   if (iframe) {
-    // eslint-disable-next-line jsx-a11y/iframe-has-title
-    return <iframe {...attrs} src={url} style={{ border: 'none', display: 'flex', margin: 'auto' }} />;
+    return <iframe {...attrs} src={url} style={{ border: 'none', display: 'flex', margin: 'auto' }} title={title} />;
   }
 
   if (!providerUrl && url)


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix CX-1935
:-------------------:|:----------:

## 🧰 Changes
- Add `title` prop to `iframe` component for a11y requirements

<img width="400" alt="image" src="https://github.com/user-attachments/assets/c5482afe-9ae7-4151-95cb-0dc4ee11cc95" />


## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
