### PR TITLE
chore: export Owlmoji again

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -13,5 +13,6 @@ const utils = {
 };
 
 export { compile, exports, hast, run, mdast, mdastV6, mdx, migrate, plain, remarkPlugins, tags } from './lib';
+export { default as Owlmoji } from './lib/owlmoji';
 export { Components, utils };
 export { tailwindCompiler } from './utils/tailwind-compiler';


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

The `@readme/markdown` package at v6.87.1 exported `Owlmoji` and we consume it in the react app.
In order to do the same with `@readme/mdx` we need to export it again.

## 🧰 Changes
- Export `Owlmoji`

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
