### PR TITLE
feat: plain compiler

### DIFF
--- a/__tests__/compilers/plain.test.ts
+++ b/__tests__/compilers/plain.test.ts
@@ -1,4 +1,4 @@
-import type { Paragraph, Root } from 'mdast';
+import type { Paragraph, Root, RootContent } from 'mdast';
 
 import { mdx } from '../../index';
 
@@ -21,5 +21,61 @@ describe('plain compiler', () => {
     };
 
     expect(mdx(ast)).toBe(`${md}\n`);
+  });
+
+  it('compiles plain nodes and does not escape characters', () => {
+    const md = '<not valid jsx>';
+    const ast: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'plain',
+              value: md,
+            },
+          ],
+        } as Paragraph,
+      ],
+    };
+
+    expect(mdx(ast)).toBe(`${md}\n`);
+  });
+
+  it('compiles plain nodes at the root level', () => {
+    const md = "- this is and isn't a list";
+    const ast: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'plain',
+          value: md,
+        },
+      ] as RootContent[],
+    };
+
+    expect(mdx(ast)).toBe(`${md}\n`);
+  });
+
+  it('compiles plain nodes in an inline context', () => {
+    const ast: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            { type: 'text', value: 'before' },
+            {
+              type: 'plain',
+              value: ' plain ',
+            },
+            { type: 'text', value: 'after' },
+          ],
+        },
+      ] as RootContent[],
+    };
+
+    expect(mdx(ast)).toBe('before plain after\n');
   });
 });

--- a/__tests__/compilers/plain.test.ts
+++ b/__tests__/compilers/plain.test.ts
@@ -1,0 +1,25 @@
+import type { Paragraph, Root } from 'mdast';
+
+import { mdx } from '../../index';
+
+describe('plain compiler', () => {
+  it('compiles plain nodes', () => {
+    const md = "- this is and isn't a list";
+    const ast: Root = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'plain',
+              value: md,
+            },
+          ],
+        } as Paragraph,
+      ],
+    };
+
+    expect(mdx(ast)).toBe(`${md}\n`);
+  });
+});

--- a/enums.ts
+++ b/enums.ts
@@ -9,6 +9,7 @@ export enum NodeTypes {
   htmlBlock = 'html-block',
   i = 'i',
   imageBlock = 'image-block',
+  plain = 'plain',
   reusableContent = 'reusable-content',
   tableau = 'tableau',
   tutorialTile = 'tutorial-tile',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@readme/markdown",
+  "name": "@readme/mdx",
   "description": "ReadMe's React-based Markdown parser",
   "author": "Rafe Goldberg <rafe@readme.io>",
   "version": "9.4.0",

--- a/processor/compile/index.ts
+++ b/processor/compile/index.ts
@@ -6,6 +6,7 @@ import compatibility from './compatibility';
 import embed from './embed';
 import gemoji from './gemoji';
 import htmlBlock from './html-block';
+import plain from './plain';
 
 function compilers() {
   const data = this.data();
@@ -25,6 +26,7 @@ function compilers() {
     figure: compatibility,
     html: compatibility,
     i: compatibility,
+    plain,
     yaml: compatibility,
   };
 

--- a/processor/compile/plain.ts
+++ b/processor/compile/plain.ts
@@ -1,0 +1,5 @@
+import type { Plain } from '../../types';
+
+const plain = (node: Plain) => node.value;
+
+export default plain;

--- a/types.d.ts
+++ b/types.d.ts
@@ -89,6 +89,10 @@ interface HTMLBlock extends Node {
   type: NodeTypes.htmlBlock;
 }
 
+interface Plain extends Literal {
+  type: NodeTypes.plain;
+}
+
 interface ImageBlockAttrs {
   align?: string;
   alt: string;
@@ -161,6 +165,7 @@ declare module 'mdast' {
     [NodeTypes.emoji]: Gemoji;
     [NodeTypes.i]: FaEmoji;
     [NodeTypes.variable]: Variable;
+    [NodeTypes.plain]: Plain;
   }
 
   interface RootContentMap {


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-12842 |
| :--------------------: | :--------: |

## 🧰 Changes

Adds a plain compiler for avoiding markdown escaping during compilation.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
