### PR TITLE
feat(owlmoji): parity with legacy package's full emoji list

### DIFF
--- a/lib/owlmoji.ts
+++ b/lib/owlmoji.ts
@@ -1,14 +1,56 @@
-import { nameToEmoji } from 'gemoji';
+import type { Gemoji } from 'gemoji';
 
-const owlmoji = ['owlbert-books', 'owlbert-mask', 'owlbert', 'owlbert-reading', 'owlbert-thinking'];
+import { gemoji, nameToEmoji } from 'gemoji';
+
+export const owlmoji = [
+  {
+    emoji: '', // This `emoji` property doesn't get consumed, but is required for type consistency
+    names: ['owlbert'],
+    tags: ['owlbert'],
+    description: 'an owlbert for any occasion',
+    category: 'ReadMe',
+  },
+  {
+    emoji: '',
+    names: ['owlbert-books'],
+    tags: ['owlbert'],
+    description: 'owlbert carrying books',
+    category: 'ReadMe',
+  },
+  {
+    emoji: '',
+    names: ['owlbert-mask'],
+    tags: ['owlbert'],
+    description: 'owlbert with a respirator',
+    category: 'ReadMe',
+  },
+  {
+    emoji: '',
+    names: ['owlbert-reading'],
+    tags: ['owlbert'],
+    description: 'owlbert reading',
+    category: 'ReadMe',
+  },
+  {
+    emoji: '',
+    names: ['owlbert-thinking'],
+    tags: ['owlbert'],
+    description: 'owlbert thinking',
+    category: 'ReadMe',
+  },
+] satisfies Gemoji[];
+
+const owlmojiNames = owlmoji.flatMap(emoji => emoji.names);
 
 export default class Owlmoji {
   static kind = (name: string) => {
     if (name in nameToEmoji) return 'gemoji';
     else if (name.match(/^fa-/)) return 'fontawesome';
-    else if (owlmoji.includes(name)) return 'owlmoji';
+    else if (owlmojiNames.includes(name)) return 'owlmoji';
     return null;
   };
 
   static nameToEmoji = nameToEmoji;
+
+  static owlmoji = gemoji.concat(owlmoji).sort((a, b) => a.names[0].localeCompare(b.names[0]));
 }


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

We add this to the `@readme/markdown` package [in this PR](https://github.com/readmeio/markdown/pull/870) but did not update the `@readme/mdx` package to to include this change.

## 🧰 Changes
- expose full emoji list

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
