### PR TITLE
fix: remove owlmoji collection sorting, add unit tests

### DIFF
--- a/__tests__/lib/__snapshots__/owlmoji.test.ts.snap
+++ b/__tests__/lib/__snapshots__/owlmoji.test.ts.snap
@@ -1,0 +1,18095 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Owlmoji > owlmoji collection matches the snapshot 1`] = `
+[
+  {
+    "category": "Smileys & Emotion",
+    "description": "grinning face",
+    "emoji": "😀",
+    "names": [
+      "grinning",
+    ],
+    "tags": [
+      "smile",
+      "happy",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "grinning face with big eyes",
+    "emoji": "😃",
+    "names": [
+      "smiley",
+    ],
+    "tags": [
+      "happy",
+      "joy",
+      "haha",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "grinning face with smiling eyes",
+    "emoji": "😄",
+    "names": [
+      "smile",
+    ],
+    "tags": [
+      "happy",
+      "joy",
+      "laugh",
+      "pleased",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "beaming face with smiling eyes",
+    "emoji": "😁",
+    "names": [
+      "grin",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "grinning squinting face",
+    "emoji": "😆",
+    "names": [
+      "laughing",
+      "satisfied",
+    ],
+    "tags": [
+      "happy",
+      "haha",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "grinning face with sweat",
+    "emoji": "😅",
+    "names": [
+      "sweat_smile",
+    ],
+    "tags": [
+      "hot",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "rolling on the floor laughing",
+    "emoji": "🤣",
+    "names": [
+      "rofl",
+    ],
+    "tags": [
+      "lol",
+      "laughing",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with tears of joy",
+    "emoji": "😂",
+    "names": [
+      "joy",
+    ],
+    "tags": [
+      "tears",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "slightly smiling face",
+    "emoji": "🙂",
+    "names": [
+      "slightly_smiling_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "upside-down face",
+    "emoji": "🙃",
+    "names": [
+      "upside_down_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "melting face",
+    "emoji": "🫠",
+    "names": [
+      "melting_face",
+    ],
+    "tags": [
+      "sarcasm",
+      "dread",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "winking face",
+    "emoji": "😉",
+    "names": [
+      "wink",
+    ],
+    "tags": [
+      "flirt",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling face with smiling eyes",
+    "emoji": "😊",
+    "names": [
+      "blush",
+    ],
+    "tags": [
+      "proud",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling face with halo",
+    "emoji": "😇",
+    "names": [
+      "innocent",
+    ],
+    "tags": [
+      "angel",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling face with hearts",
+    "emoji": "🥰",
+    "names": [
+      "smiling_face_with_three_hearts",
+    ],
+    "tags": [
+      "love",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling face with heart-eyes",
+    "emoji": "😍",
+    "names": [
+      "heart_eyes",
+    ],
+    "tags": [
+      "love",
+      "crush",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "star-struck",
+    "emoji": "🤩",
+    "names": [
+      "star_struck",
+    ],
+    "tags": [
+      "eyes",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face blowing a kiss",
+    "emoji": "😘",
+    "names": [
+      "kissing_heart",
+    ],
+    "tags": [
+      "flirt",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "kissing face",
+    "emoji": "😗",
+    "names": [
+      "kissing",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling face",
+    "emoji": "☺️",
+    "names": [
+      "relaxed",
+    ],
+    "tags": [
+      "blush",
+      "pleased",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "kissing face with closed eyes",
+    "emoji": "😚",
+    "names": [
+      "kissing_closed_eyes",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "kissing face with smiling eyes",
+    "emoji": "😙",
+    "names": [
+      "kissing_smiling_eyes",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling face with tear",
+    "emoji": "🥲",
+    "names": [
+      "smiling_face_with_tear",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face savoring food",
+    "emoji": "😋",
+    "names": [
+      "yum",
+    ],
+    "tags": [
+      "tongue",
+      "lick",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with tongue",
+    "emoji": "😛",
+    "names": [
+      "stuck_out_tongue",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "winking face with tongue",
+    "emoji": "😜",
+    "names": [
+      "stuck_out_tongue_winking_eye",
+    ],
+    "tags": [
+      "prank",
+      "silly",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "zany face",
+    "emoji": "🤪",
+    "names": [
+      "zany_face",
+    ],
+    "tags": [
+      "goofy",
+      "wacky",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "squinting face with tongue",
+    "emoji": "😝",
+    "names": [
+      "stuck_out_tongue_closed_eyes",
+    ],
+    "tags": [
+      "prank",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "money-mouth face",
+    "emoji": "🤑",
+    "names": [
+      "money_mouth_face",
+    ],
+    "tags": [
+      "rich",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling face with open hands",
+    "emoji": "🤗",
+    "names": [
+      "hugs",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with hand over mouth",
+    "emoji": "🤭",
+    "names": [
+      "hand_over_mouth",
+    ],
+    "tags": [
+      "quiet",
+      "whoops",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with open eyes and hand over mouth",
+    "emoji": "🫢",
+    "names": [
+      "face_with_open_eyes_and_hand_over_mouth",
+    ],
+    "tags": [
+      "gasp",
+      "shock",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with peeking eye",
+    "emoji": "🫣",
+    "names": [
+      "face_with_peeking_eye",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "shushing face",
+    "emoji": "🤫",
+    "names": [
+      "shushing_face",
+    ],
+    "tags": [
+      "silence",
+      "quiet",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "thinking face",
+    "emoji": "🤔",
+    "names": [
+      "thinking",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "saluting face",
+    "emoji": "🫡",
+    "names": [
+      "saluting_face",
+    ],
+    "tags": [
+      "respect",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "zipper-mouth face",
+    "emoji": "🤐",
+    "names": [
+      "zipper_mouth_face",
+    ],
+    "tags": [
+      "silence",
+      "hush",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with raised eyebrow",
+    "emoji": "🤨",
+    "names": [
+      "raised_eyebrow",
+    ],
+    "tags": [
+      "suspicious",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "neutral face",
+    "emoji": "😐",
+    "names": [
+      "neutral_face",
+    ],
+    "tags": [
+      "meh",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "expressionless face",
+    "emoji": "😑",
+    "names": [
+      "expressionless",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face without mouth",
+    "emoji": "😶",
+    "names": [
+      "no_mouth",
+    ],
+    "tags": [
+      "mute",
+      "silence",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "dotted line face",
+    "emoji": "🫥",
+    "names": [
+      "dotted_line_face",
+    ],
+    "tags": [
+      "invisible",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face in clouds",
+    "emoji": "😶‍🌫️",
+    "names": [
+      "face_in_clouds",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smirking face",
+    "emoji": "😏",
+    "names": [
+      "smirk",
+    ],
+    "tags": [
+      "smug",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "unamused face",
+    "emoji": "😒",
+    "names": [
+      "unamused",
+    ],
+    "tags": [
+      "meh",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with rolling eyes",
+    "emoji": "🙄",
+    "names": [
+      "roll_eyes",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "grimacing face",
+    "emoji": "😬",
+    "names": [
+      "grimacing",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face exhaling",
+    "emoji": "😮‍💨",
+    "names": [
+      "face_exhaling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "lying face",
+    "emoji": "🤥",
+    "names": [
+      "lying_face",
+    ],
+    "tags": [
+      "liar",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "shaking face",
+    "emoji": "🫨",
+    "names": [
+      "shaking_face",
+    ],
+    "tags": [
+      "shock",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "relieved face",
+    "emoji": "😌",
+    "names": [
+      "relieved",
+    ],
+    "tags": [
+      "whew",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "pensive face",
+    "emoji": "😔",
+    "names": [
+      "pensive",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "sleepy face",
+    "emoji": "😪",
+    "names": [
+      "sleepy",
+    ],
+    "tags": [
+      "tired",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "drooling face",
+    "emoji": "🤤",
+    "names": [
+      "drooling_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "sleeping face",
+    "emoji": "😴",
+    "names": [
+      "sleeping",
+    ],
+    "tags": [
+      "zzz",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with medical mask",
+    "emoji": "😷",
+    "names": [
+      "mask",
+    ],
+    "tags": [
+      "sick",
+      "ill",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with thermometer",
+    "emoji": "🤒",
+    "names": [
+      "face_with_thermometer",
+    ],
+    "tags": [
+      "sick",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with head-bandage",
+    "emoji": "🤕",
+    "names": [
+      "face_with_head_bandage",
+    ],
+    "tags": [
+      "hurt",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "nauseated face",
+    "emoji": "🤢",
+    "names": [
+      "nauseated_face",
+    ],
+    "tags": [
+      "sick",
+      "barf",
+      "disgusted",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face vomiting",
+    "emoji": "🤮",
+    "names": [
+      "vomiting_face",
+    ],
+    "tags": [
+      "barf",
+      "sick",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "sneezing face",
+    "emoji": "🤧",
+    "names": [
+      "sneezing_face",
+    ],
+    "tags": [
+      "achoo",
+      "sick",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "hot face",
+    "emoji": "🥵",
+    "names": [
+      "hot_face",
+    ],
+    "tags": [
+      "heat",
+      "sweating",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "cold face",
+    "emoji": "🥶",
+    "names": [
+      "cold_face",
+    ],
+    "tags": [
+      "freezing",
+      "ice",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "woozy face",
+    "emoji": "🥴",
+    "names": [
+      "woozy_face",
+    ],
+    "tags": [
+      "groggy",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with crossed-out eyes",
+    "emoji": "😵",
+    "names": [
+      "dizzy_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with spiral eyes",
+    "emoji": "😵‍💫",
+    "names": [
+      "face_with_spiral_eyes",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "exploding head",
+    "emoji": "🤯",
+    "names": [
+      "exploding_head",
+    ],
+    "tags": [
+      "mind",
+      "blown",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "cowboy hat face",
+    "emoji": "🤠",
+    "names": [
+      "cowboy_hat_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "partying face",
+    "emoji": "🥳",
+    "names": [
+      "partying_face",
+    ],
+    "tags": [
+      "celebration",
+      "birthday",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "disguised face",
+    "emoji": "🥸",
+    "names": [
+      "disguised_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling face with sunglasses",
+    "emoji": "😎",
+    "names": [
+      "sunglasses",
+    ],
+    "tags": [
+      "cool",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "nerd face",
+    "emoji": "🤓",
+    "names": [
+      "nerd_face",
+    ],
+    "tags": [
+      "geek",
+      "glasses",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with monocle",
+    "emoji": "🧐",
+    "names": [
+      "monocle_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "confused face",
+    "emoji": "😕",
+    "names": [
+      "confused",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with diagonal mouth",
+    "emoji": "🫤",
+    "names": [
+      "face_with_diagonal_mouth",
+    ],
+    "tags": [
+      "confused",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "worried face",
+    "emoji": "😟",
+    "names": [
+      "worried",
+    ],
+    "tags": [
+      "nervous",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "slightly frowning face",
+    "emoji": "🙁",
+    "names": [
+      "slightly_frowning_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "frowning face",
+    "emoji": "☹️",
+    "names": [
+      "frowning_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with open mouth",
+    "emoji": "😮",
+    "names": [
+      "open_mouth",
+    ],
+    "tags": [
+      "surprise",
+      "impressed",
+      "wow",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "hushed face",
+    "emoji": "😯",
+    "names": [
+      "hushed",
+    ],
+    "tags": [
+      "silence",
+      "speechless",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "astonished face",
+    "emoji": "😲",
+    "names": [
+      "astonished",
+    ],
+    "tags": [
+      "amazed",
+      "gasp",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "flushed face",
+    "emoji": "😳",
+    "names": [
+      "flushed",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "pleading face",
+    "emoji": "🥺",
+    "names": [
+      "pleading_face",
+    ],
+    "tags": [
+      "puppy",
+      "eyes",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face holding back tears",
+    "emoji": "🥹",
+    "names": [
+      "face_holding_back_tears",
+    ],
+    "tags": [
+      "tears",
+      "gratitude",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "frowning face with open mouth",
+    "emoji": "😦",
+    "names": [
+      "frowning",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "anguished face",
+    "emoji": "😧",
+    "names": [
+      "anguished",
+    ],
+    "tags": [
+      "stunned",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "fearful face",
+    "emoji": "😨",
+    "names": [
+      "fearful",
+    ],
+    "tags": [
+      "scared",
+      "shocked",
+      "oops",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "anxious face with sweat",
+    "emoji": "😰",
+    "names": [
+      "cold_sweat",
+    ],
+    "tags": [
+      "nervous",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "sad but relieved face",
+    "emoji": "😥",
+    "names": [
+      "disappointed_relieved",
+    ],
+    "tags": [
+      "phew",
+      "sweat",
+      "nervous",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "crying face",
+    "emoji": "😢",
+    "names": [
+      "cry",
+    ],
+    "tags": [
+      "sad",
+      "tear",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "loudly crying face",
+    "emoji": "😭",
+    "names": [
+      "sob",
+    ],
+    "tags": [
+      "sad",
+      "cry",
+      "bawling",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face screaming in fear",
+    "emoji": "😱",
+    "names": [
+      "scream",
+    ],
+    "tags": [
+      "horror",
+      "shocked",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "confounded face",
+    "emoji": "😖",
+    "names": [
+      "confounded",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "persevering face",
+    "emoji": "😣",
+    "names": [
+      "persevere",
+    ],
+    "tags": [
+      "struggling",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "disappointed face",
+    "emoji": "😞",
+    "names": [
+      "disappointed",
+    ],
+    "tags": [
+      "sad",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "downcast face with sweat",
+    "emoji": "😓",
+    "names": [
+      "sweat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "weary face",
+    "emoji": "😩",
+    "names": [
+      "weary",
+    ],
+    "tags": [
+      "tired",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "tired face",
+    "emoji": "😫",
+    "names": [
+      "tired_face",
+    ],
+    "tags": [
+      "upset",
+      "whine",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "yawning face",
+    "emoji": "🥱",
+    "names": [
+      "yawning_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with steam from nose",
+    "emoji": "😤",
+    "names": [
+      "triumph",
+    ],
+    "tags": [
+      "smug",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "enraged face",
+    "emoji": "😡",
+    "names": [
+      "rage",
+      "pout",
+    ],
+    "tags": [
+      "angry",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "angry face",
+    "emoji": "😠",
+    "names": [
+      "angry",
+    ],
+    "tags": [
+      "mad",
+      "annoyed",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "face with symbols on mouth",
+    "emoji": "🤬",
+    "names": [
+      "cursing_face",
+    ],
+    "tags": [
+      "foul",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling face with horns",
+    "emoji": "😈",
+    "names": [
+      "smiling_imp",
+    ],
+    "tags": [
+      "devil",
+      "evil",
+      "horns",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "angry face with horns",
+    "emoji": "👿",
+    "names": [
+      "imp",
+    ],
+    "tags": [
+      "angry",
+      "devil",
+      "evil",
+      "horns",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "skull",
+    "emoji": "💀",
+    "names": [
+      "skull",
+    ],
+    "tags": [
+      "dead",
+      "danger",
+      "poison",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "skull and crossbones",
+    "emoji": "☠️",
+    "names": [
+      "skull_and_crossbones",
+    ],
+    "tags": [
+      "danger",
+      "pirate",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "pile of poo",
+    "emoji": "💩",
+    "names": [
+      "hankey",
+      "poop",
+      "shit",
+    ],
+    "tags": [
+      "crap",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "clown face",
+    "emoji": "🤡",
+    "names": [
+      "clown_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "ogre",
+    "emoji": "👹",
+    "names": [
+      "japanese_ogre",
+    ],
+    "tags": [
+      "monster",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "goblin",
+    "emoji": "👺",
+    "names": [
+      "japanese_goblin",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "ghost",
+    "emoji": "👻",
+    "names": [
+      "ghost",
+    ],
+    "tags": [
+      "halloween",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "alien",
+    "emoji": "👽",
+    "names": [
+      "alien",
+    ],
+    "tags": [
+      "ufo",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "alien monster",
+    "emoji": "👾",
+    "names": [
+      "space_invader",
+    ],
+    "tags": [
+      "game",
+      "retro",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "robot",
+    "emoji": "🤖",
+    "names": [
+      "robot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "grinning cat",
+    "emoji": "😺",
+    "names": [
+      "smiley_cat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "grinning cat with smiling eyes",
+    "emoji": "😸",
+    "names": [
+      "smile_cat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "cat with tears of joy",
+    "emoji": "😹",
+    "names": [
+      "joy_cat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "smiling cat with heart-eyes",
+    "emoji": "😻",
+    "names": [
+      "heart_eyes_cat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "cat with wry smile",
+    "emoji": "😼",
+    "names": [
+      "smirk_cat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "kissing cat",
+    "emoji": "😽",
+    "names": [
+      "kissing_cat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "weary cat",
+    "emoji": "🙀",
+    "names": [
+      "scream_cat",
+    ],
+    "tags": [
+      "horror",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "crying cat",
+    "emoji": "😿",
+    "names": [
+      "crying_cat_face",
+    ],
+    "tags": [
+      "sad",
+      "tear",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "pouting cat",
+    "emoji": "😾",
+    "names": [
+      "pouting_cat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "see-no-evil monkey",
+    "emoji": "🙈",
+    "names": [
+      "see_no_evil",
+    ],
+    "tags": [
+      "monkey",
+      "blind",
+      "ignore",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "hear-no-evil monkey",
+    "emoji": "🙉",
+    "names": [
+      "hear_no_evil",
+    ],
+    "tags": [
+      "monkey",
+      "deaf",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "speak-no-evil monkey",
+    "emoji": "🙊",
+    "names": [
+      "speak_no_evil",
+    ],
+    "tags": [
+      "monkey",
+      "mute",
+      "hush",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "love letter",
+    "emoji": "💌",
+    "names": [
+      "love_letter",
+    ],
+    "tags": [
+      "email",
+      "envelope",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "heart with arrow",
+    "emoji": "💘",
+    "names": [
+      "cupid",
+    ],
+    "tags": [
+      "love",
+      "heart",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "heart with ribbon",
+    "emoji": "💝",
+    "names": [
+      "gift_heart",
+    ],
+    "tags": [
+      "chocolates",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "sparkling heart",
+    "emoji": "💖",
+    "names": [
+      "sparkling_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "growing heart",
+    "emoji": "💗",
+    "names": [
+      "heartpulse",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "beating heart",
+    "emoji": "💓",
+    "names": [
+      "heartbeat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "revolving hearts",
+    "emoji": "💞",
+    "names": [
+      "revolving_hearts",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "two hearts",
+    "emoji": "💕",
+    "names": [
+      "two_hearts",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "heart decoration",
+    "emoji": "💟",
+    "names": [
+      "heart_decoration",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "heart exclamation",
+    "emoji": "❣️",
+    "names": [
+      "heavy_heart_exclamation",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "broken heart",
+    "emoji": "💔",
+    "names": [
+      "broken_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "heart on fire",
+    "emoji": "❤️‍🔥",
+    "names": [
+      "heart_on_fire",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "mending heart",
+    "emoji": "❤️‍🩹",
+    "names": [
+      "mending_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "red heart",
+    "emoji": "❤️",
+    "names": [
+      "heart",
+    ],
+    "tags": [
+      "love",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "pink heart",
+    "emoji": "🩷",
+    "names": [
+      "pink_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "orange heart",
+    "emoji": "🧡",
+    "names": [
+      "orange_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "yellow heart",
+    "emoji": "💛",
+    "names": [
+      "yellow_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "green heart",
+    "emoji": "💚",
+    "names": [
+      "green_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "blue heart",
+    "emoji": "💙",
+    "names": [
+      "blue_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "light blue heart",
+    "emoji": "🩵",
+    "names": [
+      "light_blue_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "purple heart",
+    "emoji": "💜",
+    "names": [
+      "purple_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "brown heart",
+    "emoji": "🤎",
+    "names": [
+      "brown_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "black heart",
+    "emoji": "🖤",
+    "names": [
+      "black_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "grey heart",
+    "emoji": "🩶",
+    "names": [
+      "grey_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "white heart",
+    "emoji": "🤍",
+    "names": [
+      "white_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "kiss mark",
+    "emoji": "💋",
+    "names": [
+      "kiss",
+    ],
+    "tags": [
+      "lipstick",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "hundred points",
+    "emoji": "💯",
+    "names": [
+      "100",
+    ],
+    "tags": [
+      "score",
+      "perfect",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "anger symbol",
+    "emoji": "💢",
+    "names": [
+      "anger",
+    ],
+    "tags": [
+      "angry",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "collision",
+    "emoji": "💥",
+    "names": [
+      "boom",
+      "collision",
+    ],
+    "tags": [
+      "explode",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "dizzy",
+    "emoji": "💫",
+    "names": [
+      "dizzy",
+    ],
+    "tags": [
+      "star",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "sweat droplets",
+    "emoji": "💦",
+    "names": [
+      "sweat_drops",
+    ],
+    "tags": [
+      "water",
+      "workout",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "dashing away",
+    "emoji": "💨",
+    "names": [
+      "dash",
+    ],
+    "tags": [
+      "wind",
+      "blow",
+      "fast",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "hole",
+    "emoji": "🕳️",
+    "names": [
+      "hole",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "speech balloon",
+    "emoji": "💬",
+    "names": [
+      "speech_balloon",
+    ],
+    "tags": [
+      "comment",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "eye in speech bubble",
+    "emoji": "👁️‍🗨️",
+    "names": [
+      "eye_speech_bubble",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "left speech bubble",
+    "emoji": "🗨️",
+    "names": [
+      "left_speech_bubble",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "right anger bubble",
+    "emoji": "🗯️",
+    "names": [
+      "right_anger_bubble",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "thought balloon",
+    "emoji": "💭",
+    "names": [
+      "thought_balloon",
+    ],
+    "tags": [
+      "thinking",
+    ],
+  },
+  {
+    "category": "Smileys & Emotion",
+    "description": "ZZZ",
+    "emoji": "💤",
+    "names": [
+      "zzz",
+    ],
+    "tags": [
+      "sleeping",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "waving hand",
+    "emoji": "👋",
+    "names": [
+      "wave",
+    ],
+    "tags": [
+      "goodbye",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "raised back of hand",
+    "emoji": "🤚",
+    "names": [
+      "raised_back_of_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "hand with fingers splayed",
+    "emoji": "🖐️",
+    "names": [
+      "raised_hand_with_fingers_splayed",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "raised hand",
+    "emoji": "✋",
+    "names": [
+      "hand",
+      "raised_hand",
+    ],
+    "tags": [
+      "highfive",
+      "stop",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "vulcan salute",
+    "emoji": "🖖",
+    "names": [
+      "vulcan_salute",
+    ],
+    "tags": [
+      "prosper",
+      "spock",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "rightwards hand",
+    "emoji": "🫱",
+    "names": [
+      "rightwards_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "leftwards hand",
+    "emoji": "🫲",
+    "names": [
+      "leftwards_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "palm down hand",
+    "emoji": "🫳",
+    "names": [
+      "palm_down_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "palm up hand",
+    "emoji": "🫴",
+    "names": [
+      "palm_up_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "leftwards pushing hand",
+    "emoji": "🫷",
+    "names": [
+      "leftwards_pushing_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "rightwards pushing hand",
+    "emoji": "🫸",
+    "names": [
+      "rightwards_pushing_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "OK hand",
+    "emoji": "👌",
+    "names": [
+      "ok_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "pinched fingers",
+    "emoji": "🤌",
+    "names": [
+      "pinched_fingers",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "pinching hand",
+    "emoji": "🤏",
+    "names": [
+      "pinching_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "victory hand",
+    "emoji": "✌️",
+    "names": [
+      "v",
+    ],
+    "tags": [
+      "victory",
+      "peace",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "crossed fingers",
+    "emoji": "🤞",
+    "names": [
+      "crossed_fingers",
+    ],
+    "tags": [
+      "luck",
+      "hopeful",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "hand with index finger and thumb crossed",
+    "emoji": "🫰",
+    "names": [
+      "hand_with_index_finger_and_thumb_crossed",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "love-you gesture",
+    "emoji": "🤟",
+    "names": [
+      "love_you_gesture",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "sign of the horns",
+    "emoji": "🤘",
+    "names": [
+      "metal",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "call me hand",
+    "emoji": "🤙",
+    "names": [
+      "call_me_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "backhand index pointing left",
+    "emoji": "👈",
+    "names": [
+      "point_left",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "backhand index pointing right",
+    "emoji": "👉",
+    "names": [
+      "point_right",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "backhand index pointing up",
+    "emoji": "👆",
+    "names": [
+      "point_up_2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "middle finger",
+    "emoji": "🖕",
+    "names": [
+      "middle_finger",
+      "fu",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "backhand index pointing down",
+    "emoji": "👇",
+    "names": [
+      "point_down",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "index pointing up",
+    "emoji": "☝️",
+    "names": [
+      "point_up",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "index pointing at the viewer",
+    "emoji": "🫵",
+    "names": [
+      "index_pointing_at_the_viewer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "thumbs up",
+    "emoji": "👍",
+    "names": [
+      "+1",
+      "thumbsup",
+    ],
+    "tags": [
+      "approve",
+      "ok",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "thumbs down",
+    "emoji": "👎",
+    "names": [
+      "-1",
+      "thumbsdown",
+    ],
+    "tags": [
+      "disapprove",
+      "bury",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "raised fist",
+    "emoji": "✊",
+    "names": [
+      "fist_raised",
+      "fist",
+    ],
+    "tags": [
+      "power",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "oncoming fist",
+    "emoji": "👊",
+    "names": [
+      "fist_oncoming",
+      "facepunch",
+      "punch",
+    ],
+    "tags": [
+      "attack",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "left-facing fist",
+    "emoji": "🤛",
+    "names": [
+      "fist_left",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "right-facing fist",
+    "emoji": "🤜",
+    "names": [
+      "fist_right",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "clapping hands",
+    "emoji": "👏",
+    "names": [
+      "clap",
+    ],
+    "tags": [
+      "praise",
+      "applause",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "raising hands",
+    "emoji": "🙌",
+    "names": [
+      "raised_hands",
+    ],
+    "tags": [
+      "hooray",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "heart hands",
+    "emoji": "🫶",
+    "names": [
+      "heart_hands",
+    ],
+    "tags": [
+      "love",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "open hands",
+    "emoji": "👐",
+    "names": [
+      "open_hands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "palms up together",
+    "emoji": "🤲",
+    "names": [
+      "palms_up_together",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "handshake",
+    "emoji": "🤝",
+    "names": [
+      "handshake",
+    ],
+    "tags": [
+      "deal",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "folded hands",
+    "emoji": "🙏",
+    "names": [
+      "pray",
+    ],
+    "tags": [
+      "please",
+      "hope",
+      "wish",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "writing hand",
+    "emoji": "✍️",
+    "names": [
+      "writing_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "nail polish",
+    "emoji": "💅",
+    "names": [
+      "nail_care",
+    ],
+    "tags": [
+      "beauty",
+      "manicure",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "selfie",
+    "emoji": "🤳",
+    "names": [
+      "selfie",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "flexed biceps",
+    "emoji": "💪",
+    "names": [
+      "muscle",
+    ],
+    "tags": [
+      "flex",
+      "bicep",
+      "strong",
+      "workout",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "mechanical arm",
+    "emoji": "🦾",
+    "names": [
+      "mechanical_arm",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "mechanical leg",
+    "emoji": "🦿",
+    "names": [
+      "mechanical_leg",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "leg",
+    "emoji": "🦵",
+    "names": [
+      "leg",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "foot",
+    "emoji": "🦶",
+    "names": [
+      "foot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "ear",
+    "emoji": "👂",
+    "names": [
+      "ear",
+    ],
+    "tags": [
+      "hear",
+      "sound",
+      "listen",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "ear with hearing aid",
+    "emoji": "🦻",
+    "names": [
+      "ear_with_hearing_aid",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "nose",
+    "emoji": "👃",
+    "names": [
+      "nose",
+    ],
+    "tags": [
+      "smell",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "brain",
+    "emoji": "🧠",
+    "names": [
+      "brain",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "anatomical heart",
+    "emoji": "🫀",
+    "names": [
+      "anatomical_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "lungs",
+    "emoji": "🫁",
+    "names": [
+      "lungs",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "tooth",
+    "emoji": "🦷",
+    "names": [
+      "tooth",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "bone",
+    "emoji": "🦴",
+    "names": [
+      "bone",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "eyes",
+    "emoji": "👀",
+    "names": [
+      "eyes",
+    ],
+    "tags": [
+      "look",
+      "see",
+      "watch",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "eye",
+    "emoji": "👁️",
+    "names": [
+      "eye",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "tongue",
+    "emoji": "👅",
+    "names": [
+      "tongue",
+    ],
+    "tags": [
+      "taste",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "mouth",
+    "emoji": "👄",
+    "names": [
+      "lips",
+    ],
+    "tags": [
+      "kiss",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "biting lip",
+    "emoji": "🫦",
+    "names": [
+      "biting_lip",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "baby",
+    "emoji": "👶",
+    "names": [
+      "baby",
+    ],
+    "tags": [
+      "child",
+      "newborn",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "child",
+    "emoji": "🧒",
+    "names": [
+      "child",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "boy",
+    "emoji": "👦",
+    "names": [
+      "boy",
+    ],
+    "tags": [
+      "child",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "girl",
+    "emoji": "👧",
+    "names": [
+      "girl",
+    ],
+    "tags": [
+      "child",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person",
+    "emoji": "🧑",
+    "names": [
+      "adult",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person: blond hair",
+    "emoji": "👱",
+    "names": [
+      "blond_haired_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man",
+    "emoji": "👨",
+    "names": [
+      "man",
+    ],
+    "tags": [
+      "mustache",
+      "father",
+      "dad",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person: beard",
+    "emoji": "🧔",
+    "names": [
+      "bearded_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man: beard",
+    "emoji": "🧔‍♂️",
+    "names": [
+      "man_beard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman: beard",
+    "emoji": "🧔‍♀️",
+    "names": [
+      "woman_beard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man: red hair",
+    "emoji": "👨‍🦰",
+    "names": [
+      "red_haired_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man: curly hair",
+    "emoji": "👨‍🦱",
+    "names": [
+      "curly_haired_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man: white hair",
+    "emoji": "👨‍🦳",
+    "names": [
+      "white_haired_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man: bald",
+    "emoji": "👨‍🦲",
+    "names": [
+      "bald_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman",
+    "emoji": "👩",
+    "names": [
+      "woman",
+    ],
+    "tags": [
+      "girls",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman: red hair",
+    "emoji": "👩‍🦰",
+    "names": [
+      "red_haired_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person: red hair",
+    "emoji": "🧑‍🦰",
+    "names": [
+      "person_red_hair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman: curly hair",
+    "emoji": "👩‍🦱",
+    "names": [
+      "curly_haired_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person: curly hair",
+    "emoji": "🧑‍🦱",
+    "names": [
+      "person_curly_hair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman: white hair",
+    "emoji": "👩‍🦳",
+    "names": [
+      "white_haired_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person: white hair",
+    "emoji": "🧑‍🦳",
+    "names": [
+      "person_white_hair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman: bald",
+    "emoji": "👩‍🦲",
+    "names": [
+      "bald_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person: bald",
+    "emoji": "🧑‍🦲",
+    "names": [
+      "person_bald",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman: blond hair",
+    "emoji": "👱‍♀️",
+    "names": [
+      "blond_haired_woman",
+      "blonde_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man: blond hair",
+    "emoji": "👱‍♂️",
+    "names": [
+      "blond_haired_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "older person",
+    "emoji": "🧓",
+    "names": [
+      "older_adult",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "old man",
+    "emoji": "👴",
+    "names": [
+      "older_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "old woman",
+    "emoji": "👵",
+    "names": [
+      "older_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person frowning",
+    "emoji": "🙍",
+    "names": [
+      "frowning_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man frowning",
+    "emoji": "🙍‍♂️",
+    "names": [
+      "frowning_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman frowning",
+    "emoji": "🙍‍♀️",
+    "names": [
+      "frowning_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person pouting",
+    "emoji": "🙎",
+    "names": [
+      "pouting_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man pouting",
+    "emoji": "🙎‍♂️",
+    "names": [
+      "pouting_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman pouting",
+    "emoji": "🙎‍♀️",
+    "names": [
+      "pouting_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person gesturing NO",
+    "emoji": "🙅",
+    "names": [
+      "no_good",
+    ],
+    "tags": [
+      "stop",
+      "halt",
+      "denied",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man gesturing NO",
+    "emoji": "🙅‍♂️",
+    "names": [
+      "no_good_man",
+      "ng_man",
+    ],
+    "tags": [
+      "stop",
+      "halt",
+      "denied",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman gesturing NO",
+    "emoji": "🙅‍♀️",
+    "names": [
+      "no_good_woman",
+      "ng_woman",
+    ],
+    "tags": [
+      "stop",
+      "halt",
+      "denied",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person gesturing OK",
+    "emoji": "🙆",
+    "names": [
+      "ok_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man gesturing OK",
+    "emoji": "🙆‍♂️",
+    "names": [
+      "ok_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman gesturing OK",
+    "emoji": "🙆‍♀️",
+    "names": [
+      "ok_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person tipping hand",
+    "emoji": "💁",
+    "names": [
+      "tipping_hand_person",
+      "information_desk_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man tipping hand",
+    "emoji": "💁‍♂️",
+    "names": [
+      "tipping_hand_man",
+      "sassy_man",
+    ],
+    "tags": [
+      "information",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman tipping hand",
+    "emoji": "💁‍♀️",
+    "names": [
+      "tipping_hand_woman",
+      "sassy_woman",
+    ],
+    "tags": [
+      "information",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person raising hand",
+    "emoji": "🙋",
+    "names": [
+      "raising_hand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man raising hand",
+    "emoji": "🙋‍♂️",
+    "names": [
+      "raising_hand_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman raising hand",
+    "emoji": "🙋‍♀️",
+    "names": [
+      "raising_hand_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "deaf person",
+    "emoji": "🧏",
+    "names": [
+      "deaf_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "deaf man",
+    "emoji": "🧏‍♂️",
+    "names": [
+      "deaf_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "deaf woman",
+    "emoji": "🧏‍♀️",
+    "names": [
+      "deaf_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person bowing",
+    "emoji": "🙇",
+    "names": [
+      "bow",
+    ],
+    "tags": [
+      "respect",
+      "thanks",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man bowing",
+    "emoji": "🙇‍♂️",
+    "names": [
+      "bowing_man",
+    ],
+    "tags": [
+      "respect",
+      "thanks",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman bowing",
+    "emoji": "🙇‍♀️",
+    "names": [
+      "bowing_woman",
+    ],
+    "tags": [
+      "respect",
+      "thanks",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person facepalming",
+    "emoji": "🤦",
+    "names": [
+      "facepalm",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man facepalming",
+    "emoji": "🤦‍♂️",
+    "names": [
+      "man_facepalming",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman facepalming",
+    "emoji": "🤦‍♀️",
+    "names": [
+      "woman_facepalming",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person shrugging",
+    "emoji": "🤷",
+    "names": [
+      "shrug",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man shrugging",
+    "emoji": "🤷‍♂️",
+    "names": [
+      "man_shrugging",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman shrugging",
+    "emoji": "🤷‍♀️",
+    "names": [
+      "woman_shrugging",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "health worker",
+    "emoji": "🧑‍⚕️",
+    "names": [
+      "health_worker",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man health worker",
+    "emoji": "👨‍⚕️",
+    "names": [
+      "man_health_worker",
+    ],
+    "tags": [
+      "doctor",
+      "nurse",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman health worker",
+    "emoji": "👩‍⚕️",
+    "names": [
+      "woman_health_worker",
+    ],
+    "tags": [
+      "doctor",
+      "nurse",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "student",
+    "emoji": "🧑‍🎓",
+    "names": [
+      "student",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man student",
+    "emoji": "👨‍🎓",
+    "names": [
+      "man_student",
+    ],
+    "tags": [
+      "graduation",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman student",
+    "emoji": "👩‍🎓",
+    "names": [
+      "woman_student",
+    ],
+    "tags": [
+      "graduation",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "teacher",
+    "emoji": "🧑‍🏫",
+    "names": [
+      "teacher",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man teacher",
+    "emoji": "👨‍🏫",
+    "names": [
+      "man_teacher",
+    ],
+    "tags": [
+      "school",
+      "professor",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman teacher",
+    "emoji": "👩‍🏫",
+    "names": [
+      "woman_teacher",
+    ],
+    "tags": [
+      "school",
+      "professor",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "judge",
+    "emoji": "🧑‍⚖️",
+    "names": [
+      "judge",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man judge",
+    "emoji": "👨‍⚖️",
+    "names": [
+      "man_judge",
+    ],
+    "tags": [
+      "justice",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman judge",
+    "emoji": "👩‍⚖️",
+    "names": [
+      "woman_judge",
+    ],
+    "tags": [
+      "justice",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "farmer",
+    "emoji": "🧑‍🌾",
+    "names": [
+      "farmer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man farmer",
+    "emoji": "👨‍🌾",
+    "names": [
+      "man_farmer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman farmer",
+    "emoji": "👩‍🌾",
+    "names": [
+      "woman_farmer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "cook",
+    "emoji": "🧑‍🍳",
+    "names": [
+      "cook",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man cook",
+    "emoji": "👨‍🍳",
+    "names": [
+      "man_cook",
+    ],
+    "tags": [
+      "chef",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman cook",
+    "emoji": "👩‍🍳",
+    "names": [
+      "woman_cook",
+    ],
+    "tags": [
+      "chef",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "mechanic",
+    "emoji": "🧑‍🔧",
+    "names": [
+      "mechanic",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man mechanic",
+    "emoji": "👨‍🔧",
+    "names": [
+      "man_mechanic",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman mechanic",
+    "emoji": "👩‍🔧",
+    "names": [
+      "woman_mechanic",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "factory worker",
+    "emoji": "🧑‍🏭",
+    "names": [
+      "factory_worker",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man factory worker",
+    "emoji": "👨‍🏭",
+    "names": [
+      "man_factory_worker",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman factory worker",
+    "emoji": "👩‍🏭",
+    "names": [
+      "woman_factory_worker",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "office worker",
+    "emoji": "🧑‍💼",
+    "names": [
+      "office_worker",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man office worker",
+    "emoji": "👨‍💼",
+    "names": [
+      "man_office_worker",
+    ],
+    "tags": [
+      "business",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman office worker",
+    "emoji": "👩‍💼",
+    "names": [
+      "woman_office_worker",
+    ],
+    "tags": [
+      "business",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "scientist",
+    "emoji": "🧑‍🔬",
+    "names": [
+      "scientist",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man scientist",
+    "emoji": "👨‍🔬",
+    "names": [
+      "man_scientist",
+    ],
+    "tags": [
+      "research",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman scientist",
+    "emoji": "👩‍🔬",
+    "names": [
+      "woman_scientist",
+    ],
+    "tags": [
+      "research",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "technologist",
+    "emoji": "🧑‍💻",
+    "names": [
+      "technologist",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man technologist",
+    "emoji": "👨‍💻",
+    "names": [
+      "man_technologist",
+    ],
+    "tags": [
+      "coder",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman technologist",
+    "emoji": "👩‍💻",
+    "names": [
+      "woman_technologist",
+    ],
+    "tags": [
+      "coder",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "singer",
+    "emoji": "🧑‍🎤",
+    "names": [
+      "singer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man singer",
+    "emoji": "👨‍🎤",
+    "names": [
+      "man_singer",
+    ],
+    "tags": [
+      "rockstar",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman singer",
+    "emoji": "👩‍🎤",
+    "names": [
+      "woman_singer",
+    ],
+    "tags": [
+      "rockstar",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "artist",
+    "emoji": "🧑‍🎨",
+    "names": [
+      "artist",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man artist",
+    "emoji": "👨‍🎨",
+    "names": [
+      "man_artist",
+    ],
+    "tags": [
+      "painter",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman artist",
+    "emoji": "👩‍🎨",
+    "names": [
+      "woman_artist",
+    ],
+    "tags": [
+      "painter",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "pilot",
+    "emoji": "🧑‍✈️",
+    "names": [
+      "pilot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man pilot",
+    "emoji": "👨‍✈️",
+    "names": [
+      "man_pilot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman pilot",
+    "emoji": "👩‍✈️",
+    "names": [
+      "woman_pilot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "astronaut",
+    "emoji": "🧑‍🚀",
+    "names": [
+      "astronaut",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man astronaut",
+    "emoji": "👨‍🚀",
+    "names": [
+      "man_astronaut",
+    ],
+    "tags": [
+      "space",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman astronaut",
+    "emoji": "👩‍🚀",
+    "names": [
+      "woman_astronaut",
+    ],
+    "tags": [
+      "space",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "firefighter",
+    "emoji": "🧑‍🚒",
+    "names": [
+      "firefighter",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man firefighter",
+    "emoji": "👨‍🚒",
+    "names": [
+      "man_firefighter",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman firefighter",
+    "emoji": "👩‍🚒",
+    "names": [
+      "woman_firefighter",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "police officer",
+    "emoji": "👮",
+    "names": [
+      "police_officer",
+      "cop",
+    ],
+    "tags": [
+      "law",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man police officer",
+    "emoji": "👮‍♂️",
+    "names": [
+      "policeman",
+    ],
+    "tags": [
+      "law",
+      "cop",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman police officer",
+    "emoji": "👮‍♀️",
+    "names": [
+      "policewoman",
+    ],
+    "tags": [
+      "law",
+      "cop",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "detective",
+    "emoji": "🕵️",
+    "names": [
+      "detective",
+    ],
+    "tags": [
+      "sleuth",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man detective",
+    "emoji": "🕵️‍♂️",
+    "names": [
+      "male_detective",
+    ],
+    "tags": [
+      "sleuth",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman detective",
+    "emoji": "🕵️‍♀️",
+    "names": [
+      "female_detective",
+    ],
+    "tags": [
+      "sleuth",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "guard",
+    "emoji": "💂",
+    "names": [
+      "guard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man guard",
+    "emoji": "💂‍♂️",
+    "names": [
+      "guardsman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman guard",
+    "emoji": "💂‍♀️",
+    "names": [
+      "guardswoman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "ninja",
+    "emoji": "🥷",
+    "names": [
+      "ninja",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "construction worker",
+    "emoji": "👷",
+    "names": [
+      "construction_worker",
+    ],
+    "tags": [
+      "helmet",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man construction worker",
+    "emoji": "👷‍♂️",
+    "names": [
+      "construction_worker_man",
+    ],
+    "tags": [
+      "helmet",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman construction worker",
+    "emoji": "👷‍♀️",
+    "names": [
+      "construction_worker_woman",
+    ],
+    "tags": [
+      "helmet",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person with crown",
+    "emoji": "🫅",
+    "names": [
+      "person_with_crown",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "prince",
+    "emoji": "🤴",
+    "names": [
+      "prince",
+    ],
+    "tags": [
+      "crown",
+      "royal",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "princess",
+    "emoji": "👸",
+    "names": [
+      "princess",
+    ],
+    "tags": [
+      "crown",
+      "royal",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person wearing turban",
+    "emoji": "👳",
+    "names": [
+      "person_with_turban",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man wearing turban",
+    "emoji": "👳‍♂️",
+    "names": [
+      "man_with_turban",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman wearing turban",
+    "emoji": "👳‍♀️",
+    "names": [
+      "woman_with_turban",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person with skullcap",
+    "emoji": "👲",
+    "names": [
+      "man_with_gua_pi_mao",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman with headscarf",
+    "emoji": "🧕",
+    "names": [
+      "woman_with_headscarf",
+    ],
+    "tags": [
+      "hijab",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person in tuxedo",
+    "emoji": "🤵",
+    "names": [
+      "person_in_tuxedo",
+    ],
+    "tags": [
+      "groom",
+      "marriage",
+      "wedding",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man in tuxedo",
+    "emoji": "🤵‍♂️",
+    "names": [
+      "man_in_tuxedo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman in tuxedo",
+    "emoji": "🤵‍♀️",
+    "names": [
+      "woman_in_tuxedo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person with veil",
+    "emoji": "👰",
+    "names": [
+      "person_with_veil",
+    ],
+    "tags": [
+      "marriage",
+      "wedding",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man with veil",
+    "emoji": "👰‍♂️",
+    "names": [
+      "man_with_veil",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman with veil",
+    "emoji": "👰‍♀️",
+    "names": [
+      "woman_with_veil",
+      "bride_with_veil",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "pregnant woman",
+    "emoji": "🤰",
+    "names": [
+      "pregnant_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "pregnant man",
+    "emoji": "🫃",
+    "names": [
+      "pregnant_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "pregnant person",
+    "emoji": "🫄",
+    "names": [
+      "pregnant_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "breast-feeding",
+    "emoji": "🤱",
+    "names": [
+      "breast_feeding",
+    ],
+    "tags": [
+      "nursing",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman feeding baby",
+    "emoji": "👩‍🍼",
+    "names": [
+      "woman_feeding_baby",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man feeding baby",
+    "emoji": "👨‍🍼",
+    "names": [
+      "man_feeding_baby",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person feeding baby",
+    "emoji": "🧑‍🍼",
+    "names": [
+      "person_feeding_baby",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "baby angel",
+    "emoji": "👼",
+    "names": [
+      "angel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "Santa Claus",
+    "emoji": "🎅",
+    "names": [
+      "santa",
+    ],
+    "tags": [
+      "christmas",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "Mrs. Claus",
+    "emoji": "🤶",
+    "names": [
+      "mrs_claus",
+    ],
+    "tags": [
+      "santa",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "mx claus",
+    "emoji": "🧑‍🎄",
+    "names": [
+      "mx_claus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "superhero",
+    "emoji": "🦸",
+    "names": [
+      "superhero",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man superhero",
+    "emoji": "🦸‍♂️",
+    "names": [
+      "superhero_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman superhero",
+    "emoji": "🦸‍♀️",
+    "names": [
+      "superhero_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "supervillain",
+    "emoji": "🦹",
+    "names": [
+      "supervillain",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man supervillain",
+    "emoji": "🦹‍♂️",
+    "names": [
+      "supervillain_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman supervillain",
+    "emoji": "🦹‍♀️",
+    "names": [
+      "supervillain_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "mage",
+    "emoji": "🧙",
+    "names": [
+      "mage",
+    ],
+    "tags": [
+      "wizard",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man mage",
+    "emoji": "🧙‍♂️",
+    "names": [
+      "mage_man",
+    ],
+    "tags": [
+      "wizard",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman mage",
+    "emoji": "🧙‍♀️",
+    "names": [
+      "mage_woman",
+    ],
+    "tags": [
+      "wizard",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "fairy",
+    "emoji": "🧚",
+    "names": [
+      "fairy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man fairy",
+    "emoji": "🧚‍♂️",
+    "names": [
+      "fairy_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman fairy",
+    "emoji": "🧚‍♀️",
+    "names": [
+      "fairy_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "vampire",
+    "emoji": "🧛",
+    "names": [
+      "vampire",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man vampire",
+    "emoji": "🧛‍♂️",
+    "names": [
+      "vampire_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman vampire",
+    "emoji": "🧛‍♀️",
+    "names": [
+      "vampire_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "merperson",
+    "emoji": "🧜",
+    "names": [
+      "merperson",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "merman",
+    "emoji": "🧜‍♂️",
+    "names": [
+      "merman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "mermaid",
+    "emoji": "🧜‍♀️",
+    "names": [
+      "mermaid",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "elf",
+    "emoji": "🧝",
+    "names": [
+      "elf",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man elf",
+    "emoji": "🧝‍♂️",
+    "names": [
+      "elf_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman elf",
+    "emoji": "🧝‍♀️",
+    "names": [
+      "elf_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "genie",
+    "emoji": "🧞",
+    "names": [
+      "genie",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man genie",
+    "emoji": "🧞‍♂️",
+    "names": [
+      "genie_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman genie",
+    "emoji": "🧞‍♀️",
+    "names": [
+      "genie_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "zombie",
+    "emoji": "🧟",
+    "names": [
+      "zombie",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man zombie",
+    "emoji": "🧟‍♂️",
+    "names": [
+      "zombie_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman zombie",
+    "emoji": "🧟‍♀️",
+    "names": [
+      "zombie_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "troll",
+    "emoji": "🧌",
+    "names": [
+      "troll",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person getting massage",
+    "emoji": "💆",
+    "names": [
+      "massage",
+    ],
+    "tags": [
+      "spa",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man getting massage",
+    "emoji": "💆‍♂️",
+    "names": [
+      "massage_man",
+    ],
+    "tags": [
+      "spa",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman getting massage",
+    "emoji": "💆‍♀️",
+    "names": [
+      "massage_woman",
+    ],
+    "tags": [
+      "spa",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person getting haircut",
+    "emoji": "💇",
+    "names": [
+      "haircut",
+    ],
+    "tags": [
+      "beauty",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man getting haircut",
+    "emoji": "💇‍♂️",
+    "names": [
+      "haircut_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman getting haircut",
+    "emoji": "💇‍♀️",
+    "names": [
+      "haircut_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person walking",
+    "emoji": "🚶",
+    "names": [
+      "walking",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man walking",
+    "emoji": "🚶‍♂️",
+    "names": [
+      "walking_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman walking",
+    "emoji": "🚶‍♀️",
+    "names": [
+      "walking_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person standing",
+    "emoji": "🧍",
+    "names": [
+      "standing_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man standing",
+    "emoji": "🧍‍♂️",
+    "names": [
+      "standing_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman standing",
+    "emoji": "🧍‍♀️",
+    "names": [
+      "standing_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person kneeling",
+    "emoji": "🧎",
+    "names": [
+      "kneeling_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man kneeling",
+    "emoji": "🧎‍♂️",
+    "names": [
+      "kneeling_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman kneeling",
+    "emoji": "🧎‍♀️",
+    "names": [
+      "kneeling_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person with white cane",
+    "emoji": "🧑‍🦯",
+    "names": [
+      "person_with_probing_cane",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man with white cane",
+    "emoji": "👨‍🦯",
+    "names": [
+      "man_with_probing_cane",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman with white cane",
+    "emoji": "👩‍🦯",
+    "names": [
+      "woman_with_probing_cane",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person in motorized wheelchair",
+    "emoji": "🧑‍🦼",
+    "names": [
+      "person_in_motorized_wheelchair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man in motorized wheelchair",
+    "emoji": "👨‍🦼",
+    "names": [
+      "man_in_motorized_wheelchair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman in motorized wheelchair",
+    "emoji": "👩‍🦼",
+    "names": [
+      "woman_in_motorized_wheelchair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person in manual wheelchair",
+    "emoji": "🧑‍🦽",
+    "names": [
+      "person_in_manual_wheelchair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man in manual wheelchair",
+    "emoji": "👨‍🦽",
+    "names": [
+      "man_in_manual_wheelchair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman in manual wheelchair",
+    "emoji": "👩‍🦽",
+    "names": [
+      "woman_in_manual_wheelchair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person running",
+    "emoji": "🏃",
+    "names": [
+      "runner",
+      "running",
+    ],
+    "tags": [
+      "exercise",
+      "workout",
+      "marathon",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man running",
+    "emoji": "🏃‍♂️",
+    "names": [
+      "running_man",
+    ],
+    "tags": [
+      "exercise",
+      "workout",
+      "marathon",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman running",
+    "emoji": "🏃‍♀️",
+    "names": [
+      "running_woman",
+    ],
+    "tags": [
+      "exercise",
+      "workout",
+      "marathon",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman dancing",
+    "emoji": "💃",
+    "names": [
+      "woman_dancing",
+      "dancer",
+    ],
+    "tags": [
+      "dress",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man dancing",
+    "emoji": "🕺",
+    "names": [
+      "man_dancing",
+    ],
+    "tags": [
+      "dancer",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person in suit levitating",
+    "emoji": "🕴️",
+    "names": [
+      "business_suit_levitating",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "people with bunny ears",
+    "emoji": "👯",
+    "names": [
+      "dancers",
+    ],
+    "tags": [
+      "bunny",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "men with bunny ears",
+    "emoji": "👯‍♂️",
+    "names": [
+      "dancing_men",
+    ],
+    "tags": [
+      "bunny",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "women with bunny ears",
+    "emoji": "👯‍♀️",
+    "names": [
+      "dancing_women",
+    ],
+    "tags": [
+      "bunny",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person in steamy room",
+    "emoji": "🧖",
+    "names": [
+      "sauna_person",
+    ],
+    "tags": [
+      "steamy",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man in steamy room",
+    "emoji": "🧖‍♂️",
+    "names": [
+      "sauna_man",
+    ],
+    "tags": [
+      "steamy",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman in steamy room",
+    "emoji": "🧖‍♀️",
+    "names": [
+      "sauna_woman",
+    ],
+    "tags": [
+      "steamy",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person climbing",
+    "emoji": "🧗",
+    "names": [
+      "climbing",
+    ],
+    "tags": [
+      "bouldering",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man climbing",
+    "emoji": "🧗‍♂️",
+    "names": [
+      "climbing_man",
+    ],
+    "tags": [
+      "bouldering",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman climbing",
+    "emoji": "🧗‍♀️",
+    "names": [
+      "climbing_woman",
+    ],
+    "tags": [
+      "bouldering",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person fencing",
+    "emoji": "🤺",
+    "names": [
+      "person_fencing",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "horse racing",
+    "emoji": "🏇",
+    "names": [
+      "horse_racing",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "skier",
+    "emoji": "⛷️",
+    "names": [
+      "skier",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "snowboarder",
+    "emoji": "🏂",
+    "names": [
+      "snowboarder",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person golfing",
+    "emoji": "🏌️",
+    "names": [
+      "golfing",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man golfing",
+    "emoji": "🏌️‍♂️",
+    "names": [
+      "golfing_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman golfing",
+    "emoji": "🏌️‍♀️",
+    "names": [
+      "golfing_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person surfing",
+    "emoji": "🏄",
+    "names": [
+      "surfer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man surfing",
+    "emoji": "🏄‍♂️",
+    "names": [
+      "surfing_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman surfing",
+    "emoji": "🏄‍♀️",
+    "names": [
+      "surfing_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person rowing boat",
+    "emoji": "🚣",
+    "names": [
+      "rowboat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man rowing boat",
+    "emoji": "🚣‍♂️",
+    "names": [
+      "rowing_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman rowing boat",
+    "emoji": "🚣‍♀️",
+    "names": [
+      "rowing_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person swimming",
+    "emoji": "🏊",
+    "names": [
+      "swimmer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man swimming",
+    "emoji": "🏊‍♂️",
+    "names": [
+      "swimming_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman swimming",
+    "emoji": "🏊‍♀️",
+    "names": [
+      "swimming_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person bouncing ball",
+    "emoji": "⛹️",
+    "names": [
+      "bouncing_ball_person",
+    ],
+    "tags": [
+      "basketball",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man bouncing ball",
+    "emoji": "⛹️‍♂️",
+    "names": [
+      "bouncing_ball_man",
+      "basketball_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman bouncing ball",
+    "emoji": "⛹️‍♀️",
+    "names": [
+      "bouncing_ball_woman",
+      "basketball_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person lifting weights",
+    "emoji": "🏋️",
+    "names": [
+      "weight_lifting",
+    ],
+    "tags": [
+      "gym",
+      "workout",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man lifting weights",
+    "emoji": "🏋️‍♂️",
+    "names": [
+      "weight_lifting_man",
+    ],
+    "tags": [
+      "gym",
+      "workout",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman lifting weights",
+    "emoji": "🏋️‍♀️",
+    "names": [
+      "weight_lifting_woman",
+    ],
+    "tags": [
+      "gym",
+      "workout",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person biking",
+    "emoji": "🚴",
+    "names": [
+      "bicyclist",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man biking",
+    "emoji": "🚴‍♂️",
+    "names": [
+      "biking_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman biking",
+    "emoji": "🚴‍♀️",
+    "names": [
+      "biking_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person mountain biking",
+    "emoji": "🚵",
+    "names": [
+      "mountain_bicyclist",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man mountain biking",
+    "emoji": "🚵‍♂️",
+    "names": [
+      "mountain_biking_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman mountain biking",
+    "emoji": "🚵‍♀️",
+    "names": [
+      "mountain_biking_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person cartwheeling",
+    "emoji": "🤸",
+    "names": [
+      "cartwheeling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man cartwheeling",
+    "emoji": "🤸‍♂️",
+    "names": [
+      "man_cartwheeling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman cartwheeling",
+    "emoji": "🤸‍♀️",
+    "names": [
+      "woman_cartwheeling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "people wrestling",
+    "emoji": "🤼",
+    "names": [
+      "wrestling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "men wrestling",
+    "emoji": "🤼‍♂️",
+    "names": [
+      "men_wrestling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "women wrestling",
+    "emoji": "🤼‍♀️",
+    "names": [
+      "women_wrestling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person playing water polo",
+    "emoji": "🤽",
+    "names": [
+      "water_polo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man playing water polo",
+    "emoji": "🤽‍♂️",
+    "names": [
+      "man_playing_water_polo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman playing water polo",
+    "emoji": "🤽‍♀️",
+    "names": [
+      "woman_playing_water_polo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person playing handball",
+    "emoji": "🤾",
+    "names": [
+      "handball_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man playing handball",
+    "emoji": "🤾‍♂️",
+    "names": [
+      "man_playing_handball",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman playing handball",
+    "emoji": "🤾‍♀️",
+    "names": [
+      "woman_playing_handball",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person juggling",
+    "emoji": "🤹",
+    "names": [
+      "juggling_person",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "man juggling",
+    "emoji": "🤹‍♂️",
+    "names": [
+      "man_juggling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman juggling",
+    "emoji": "🤹‍♀️",
+    "names": [
+      "woman_juggling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "person in lotus position",
+    "emoji": "🧘",
+    "names": [
+      "lotus_position",
+    ],
+    "tags": [
+      "meditation",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "man in lotus position",
+    "emoji": "🧘‍♂️",
+    "names": [
+      "lotus_position_man",
+    ],
+    "tags": [
+      "meditation",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman in lotus position",
+    "emoji": "🧘‍♀️",
+    "names": [
+      "lotus_position_woman",
+    ],
+    "tags": [
+      "meditation",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person taking bath",
+    "emoji": "🛀",
+    "names": [
+      "bath",
+    ],
+    "tags": [
+      "shower",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "person in bed",
+    "emoji": "🛌",
+    "names": [
+      "sleeping_bed",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "people holding hands",
+    "emoji": "🧑‍🤝‍🧑",
+    "names": [
+      "people_holding_hands",
+    ],
+    "tags": [
+      "couple",
+      "date",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "women holding hands",
+    "emoji": "👭",
+    "names": [
+      "two_women_holding_hands",
+    ],
+    "tags": [
+      "couple",
+      "date",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "woman and man holding hands",
+    "emoji": "👫",
+    "names": [
+      "couple",
+    ],
+    "tags": [
+      "date",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "men holding hands",
+    "emoji": "👬",
+    "names": [
+      "two_men_holding_hands",
+    ],
+    "tags": [
+      "couple",
+      "date",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "kiss",
+    "emoji": "💏",
+    "names": [
+      "couplekiss",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "kiss: woman, man",
+    "emoji": "👩‍❤️‍💋‍👨",
+    "names": [
+      "couplekiss_man_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "kiss: man, man",
+    "emoji": "👨‍❤️‍💋‍👨",
+    "names": [
+      "couplekiss_man_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "kiss: woman, woman",
+    "emoji": "👩‍❤️‍💋‍👩",
+    "names": [
+      "couplekiss_woman_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "couple with heart",
+    "emoji": "💑",
+    "names": [
+      "couple_with_heart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "couple with heart: woman, man",
+    "emoji": "👩‍❤️‍👨",
+    "names": [
+      "couple_with_heart_woman_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "couple with heart: man, man",
+    "emoji": "👨‍❤️‍👨",
+    "names": [
+      "couple_with_heart_man_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "couple with heart: woman, woman",
+    "emoji": "👩‍❤️‍👩",
+    "names": [
+      "couple_with_heart_woman_woman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family",
+    "emoji": "👪",
+    "names": [
+      "family",
+    ],
+    "tags": [
+      "home",
+      "parents",
+      "child",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, woman, boy",
+    "emoji": "👨‍👩‍👦",
+    "names": [
+      "family_man_woman_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, woman, girl",
+    "emoji": "👨‍👩‍👧",
+    "names": [
+      "family_man_woman_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, woman, girl, boy",
+    "emoji": "👨‍👩‍👧‍👦",
+    "names": [
+      "family_man_woman_girl_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, woman, boy, boy",
+    "emoji": "👨‍👩‍👦‍👦",
+    "names": [
+      "family_man_woman_boy_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, woman, girl, girl",
+    "emoji": "👨‍👩‍👧‍👧",
+    "names": [
+      "family_man_woman_girl_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, man, boy",
+    "emoji": "👨‍👨‍👦",
+    "names": [
+      "family_man_man_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, man, girl",
+    "emoji": "👨‍👨‍👧",
+    "names": [
+      "family_man_man_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, man, girl, boy",
+    "emoji": "👨‍👨‍👧‍👦",
+    "names": [
+      "family_man_man_girl_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, man, boy, boy",
+    "emoji": "👨‍👨‍👦‍👦",
+    "names": [
+      "family_man_man_boy_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, man, girl, girl",
+    "emoji": "👨‍👨‍👧‍👧",
+    "names": [
+      "family_man_man_girl_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, woman, boy",
+    "emoji": "👩‍👩‍👦",
+    "names": [
+      "family_woman_woman_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, woman, girl",
+    "emoji": "👩‍👩‍👧",
+    "names": [
+      "family_woman_woman_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, woman, girl, boy",
+    "emoji": "👩‍👩‍👧‍👦",
+    "names": [
+      "family_woman_woman_girl_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, woman, boy, boy",
+    "emoji": "👩‍👩‍👦‍👦",
+    "names": [
+      "family_woman_woman_boy_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, woman, girl, girl",
+    "emoji": "👩‍👩‍👧‍👧",
+    "names": [
+      "family_woman_woman_girl_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, boy",
+    "emoji": "👨‍👦",
+    "names": [
+      "family_man_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, boy, boy",
+    "emoji": "👨‍👦‍👦",
+    "names": [
+      "family_man_boy_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, girl",
+    "emoji": "👨‍👧",
+    "names": [
+      "family_man_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, girl, boy",
+    "emoji": "👨‍👧‍👦",
+    "names": [
+      "family_man_girl_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: man, girl, girl",
+    "emoji": "👨‍👧‍👧",
+    "names": [
+      "family_man_girl_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, boy",
+    "emoji": "👩‍👦",
+    "names": [
+      "family_woman_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, boy, boy",
+    "emoji": "👩‍👦‍👦",
+    "names": [
+      "family_woman_boy_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, girl",
+    "emoji": "👩‍👧",
+    "names": [
+      "family_woman_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, girl, boy",
+    "emoji": "👩‍👧‍👦",
+    "names": [
+      "family_woman_girl_boy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "family: woman, girl, girl",
+    "emoji": "👩‍👧‍👧",
+    "names": [
+      "family_woman_girl_girl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "speaking head",
+    "emoji": "🗣️",
+    "names": [
+      "speaking_head",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "bust in silhouette",
+    "emoji": "👤",
+    "names": [
+      "bust_in_silhouette",
+    ],
+    "tags": [
+      "user",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "busts in silhouette",
+    "emoji": "👥",
+    "names": [
+      "busts_in_silhouette",
+    ],
+    "tags": [
+      "users",
+      "group",
+      "team",
+    ],
+  },
+  {
+    "category": "People & Body",
+    "description": "people hugging",
+    "emoji": "🫂",
+    "names": [
+      "people_hugging",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "People & Body",
+    "description": "footprints",
+    "emoji": "👣",
+    "names": [
+      "footprints",
+    ],
+    "tags": [
+      "feet",
+      "tracks",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "monkey face",
+    "emoji": "🐵",
+    "names": [
+      "monkey_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "monkey",
+    "emoji": "🐒",
+    "names": [
+      "monkey",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "gorilla",
+    "emoji": "🦍",
+    "names": [
+      "gorilla",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "orangutan",
+    "emoji": "🦧",
+    "names": [
+      "orangutan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "dog face",
+    "emoji": "🐶",
+    "names": [
+      "dog",
+    ],
+    "tags": [
+      "pet",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "dog",
+    "emoji": "🐕",
+    "names": [
+      "dog2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "guide dog",
+    "emoji": "🦮",
+    "names": [
+      "guide_dog",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "service dog",
+    "emoji": "🐕‍🦺",
+    "names": [
+      "service_dog",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "poodle",
+    "emoji": "🐩",
+    "names": [
+      "poodle",
+    ],
+    "tags": [
+      "dog",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "wolf",
+    "emoji": "🐺",
+    "names": [
+      "wolf",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "fox",
+    "emoji": "🦊",
+    "names": [
+      "fox_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "raccoon",
+    "emoji": "🦝",
+    "names": [
+      "raccoon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "cat face",
+    "emoji": "🐱",
+    "names": [
+      "cat",
+    ],
+    "tags": [
+      "pet",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "cat",
+    "emoji": "🐈",
+    "names": [
+      "cat2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "black cat",
+    "emoji": "🐈‍⬛",
+    "names": [
+      "black_cat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "lion",
+    "emoji": "🦁",
+    "names": [
+      "lion",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "tiger face",
+    "emoji": "🐯",
+    "names": [
+      "tiger",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "tiger",
+    "emoji": "🐅",
+    "names": [
+      "tiger2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "leopard",
+    "emoji": "🐆",
+    "names": [
+      "leopard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "horse face",
+    "emoji": "🐴",
+    "names": [
+      "horse",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "moose",
+    "emoji": "🫎",
+    "names": [
+      "moose",
+    ],
+    "tags": [
+      "canada",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "donkey",
+    "emoji": "🫏",
+    "names": [
+      "donkey",
+    ],
+    "tags": [
+      "mule",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "horse",
+    "emoji": "🐎",
+    "names": [
+      "racehorse",
+    ],
+    "tags": [
+      "speed",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "unicorn",
+    "emoji": "🦄",
+    "names": [
+      "unicorn",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "zebra",
+    "emoji": "🦓",
+    "names": [
+      "zebra",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "deer",
+    "emoji": "🦌",
+    "names": [
+      "deer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "bison",
+    "emoji": "🦬",
+    "names": [
+      "bison",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "cow face",
+    "emoji": "🐮",
+    "names": [
+      "cow",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "ox",
+    "emoji": "🐂",
+    "names": [
+      "ox",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "water buffalo",
+    "emoji": "🐃",
+    "names": [
+      "water_buffalo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "cow",
+    "emoji": "🐄",
+    "names": [
+      "cow2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "pig face",
+    "emoji": "🐷",
+    "names": [
+      "pig",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "pig",
+    "emoji": "🐖",
+    "names": [
+      "pig2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "boar",
+    "emoji": "🐗",
+    "names": [
+      "boar",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "pig nose",
+    "emoji": "🐽",
+    "names": [
+      "pig_nose",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "ram",
+    "emoji": "🐏",
+    "names": [
+      "ram",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "ewe",
+    "emoji": "🐑",
+    "names": [
+      "sheep",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "goat",
+    "emoji": "🐐",
+    "names": [
+      "goat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "camel",
+    "emoji": "🐪",
+    "names": [
+      "dromedary_camel",
+    ],
+    "tags": [
+      "desert",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "two-hump camel",
+    "emoji": "🐫",
+    "names": [
+      "camel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "llama",
+    "emoji": "🦙",
+    "names": [
+      "llama",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "giraffe",
+    "emoji": "🦒",
+    "names": [
+      "giraffe",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "elephant",
+    "emoji": "🐘",
+    "names": [
+      "elephant",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "mammoth",
+    "emoji": "🦣",
+    "names": [
+      "mammoth",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "rhinoceros",
+    "emoji": "🦏",
+    "names": [
+      "rhinoceros",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "hippopotamus",
+    "emoji": "🦛",
+    "names": [
+      "hippopotamus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "mouse face",
+    "emoji": "🐭",
+    "names": [
+      "mouse",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "mouse",
+    "emoji": "🐁",
+    "names": [
+      "mouse2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "rat",
+    "emoji": "🐀",
+    "names": [
+      "rat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "hamster",
+    "emoji": "🐹",
+    "names": [
+      "hamster",
+    ],
+    "tags": [
+      "pet",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "rabbit face",
+    "emoji": "🐰",
+    "names": [
+      "rabbit",
+    ],
+    "tags": [
+      "bunny",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "rabbit",
+    "emoji": "🐇",
+    "names": [
+      "rabbit2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "chipmunk",
+    "emoji": "🐿️",
+    "names": [
+      "chipmunk",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "beaver",
+    "emoji": "🦫",
+    "names": [
+      "beaver",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "hedgehog",
+    "emoji": "🦔",
+    "names": [
+      "hedgehog",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "bat",
+    "emoji": "🦇",
+    "names": [
+      "bat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "bear",
+    "emoji": "🐻",
+    "names": [
+      "bear",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "polar bear",
+    "emoji": "🐻‍❄️",
+    "names": [
+      "polar_bear",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "koala",
+    "emoji": "🐨",
+    "names": [
+      "koala",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "panda",
+    "emoji": "🐼",
+    "names": [
+      "panda_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "sloth",
+    "emoji": "🦥",
+    "names": [
+      "sloth",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "otter",
+    "emoji": "🦦",
+    "names": [
+      "otter",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "skunk",
+    "emoji": "🦨",
+    "names": [
+      "skunk",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "kangaroo",
+    "emoji": "🦘",
+    "names": [
+      "kangaroo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "badger",
+    "emoji": "🦡",
+    "names": [
+      "badger",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "paw prints",
+    "emoji": "🐾",
+    "names": [
+      "feet",
+      "paw_prints",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "turkey",
+    "emoji": "🦃",
+    "names": [
+      "turkey",
+    ],
+    "tags": [
+      "thanksgiving",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "chicken",
+    "emoji": "🐔",
+    "names": [
+      "chicken",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "rooster",
+    "emoji": "🐓",
+    "names": [
+      "rooster",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "hatching chick",
+    "emoji": "🐣",
+    "names": [
+      "hatching_chick",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "baby chick",
+    "emoji": "🐤",
+    "names": [
+      "baby_chick",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "front-facing baby chick",
+    "emoji": "🐥",
+    "names": [
+      "hatched_chick",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "bird",
+    "emoji": "🐦",
+    "names": [
+      "bird",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "penguin",
+    "emoji": "🐧",
+    "names": [
+      "penguin",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "dove",
+    "emoji": "🕊️",
+    "names": [
+      "dove",
+    ],
+    "tags": [
+      "peace",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "eagle",
+    "emoji": "🦅",
+    "names": [
+      "eagle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "duck",
+    "emoji": "🦆",
+    "names": [
+      "duck",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "swan",
+    "emoji": "🦢",
+    "names": [
+      "swan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "owl",
+    "emoji": "🦉",
+    "names": [
+      "owl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "dodo",
+    "emoji": "🦤",
+    "names": [
+      "dodo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "feather",
+    "emoji": "🪶",
+    "names": [
+      "feather",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "flamingo",
+    "emoji": "🦩",
+    "names": [
+      "flamingo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "peacock",
+    "emoji": "🦚",
+    "names": [
+      "peacock",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "parrot",
+    "emoji": "🦜",
+    "names": [
+      "parrot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "wing",
+    "emoji": "🪽",
+    "names": [
+      "wing",
+    ],
+    "tags": [
+      "fly",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "black bird",
+    "emoji": "🐦‍⬛",
+    "names": [
+      "black_bird",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "goose",
+    "emoji": "🪿",
+    "names": [
+      "goose",
+    ],
+    "tags": [
+      "honk",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "frog",
+    "emoji": "🐸",
+    "names": [
+      "frog",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "crocodile",
+    "emoji": "🐊",
+    "names": [
+      "crocodile",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "turtle",
+    "emoji": "🐢",
+    "names": [
+      "turtle",
+    ],
+    "tags": [
+      "slow",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "lizard",
+    "emoji": "🦎",
+    "names": [
+      "lizard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "snake",
+    "emoji": "🐍",
+    "names": [
+      "snake",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "dragon face",
+    "emoji": "🐲",
+    "names": [
+      "dragon_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "dragon",
+    "emoji": "🐉",
+    "names": [
+      "dragon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "sauropod",
+    "emoji": "🦕",
+    "names": [
+      "sauropod",
+    ],
+    "tags": [
+      "dinosaur",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "T-Rex",
+    "emoji": "🦖",
+    "names": [
+      "t-rex",
+    ],
+    "tags": [
+      "dinosaur",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "spouting whale",
+    "emoji": "🐳",
+    "names": [
+      "whale",
+    ],
+    "tags": [
+      "sea",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "whale",
+    "emoji": "🐋",
+    "names": [
+      "whale2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "dolphin",
+    "emoji": "🐬",
+    "names": [
+      "dolphin",
+      "flipper",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "seal",
+    "emoji": "🦭",
+    "names": [
+      "seal",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "fish",
+    "emoji": "🐟",
+    "names": [
+      "fish",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "tropical fish",
+    "emoji": "🐠",
+    "names": [
+      "tropical_fish",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "blowfish",
+    "emoji": "🐡",
+    "names": [
+      "blowfish",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "shark",
+    "emoji": "🦈",
+    "names": [
+      "shark",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "octopus",
+    "emoji": "🐙",
+    "names": [
+      "octopus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "spiral shell",
+    "emoji": "🐚",
+    "names": [
+      "shell",
+    ],
+    "tags": [
+      "sea",
+      "beach",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "coral",
+    "emoji": "🪸",
+    "names": [
+      "coral",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "jellyfish",
+    "emoji": "🪼",
+    "names": [
+      "jellyfish",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "snail",
+    "emoji": "🐌",
+    "names": [
+      "snail",
+    ],
+    "tags": [
+      "slow",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "butterfly",
+    "emoji": "🦋",
+    "names": [
+      "butterfly",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "bug",
+    "emoji": "🐛",
+    "names": [
+      "bug",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "ant",
+    "emoji": "🐜",
+    "names": [
+      "ant",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "honeybee",
+    "emoji": "🐝",
+    "names": [
+      "bee",
+      "honeybee",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "beetle",
+    "emoji": "🪲",
+    "names": [
+      "beetle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "lady beetle",
+    "emoji": "🐞",
+    "names": [
+      "lady_beetle",
+    ],
+    "tags": [
+      "bug",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "cricket",
+    "emoji": "🦗",
+    "names": [
+      "cricket",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "cockroach",
+    "emoji": "🪳",
+    "names": [
+      "cockroach",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "spider",
+    "emoji": "🕷️",
+    "names": [
+      "spider",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "spider web",
+    "emoji": "🕸️",
+    "names": [
+      "spider_web",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "scorpion",
+    "emoji": "🦂",
+    "names": [
+      "scorpion",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "mosquito",
+    "emoji": "🦟",
+    "names": [
+      "mosquito",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "fly",
+    "emoji": "🪰",
+    "names": [
+      "fly",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "worm",
+    "emoji": "🪱",
+    "names": [
+      "worm",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "microbe",
+    "emoji": "🦠",
+    "names": [
+      "microbe",
+    ],
+    "tags": [
+      "germ",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "bouquet",
+    "emoji": "💐",
+    "names": [
+      "bouquet",
+    ],
+    "tags": [
+      "flowers",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "cherry blossom",
+    "emoji": "🌸",
+    "names": [
+      "cherry_blossom",
+    ],
+    "tags": [
+      "flower",
+      "spring",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "white flower",
+    "emoji": "💮",
+    "names": [
+      "white_flower",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "lotus",
+    "emoji": "🪷",
+    "names": [
+      "lotus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "rosette",
+    "emoji": "🏵️",
+    "names": [
+      "rosette",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "rose",
+    "emoji": "🌹",
+    "names": [
+      "rose",
+    ],
+    "tags": [
+      "flower",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "wilted flower",
+    "emoji": "🥀",
+    "names": [
+      "wilted_flower",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "hibiscus",
+    "emoji": "🌺",
+    "names": [
+      "hibiscus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "sunflower",
+    "emoji": "🌻",
+    "names": [
+      "sunflower",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "blossom",
+    "emoji": "🌼",
+    "names": [
+      "blossom",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "tulip",
+    "emoji": "🌷",
+    "names": [
+      "tulip",
+    ],
+    "tags": [
+      "flower",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "hyacinth",
+    "emoji": "🪻",
+    "names": [
+      "hyacinth",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "seedling",
+    "emoji": "🌱",
+    "names": [
+      "seedling",
+    ],
+    "tags": [
+      "plant",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "potted plant",
+    "emoji": "🪴",
+    "names": [
+      "potted_plant",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "evergreen tree",
+    "emoji": "🌲",
+    "names": [
+      "evergreen_tree",
+    ],
+    "tags": [
+      "wood",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "deciduous tree",
+    "emoji": "🌳",
+    "names": [
+      "deciduous_tree",
+    ],
+    "tags": [
+      "wood",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "palm tree",
+    "emoji": "🌴",
+    "names": [
+      "palm_tree",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "cactus",
+    "emoji": "🌵",
+    "names": [
+      "cactus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "sheaf of rice",
+    "emoji": "🌾",
+    "names": [
+      "ear_of_rice",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "herb",
+    "emoji": "🌿",
+    "names": [
+      "herb",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "shamrock",
+    "emoji": "☘️",
+    "names": [
+      "shamrock",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "four leaf clover",
+    "emoji": "🍀",
+    "names": [
+      "four_leaf_clover",
+    ],
+    "tags": [
+      "luck",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "maple leaf",
+    "emoji": "🍁",
+    "names": [
+      "maple_leaf",
+    ],
+    "tags": [
+      "canada",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "fallen leaf",
+    "emoji": "🍂",
+    "names": [
+      "fallen_leaf",
+    ],
+    "tags": [
+      "autumn",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "leaf fluttering in wind",
+    "emoji": "🍃",
+    "names": [
+      "leaves",
+    ],
+    "tags": [
+      "leaf",
+    ],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "empty nest",
+    "emoji": "🪹",
+    "names": [
+      "empty_nest",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "nest with eggs",
+    "emoji": "🪺",
+    "names": [
+      "nest_with_eggs",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Animals & Nature",
+    "description": "mushroom",
+    "emoji": "🍄",
+    "names": [
+      "mushroom",
+    ],
+    "tags": [
+      "fungus",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "grapes",
+    "emoji": "🍇",
+    "names": [
+      "grapes",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "melon",
+    "emoji": "🍈",
+    "names": [
+      "melon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "watermelon",
+    "emoji": "🍉",
+    "names": [
+      "watermelon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "tangerine",
+    "emoji": "🍊",
+    "names": [
+      "tangerine",
+      "orange",
+      "mandarin",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "lemon",
+    "emoji": "🍋",
+    "names": [
+      "lemon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "banana",
+    "emoji": "🍌",
+    "names": [
+      "banana",
+    ],
+    "tags": [
+      "fruit",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "pineapple",
+    "emoji": "🍍",
+    "names": [
+      "pineapple",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "mango",
+    "emoji": "🥭",
+    "names": [
+      "mango",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "red apple",
+    "emoji": "🍎",
+    "names": [
+      "apple",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "green apple",
+    "emoji": "🍏",
+    "names": [
+      "green_apple",
+    ],
+    "tags": [
+      "fruit",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "pear",
+    "emoji": "🍐",
+    "names": [
+      "pear",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "peach",
+    "emoji": "🍑",
+    "names": [
+      "peach",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cherries",
+    "emoji": "🍒",
+    "names": [
+      "cherries",
+    ],
+    "tags": [
+      "fruit",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "strawberry",
+    "emoji": "🍓",
+    "names": [
+      "strawberry",
+    ],
+    "tags": [
+      "fruit",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "blueberries",
+    "emoji": "🫐",
+    "names": [
+      "blueberries",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "kiwi fruit",
+    "emoji": "🥝",
+    "names": [
+      "kiwi_fruit",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "tomato",
+    "emoji": "🍅",
+    "names": [
+      "tomato",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "olive",
+    "emoji": "🫒",
+    "names": [
+      "olive",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "coconut",
+    "emoji": "🥥",
+    "names": [
+      "coconut",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "avocado",
+    "emoji": "🥑",
+    "names": [
+      "avocado",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "eggplant",
+    "emoji": "🍆",
+    "names": [
+      "eggplant",
+    ],
+    "tags": [
+      "aubergine",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "potato",
+    "emoji": "🥔",
+    "names": [
+      "potato",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "carrot",
+    "emoji": "🥕",
+    "names": [
+      "carrot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "ear of corn",
+    "emoji": "🌽",
+    "names": [
+      "corn",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "hot pepper",
+    "emoji": "🌶️",
+    "names": [
+      "hot_pepper",
+    ],
+    "tags": [
+      "spicy",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "bell pepper",
+    "emoji": "🫑",
+    "names": [
+      "bell_pepper",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cucumber",
+    "emoji": "🥒",
+    "names": [
+      "cucumber",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "leafy green",
+    "emoji": "🥬",
+    "names": [
+      "leafy_green",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "broccoli",
+    "emoji": "🥦",
+    "names": [
+      "broccoli",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "garlic",
+    "emoji": "🧄",
+    "names": [
+      "garlic",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "onion",
+    "emoji": "🧅",
+    "names": [
+      "onion",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "peanuts",
+    "emoji": "🥜",
+    "names": [
+      "peanuts",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "beans",
+    "emoji": "🫘",
+    "names": [
+      "beans",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "chestnut",
+    "emoji": "🌰",
+    "names": [
+      "chestnut",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "ginger root",
+    "emoji": "🫚",
+    "names": [
+      "ginger_root",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "pea pod",
+    "emoji": "🫛",
+    "names": [
+      "pea_pod",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "bread",
+    "emoji": "🍞",
+    "names": [
+      "bread",
+    ],
+    "tags": [
+      "toast",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "croissant",
+    "emoji": "🥐",
+    "names": [
+      "croissant",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "baguette bread",
+    "emoji": "🥖",
+    "names": [
+      "baguette_bread",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "flatbread",
+    "emoji": "🫓",
+    "names": [
+      "flatbread",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "pretzel",
+    "emoji": "🥨",
+    "names": [
+      "pretzel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "bagel",
+    "emoji": "🥯",
+    "names": [
+      "bagel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "pancakes",
+    "emoji": "🥞",
+    "names": [
+      "pancakes",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "waffle",
+    "emoji": "🧇",
+    "names": [
+      "waffle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cheese wedge",
+    "emoji": "🧀",
+    "names": [
+      "cheese",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "meat on bone",
+    "emoji": "🍖",
+    "names": [
+      "meat_on_bone",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "poultry leg",
+    "emoji": "🍗",
+    "names": [
+      "poultry_leg",
+    ],
+    "tags": [
+      "meat",
+      "chicken",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cut of meat",
+    "emoji": "🥩",
+    "names": [
+      "cut_of_meat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "bacon",
+    "emoji": "🥓",
+    "names": [
+      "bacon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "hamburger",
+    "emoji": "🍔",
+    "names": [
+      "hamburger",
+    ],
+    "tags": [
+      "burger",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "french fries",
+    "emoji": "🍟",
+    "names": [
+      "fries",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "pizza",
+    "emoji": "🍕",
+    "names": [
+      "pizza",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "hot dog",
+    "emoji": "🌭",
+    "names": [
+      "hotdog",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "sandwich",
+    "emoji": "🥪",
+    "names": [
+      "sandwich",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "taco",
+    "emoji": "🌮",
+    "names": [
+      "taco",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "burrito",
+    "emoji": "🌯",
+    "names": [
+      "burrito",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "tamale",
+    "emoji": "🫔",
+    "names": [
+      "tamale",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "stuffed flatbread",
+    "emoji": "🥙",
+    "names": [
+      "stuffed_flatbread",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "falafel",
+    "emoji": "🧆",
+    "names": [
+      "falafel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "egg",
+    "emoji": "🥚",
+    "names": [
+      "egg",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cooking",
+    "emoji": "🍳",
+    "names": [
+      "fried_egg",
+    ],
+    "tags": [
+      "breakfast",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "shallow pan of food",
+    "emoji": "🥘",
+    "names": [
+      "shallow_pan_of_food",
+    ],
+    "tags": [
+      "paella",
+      "curry",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "pot of food",
+    "emoji": "🍲",
+    "names": [
+      "stew",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "fondue",
+    "emoji": "🫕",
+    "names": [
+      "fondue",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "bowl with spoon",
+    "emoji": "🥣",
+    "names": [
+      "bowl_with_spoon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "green salad",
+    "emoji": "🥗",
+    "names": [
+      "green_salad",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "popcorn",
+    "emoji": "🍿",
+    "names": [
+      "popcorn",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "butter",
+    "emoji": "🧈",
+    "names": [
+      "butter",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "salt",
+    "emoji": "🧂",
+    "names": [
+      "salt",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "canned food",
+    "emoji": "🥫",
+    "names": [
+      "canned_food",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "bento box",
+    "emoji": "🍱",
+    "names": [
+      "bento",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "rice cracker",
+    "emoji": "🍘",
+    "names": [
+      "rice_cracker",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "rice ball",
+    "emoji": "🍙",
+    "names": [
+      "rice_ball",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cooked rice",
+    "emoji": "🍚",
+    "names": [
+      "rice",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "curry rice",
+    "emoji": "🍛",
+    "names": [
+      "curry",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "steaming bowl",
+    "emoji": "🍜",
+    "names": [
+      "ramen",
+    ],
+    "tags": [
+      "noodle",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "spaghetti",
+    "emoji": "🍝",
+    "names": [
+      "spaghetti",
+    ],
+    "tags": [
+      "pasta",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "roasted sweet potato",
+    "emoji": "🍠",
+    "names": [
+      "sweet_potato",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "oden",
+    "emoji": "🍢",
+    "names": [
+      "oden",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "sushi",
+    "emoji": "🍣",
+    "names": [
+      "sushi",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "fried shrimp",
+    "emoji": "🍤",
+    "names": [
+      "fried_shrimp",
+    ],
+    "tags": [
+      "tempura",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "fish cake with swirl",
+    "emoji": "🍥",
+    "names": [
+      "fish_cake",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "moon cake",
+    "emoji": "🥮",
+    "names": [
+      "moon_cake",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "dango",
+    "emoji": "🍡",
+    "names": [
+      "dango",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "dumpling",
+    "emoji": "🥟",
+    "names": [
+      "dumpling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "fortune cookie",
+    "emoji": "🥠",
+    "names": [
+      "fortune_cookie",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "takeout box",
+    "emoji": "🥡",
+    "names": [
+      "takeout_box",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "crab",
+    "emoji": "🦀",
+    "names": [
+      "crab",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "lobster",
+    "emoji": "🦞",
+    "names": [
+      "lobster",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "shrimp",
+    "emoji": "🦐",
+    "names": [
+      "shrimp",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "squid",
+    "emoji": "🦑",
+    "names": [
+      "squid",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "oyster",
+    "emoji": "🦪",
+    "names": [
+      "oyster",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "soft ice cream",
+    "emoji": "🍦",
+    "names": [
+      "icecream",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "shaved ice",
+    "emoji": "🍧",
+    "names": [
+      "shaved_ice",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "ice cream",
+    "emoji": "🍨",
+    "names": [
+      "ice_cream",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "doughnut",
+    "emoji": "🍩",
+    "names": [
+      "doughnut",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cookie",
+    "emoji": "🍪",
+    "names": [
+      "cookie",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "birthday cake",
+    "emoji": "🎂",
+    "names": [
+      "birthday",
+    ],
+    "tags": [
+      "party",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "shortcake",
+    "emoji": "🍰",
+    "names": [
+      "cake",
+    ],
+    "tags": [
+      "dessert",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cupcake",
+    "emoji": "🧁",
+    "names": [
+      "cupcake",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "pie",
+    "emoji": "🥧",
+    "names": [
+      "pie",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "chocolate bar",
+    "emoji": "🍫",
+    "names": [
+      "chocolate_bar",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "candy",
+    "emoji": "🍬",
+    "names": [
+      "candy",
+    ],
+    "tags": [
+      "sweet",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "lollipop",
+    "emoji": "🍭",
+    "names": [
+      "lollipop",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "custard",
+    "emoji": "🍮",
+    "names": [
+      "custard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "honey pot",
+    "emoji": "🍯",
+    "names": [
+      "honey_pot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "baby bottle",
+    "emoji": "🍼",
+    "names": [
+      "baby_bottle",
+    ],
+    "tags": [
+      "milk",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "glass of milk",
+    "emoji": "🥛",
+    "names": [
+      "milk_glass",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "hot beverage",
+    "emoji": "☕",
+    "names": [
+      "coffee",
+    ],
+    "tags": [
+      "cafe",
+      "espresso",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "teapot",
+    "emoji": "🫖",
+    "names": [
+      "teapot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "teacup without handle",
+    "emoji": "🍵",
+    "names": [
+      "tea",
+    ],
+    "tags": [
+      "green",
+      "breakfast",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "sake",
+    "emoji": "🍶",
+    "names": [
+      "sake",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "bottle with popping cork",
+    "emoji": "🍾",
+    "names": [
+      "champagne",
+    ],
+    "tags": [
+      "bottle",
+      "bubbly",
+      "celebration",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "wine glass",
+    "emoji": "🍷",
+    "names": [
+      "wine_glass",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cocktail glass",
+    "emoji": "🍸",
+    "names": [
+      "cocktail",
+    ],
+    "tags": [
+      "drink",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "tropical drink",
+    "emoji": "🍹",
+    "names": [
+      "tropical_drink",
+    ],
+    "tags": [
+      "summer",
+      "vacation",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "beer mug",
+    "emoji": "🍺",
+    "names": [
+      "beer",
+    ],
+    "tags": [
+      "drink",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "clinking beer mugs",
+    "emoji": "🍻",
+    "names": [
+      "beers",
+    ],
+    "tags": [
+      "drinks",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "clinking glasses",
+    "emoji": "🥂",
+    "names": [
+      "clinking_glasses",
+    ],
+    "tags": [
+      "cheers",
+      "toast",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "tumbler glass",
+    "emoji": "🥃",
+    "names": [
+      "tumbler_glass",
+    ],
+    "tags": [
+      "whisky",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "pouring liquid",
+    "emoji": "🫗",
+    "names": [
+      "pouring_liquid",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "cup with straw",
+    "emoji": "🥤",
+    "names": [
+      "cup_with_straw",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "bubble tea",
+    "emoji": "🧋",
+    "names": [
+      "bubble_tea",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "beverage box",
+    "emoji": "🧃",
+    "names": [
+      "beverage_box",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "mate",
+    "emoji": "🧉",
+    "names": [
+      "mate",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "ice",
+    "emoji": "🧊",
+    "names": [
+      "ice_cube",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "chopsticks",
+    "emoji": "🥢",
+    "names": [
+      "chopsticks",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "fork and knife with plate",
+    "emoji": "🍽️",
+    "names": [
+      "plate_with_cutlery",
+    ],
+    "tags": [
+      "dining",
+      "dinner",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "fork and knife",
+    "emoji": "🍴",
+    "names": [
+      "fork_and_knife",
+    ],
+    "tags": [
+      "cutlery",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "spoon",
+    "emoji": "🥄",
+    "names": [
+      "spoon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "kitchen knife",
+    "emoji": "🔪",
+    "names": [
+      "hocho",
+      "knife",
+    ],
+    "tags": [
+      "cut",
+      "chop",
+    ],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "jar",
+    "emoji": "🫙",
+    "names": [
+      "jar",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Food & Drink",
+    "description": "amphora",
+    "emoji": "🏺",
+    "names": [
+      "amphora",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "globe showing Europe-Africa",
+    "emoji": "🌍",
+    "names": [
+      "earth_africa",
+    ],
+    "tags": [
+      "globe",
+      "world",
+      "international",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "globe showing Americas",
+    "emoji": "🌎",
+    "names": [
+      "earth_americas",
+    ],
+    "tags": [
+      "globe",
+      "world",
+      "international",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "globe showing Asia-Australia",
+    "emoji": "🌏",
+    "names": [
+      "earth_asia",
+    ],
+    "tags": [
+      "globe",
+      "world",
+      "international",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "globe with meridians",
+    "emoji": "🌐",
+    "names": [
+      "globe_with_meridians",
+    ],
+    "tags": [
+      "world",
+      "global",
+      "international",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "world map",
+    "emoji": "🗺️",
+    "names": [
+      "world_map",
+    ],
+    "tags": [
+      "travel",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "map of Japan",
+    "emoji": "🗾",
+    "names": [
+      "japan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "compass",
+    "emoji": "🧭",
+    "names": [
+      "compass",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "snow-capped mountain",
+    "emoji": "🏔️",
+    "names": [
+      "mountain_snow",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "mountain",
+    "emoji": "⛰️",
+    "names": [
+      "mountain",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "volcano",
+    "emoji": "🌋",
+    "names": [
+      "volcano",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "mount fuji",
+    "emoji": "🗻",
+    "names": [
+      "mount_fuji",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "camping",
+    "emoji": "🏕️",
+    "names": [
+      "camping",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "beach with umbrella",
+    "emoji": "🏖️",
+    "names": [
+      "beach_umbrella",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "desert",
+    "emoji": "🏜️",
+    "names": [
+      "desert",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "desert island",
+    "emoji": "🏝️",
+    "names": [
+      "desert_island",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "national park",
+    "emoji": "🏞️",
+    "names": [
+      "national_park",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "stadium",
+    "emoji": "🏟️",
+    "names": [
+      "stadium",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "classical building",
+    "emoji": "🏛️",
+    "names": [
+      "classical_building",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "building construction",
+    "emoji": "🏗️",
+    "names": [
+      "building_construction",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "brick",
+    "emoji": "🧱",
+    "names": [
+      "bricks",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "rock",
+    "emoji": "🪨",
+    "names": [
+      "rock",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "wood",
+    "emoji": "🪵",
+    "names": [
+      "wood",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "hut",
+    "emoji": "🛖",
+    "names": [
+      "hut",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "houses",
+    "emoji": "🏘️",
+    "names": [
+      "houses",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "derelict house",
+    "emoji": "🏚️",
+    "names": [
+      "derelict_house",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "house",
+    "emoji": "🏠",
+    "names": [
+      "house",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "house with garden",
+    "emoji": "🏡",
+    "names": [
+      "house_with_garden",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "office building",
+    "emoji": "🏢",
+    "names": [
+      "office",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "Japanese post office",
+    "emoji": "🏣",
+    "names": [
+      "post_office",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "post office",
+    "emoji": "🏤",
+    "names": [
+      "european_post_office",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "hospital",
+    "emoji": "🏥",
+    "names": [
+      "hospital",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "bank",
+    "emoji": "🏦",
+    "names": [
+      "bank",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "hotel",
+    "emoji": "🏨",
+    "names": [
+      "hotel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "love hotel",
+    "emoji": "🏩",
+    "names": [
+      "love_hotel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "convenience store",
+    "emoji": "🏪",
+    "names": [
+      "convenience_store",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "school",
+    "emoji": "🏫",
+    "names": [
+      "school",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "department store",
+    "emoji": "🏬",
+    "names": [
+      "department_store",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "factory",
+    "emoji": "🏭",
+    "names": [
+      "factory",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "Japanese castle",
+    "emoji": "🏯",
+    "names": [
+      "japanese_castle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "castle",
+    "emoji": "🏰",
+    "names": [
+      "european_castle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "wedding",
+    "emoji": "💒",
+    "names": [
+      "wedding",
+    ],
+    "tags": [
+      "marriage",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "Tokyo tower",
+    "emoji": "🗼",
+    "names": [
+      "tokyo_tower",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "Statue of Liberty",
+    "emoji": "🗽",
+    "names": [
+      "statue_of_liberty",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "church",
+    "emoji": "⛪",
+    "names": [
+      "church",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "mosque",
+    "emoji": "🕌",
+    "names": [
+      "mosque",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "hindu temple",
+    "emoji": "🛕",
+    "names": [
+      "hindu_temple",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "synagogue",
+    "emoji": "🕍",
+    "names": [
+      "synagogue",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "shinto shrine",
+    "emoji": "⛩️",
+    "names": [
+      "shinto_shrine",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "kaaba",
+    "emoji": "🕋",
+    "names": [
+      "kaaba",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "fountain",
+    "emoji": "⛲",
+    "names": [
+      "fountain",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "tent",
+    "emoji": "⛺",
+    "names": [
+      "tent",
+    ],
+    "tags": [
+      "camping",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "foggy",
+    "emoji": "🌁",
+    "names": [
+      "foggy",
+    ],
+    "tags": [
+      "karl",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "night with stars",
+    "emoji": "🌃",
+    "names": [
+      "night_with_stars",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "cityscape",
+    "emoji": "🏙️",
+    "names": [
+      "cityscape",
+    ],
+    "tags": [
+      "skyline",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sunrise over mountains",
+    "emoji": "🌄",
+    "names": [
+      "sunrise_over_mountains",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sunrise",
+    "emoji": "🌅",
+    "names": [
+      "sunrise",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "cityscape at dusk",
+    "emoji": "🌆",
+    "names": [
+      "city_sunset",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sunset",
+    "emoji": "🌇",
+    "names": [
+      "city_sunrise",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "bridge at night",
+    "emoji": "🌉",
+    "names": [
+      "bridge_at_night",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "hot springs",
+    "emoji": "♨️",
+    "names": [
+      "hotsprings",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "carousel horse",
+    "emoji": "🎠",
+    "names": [
+      "carousel_horse",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "playground slide",
+    "emoji": "🛝",
+    "names": [
+      "playground_slide",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "ferris wheel",
+    "emoji": "🎡",
+    "names": [
+      "ferris_wheel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "roller coaster",
+    "emoji": "🎢",
+    "names": [
+      "roller_coaster",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "barber pole",
+    "emoji": "💈",
+    "names": [
+      "barber",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "circus tent",
+    "emoji": "🎪",
+    "names": [
+      "circus_tent",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "locomotive",
+    "emoji": "🚂",
+    "names": [
+      "steam_locomotive",
+    ],
+    "tags": [
+      "train",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "railway car",
+    "emoji": "🚃",
+    "names": [
+      "railway_car",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "high-speed train",
+    "emoji": "🚄",
+    "names": [
+      "bullettrain_side",
+    ],
+    "tags": [
+      "train",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "bullet train",
+    "emoji": "🚅",
+    "names": [
+      "bullettrain_front",
+    ],
+    "tags": [
+      "train",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "train",
+    "emoji": "🚆",
+    "names": [
+      "train2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "metro",
+    "emoji": "🚇",
+    "names": [
+      "metro",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "light rail",
+    "emoji": "🚈",
+    "names": [
+      "light_rail",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "station",
+    "emoji": "🚉",
+    "names": [
+      "station",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "tram",
+    "emoji": "🚊",
+    "names": [
+      "tram",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "monorail",
+    "emoji": "🚝",
+    "names": [
+      "monorail",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "mountain railway",
+    "emoji": "🚞",
+    "names": [
+      "mountain_railway",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "tram car",
+    "emoji": "🚋",
+    "names": [
+      "train",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "bus",
+    "emoji": "🚌",
+    "names": [
+      "bus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "oncoming bus",
+    "emoji": "🚍",
+    "names": [
+      "oncoming_bus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "trolleybus",
+    "emoji": "🚎",
+    "names": [
+      "trolleybus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "minibus",
+    "emoji": "🚐",
+    "names": [
+      "minibus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "ambulance",
+    "emoji": "🚑",
+    "names": [
+      "ambulance",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "fire engine",
+    "emoji": "🚒",
+    "names": [
+      "fire_engine",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "police car",
+    "emoji": "🚓",
+    "names": [
+      "police_car",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "oncoming police car",
+    "emoji": "🚔",
+    "names": [
+      "oncoming_police_car",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "taxi",
+    "emoji": "🚕",
+    "names": [
+      "taxi",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "oncoming taxi",
+    "emoji": "🚖",
+    "names": [
+      "oncoming_taxi",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "automobile",
+    "emoji": "🚗",
+    "names": [
+      "car",
+      "red_car",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "oncoming automobile",
+    "emoji": "🚘",
+    "names": [
+      "oncoming_automobile",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sport utility vehicle",
+    "emoji": "🚙",
+    "names": [
+      "blue_car",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "pickup truck",
+    "emoji": "🛻",
+    "names": [
+      "pickup_truck",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "delivery truck",
+    "emoji": "🚚",
+    "names": [
+      "truck",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "articulated lorry",
+    "emoji": "🚛",
+    "names": [
+      "articulated_lorry",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "tractor",
+    "emoji": "🚜",
+    "names": [
+      "tractor",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "racing car",
+    "emoji": "🏎️",
+    "names": [
+      "racing_car",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "motorcycle",
+    "emoji": "🏍️",
+    "names": [
+      "motorcycle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "motor scooter",
+    "emoji": "🛵",
+    "names": [
+      "motor_scooter",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "manual wheelchair",
+    "emoji": "🦽",
+    "names": [
+      "manual_wheelchair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "motorized wheelchair",
+    "emoji": "🦼",
+    "names": [
+      "motorized_wheelchair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "auto rickshaw",
+    "emoji": "🛺",
+    "names": [
+      "auto_rickshaw",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "bicycle",
+    "emoji": "🚲",
+    "names": [
+      "bike",
+    ],
+    "tags": [
+      "bicycle",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "kick scooter",
+    "emoji": "🛴",
+    "names": [
+      "kick_scooter",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "skateboard",
+    "emoji": "🛹",
+    "names": [
+      "skateboard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "roller skate",
+    "emoji": "🛼",
+    "names": [
+      "roller_skate",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "bus stop",
+    "emoji": "🚏",
+    "names": [
+      "busstop",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "motorway",
+    "emoji": "🛣️",
+    "names": [
+      "motorway",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "railway track",
+    "emoji": "🛤️",
+    "names": [
+      "railway_track",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "oil drum",
+    "emoji": "🛢️",
+    "names": [
+      "oil_drum",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "fuel pump",
+    "emoji": "⛽",
+    "names": [
+      "fuelpump",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "wheel",
+    "emoji": "🛞",
+    "names": [
+      "wheel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "police car light",
+    "emoji": "🚨",
+    "names": [
+      "rotating_light",
+    ],
+    "tags": [
+      "911",
+      "emergency",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "horizontal traffic light",
+    "emoji": "🚥",
+    "names": [
+      "traffic_light",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "vertical traffic light",
+    "emoji": "🚦",
+    "names": [
+      "vertical_traffic_light",
+    ],
+    "tags": [
+      "semaphore",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "stop sign",
+    "emoji": "🛑",
+    "names": [
+      "stop_sign",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "construction",
+    "emoji": "🚧",
+    "names": [
+      "construction",
+    ],
+    "tags": [
+      "wip",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "anchor",
+    "emoji": "⚓",
+    "names": [
+      "anchor",
+    ],
+    "tags": [
+      "ship",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "ring buoy",
+    "emoji": "🛟",
+    "names": [
+      "ring_buoy",
+    ],
+    "tags": [
+      "life preserver",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sailboat",
+    "emoji": "⛵",
+    "names": [
+      "boat",
+      "sailboat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "canoe",
+    "emoji": "🛶",
+    "names": [
+      "canoe",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "speedboat",
+    "emoji": "🚤",
+    "names": [
+      "speedboat",
+    ],
+    "tags": [
+      "ship",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "passenger ship",
+    "emoji": "🛳️",
+    "names": [
+      "passenger_ship",
+    ],
+    "tags": [
+      "cruise",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "ferry",
+    "emoji": "⛴️",
+    "names": [
+      "ferry",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "motor boat",
+    "emoji": "🛥️",
+    "names": [
+      "motor_boat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "ship",
+    "emoji": "🚢",
+    "names": [
+      "ship",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "airplane",
+    "emoji": "✈️",
+    "names": [
+      "airplane",
+    ],
+    "tags": [
+      "flight",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "small airplane",
+    "emoji": "🛩️",
+    "names": [
+      "small_airplane",
+    ],
+    "tags": [
+      "flight",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "airplane departure",
+    "emoji": "🛫",
+    "names": [
+      "flight_departure",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "airplane arrival",
+    "emoji": "🛬",
+    "names": [
+      "flight_arrival",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "parachute",
+    "emoji": "🪂",
+    "names": [
+      "parachute",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "seat",
+    "emoji": "💺",
+    "names": [
+      "seat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "helicopter",
+    "emoji": "🚁",
+    "names": [
+      "helicopter",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "suspension railway",
+    "emoji": "🚟",
+    "names": [
+      "suspension_railway",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "mountain cableway",
+    "emoji": "🚠",
+    "names": [
+      "mountain_cableway",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "aerial tramway",
+    "emoji": "🚡",
+    "names": [
+      "aerial_tramway",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "satellite",
+    "emoji": "🛰️",
+    "names": [
+      "artificial_satellite",
+    ],
+    "tags": [
+      "orbit",
+      "space",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "rocket",
+    "emoji": "🚀",
+    "names": [
+      "rocket",
+    ],
+    "tags": [
+      "ship",
+      "launch",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "flying saucer",
+    "emoji": "🛸",
+    "names": [
+      "flying_saucer",
+    ],
+    "tags": [
+      "ufo",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "bellhop bell",
+    "emoji": "🛎️",
+    "names": [
+      "bellhop_bell",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "luggage",
+    "emoji": "🧳",
+    "names": [
+      "luggage",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "hourglass done",
+    "emoji": "⌛",
+    "names": [
+      "hourglass",
+    ],
+    "tags": [
+      "time",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "hourglass not done",
+    "emoji": "⏳",
+    "names": [
+      "hourglass_flowing_sand",
+    ],
+    "tags": [
+      "time",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "watch",
+    "emoji": "⌚",
+    "names": [
+      "watch",
+    ],
+    "tags": [
+      "time",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "alarm clock",
+    "emoji": "⏰",
+    "names": [
+      "alarm_clock",
+    ],
+    "tags": [
+      "morning",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "stopwatch",
+    "emoji": "⏱️",
+    "names": [
+      "stopwatch",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "timer clock",
+    "emoji": "⏲️",
+    "names": [
+      "timer_clock",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "mantelpiece clock",
+    "emoji": "🕰️",
+    "names": [
+      "mantelpiece_clock",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "twelve o’clock",
+    "emoji": "🕛",
+    "names": [
+      "clock12",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "twelve-thirty",
+    "emoji": "🕧",
+    "names": [
+      "clock1230",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "one o’clock",
+    "emoji": "🕐",
+    "names": [
+      "clock1",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "one-thirty",
+    "emoji": "🕜",
+    "names": [
+      "clock130",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "two o’clock",
+    "emoji": "🕑",
+    "names": [
+      "clock2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "two-thirty",
+    "emoji": "🕝",
+    "names": [
+      "clock230",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "three o’clock",
+    "emoji": "🕒",
+    "names": [
+      "clock3",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "three-thirty",
+    "emoji": "🕞",
+    "names": [
+      "clock330",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "four o’clock",
+    "emoji": "🕓",
+    "names": [
+      "clock4",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "four-thirty",
+    "emoji": "🕟",
+    "names": [
+      "clock430",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "five o’clock",
+    "emoji": "🕔",
+    "names": [
+      "clock5",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "five-thirty",
+    "emoji": "🕠",
+    "names": [
+      "clock530",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "six o’clock",
+    "emoji": "🕕",
+    "names": [
+      "clock6",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "six-thirty",
+    "emoji": "🕡",
+    "names": [
+      "clock630",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "seven o’clock",
+    "emoji": "🕖",
+    "names": [
+      "clock7",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "seven-thirty",
+    "emoji": "🕢",
+    "names": [
+      "clock730",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "eight o’clock",
+    "emoji": "🕗",
+    "names": [
+      "clock8",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "eight-thirty",
+    "emoji": "🕣",
+    "names": [
+      "clock830",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "nine o’clock",
+    "emoji": "🕘",
+    "names": [
+      "clock9",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "nine-thirty",
+    "emoji": "🕤",
+    "names": [
+      "clock930",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "ten o’clock",
+    "emoji": "🕙",
+    "names": [
+      "clock10",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "ten-thirty",
+    "emoji": "🕥",
+    "names": [
+      "clock1030",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "eleven o’clock",
+    "emoji": "🕚",
+    "names": [
+      "clock11",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "eleven-thirty",
+    "emoji": "🕦",
+    "names": [
+      "clock1130",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "new moon",
+    "emoji": "🌑",
+    "names": [
+      "new_moon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "waxing crescent moon",
+    "emoji": "🌒",
+    "names": [
+      "waxing_crescent_moon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "first quarter moon",
+    "emoji": "🌓",
+    "names": [
+      "first_quarter_moon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "waxing gibbous moon",
+    "emoji": "🌔",
+    "names": [
+      "moon",
+      "waxing_gibbous_moon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "full moon",
+    "emoji": "🌕",
+    "names": [
+      "full_moon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "waning gibbous moon",
+    "emoji": "🌖",
+    "names": [
+      "waning_gibbous_moon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "last quarter moon",
+    "emoji": "🌗",
+    "names": [
+      "last_quarter_moon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "waning crescent moon",
+    "emoji": "🌘",
+    "names": [
+      "waning_crescent_moon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "crescent moon",
+    "emoji": "🌙",
+    "names": [
+      "crescent_moon",
+    ],
+    "tags": [
+      "night",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "new moon face",
+    "emoji": "🌚",
+    "names": [
+      "new_moon_with_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "first quarter moon face",
+    "emoji": "🌛",
+    "names": [
+      "first_quarter_moon_with_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "last quarter moon face",
+    "emoji": "🌜",
+    "names": [
+      "last_quarter_moon_with_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "thermometer",
+    "emoji": "🌡️",
+    "names": [
+      "thermometer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sun",
+    "emoji": "☀️",
+    "names": [
+      "sunny",
+    ],
+    "tags": [
+      "weather",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "full moon face",
+    "emoji": "🌝",
+    "names": [
+      "full_moon_with_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sun with face",
+    "emoji": "🌞",
+    "names": [
+      "sun_with_face",
+    ],
+    "tags": [
+      "summer",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "ringed planet",
+    "emoji": "🪐",
+    "names": [
+      "ringed_planet",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "star",
+    "emoji": "⭐",
+    "names": [
+      "star",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "glowing star",
+    "emoji": "🌟",
+    "names": [
+      "star2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "shooting star",
+    "emoji": "🌠",
+    "names": [
+      "stars",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "milky way",
+    "emoji": "🌌",
+    "names": [
+      "milky_way",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "cloud",
+    "emoji": "☁️",
+    "names": [
+      "cloud",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sun behind cloud",
+    "emoji": "⛅",
+    "names": [
+      "partly_sunny",
+    ],
+    "tags": [
+      "weather",
+      "cloud",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "cloud with lightning and rain",
+    "emoji": "⛈️",
+    "names": [
+      "cloud_with_lightning_and_rain",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sun behind small cloud",
+    "emoji": "🌤️",
+    "names": [
+      "sun_behind_small_cloud",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sun behind large cloud",
+    "emoji": "🌥️",
+    "names": [
+      "sun_behind_large_cloud",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "sun behind rain cloud",
+    "emoji": "🌦️",
+    "names": [
+      "sun_behind_rain_cloud",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "cloud with rain",
+    "emoji": "🌧️",
+    "names": [
+      "cloud_with_rain",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "cloud with snow",
+    "emoji": "🌨️",
+    "names": [
+      "cloud_with_snow",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "cloud with lightning",
+    "emoji": "🌩️",
+    "names": [
+      "cloud_with_lightning",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "tornado",
+    "emoji": "🌪️",
+    "names": [
+      "tornado",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "fog",
+    "emoji": "🌫️",
+    "names": [
+      "fog",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "wind face",
+    "emoji": "🌬️",
+    "names": [
+      "wind_face",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "cyclone",
+    "emoji": "🌀",
+    "names": [
+      "cyclone",
+    ],
+    "tags": [
+      "swirl",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "rainbow",
+    "emoji": "🌈",
+    "names": [
+      "rainbow",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "closed umbrella",
+    "emoji": "🌂",
+    "names": [
+      "closed_umbrella",
+    ],
+    "tags": [
+      "weather",
+      "rain",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "umbrella",
+    "emoji": "☂️",
+    "names": [
+      "open_umbrella",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "umbrella with rain drops",
+    "emoji": "☔",
+    "names": [
+      "umbrella",
+    ],
+    "tags": [
+      "rain",
+      "weather",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "umbrella on ground",
+    "emoji": "⛱️",
+    "names": [
+      "parasol_on_ground",
+    ],
+    "tags": [
+      "beach_umbrella",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "high voltage",
+    "emoji": "⚡",
+    "names": [
+      "zap",
+    ],
+    "tags": [
+      "lightning",
+      "thunder",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "snowflake",
+    "emoji": "❄️",
+    "names": [
+      "snowflake",
+    ],
+    "tags": [
+      "winter",
+      "cold",
+      "weather",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "snowman",
+    "emoji": "☃️",
+    "names": [
+      "snowman_with_snow",
+    ],
+    "tags": [
+      "winter",
+      "christmas",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "snowman without snow",
+    "emoji": "⛄",
+    "names": [
+      "snowman",
+    ],
+    "tags": [
+      "winter",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "comet",
+    "emoji": "☄️",
+    "names": [
+      "comet",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "fire",
+    "emoji": "🔥",
+    "names": [
+      "fire",
+    ],
+    "tags": [
+      "burn",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "droplet",
+    "emoji": "💧",
+    "names": [
+      "droplet",
+    ],
+    "tags": [
+      "water",
+    ],
+  },
+  {
+    "category": "Travel & Places",
+    "description": "water wave",
+    "emoji": "🌊",
+    "names": [
+      "ocean",
+    ],
+    "tags": [
+      "sea",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "jack-o-lantern",
+    "emoji": "🎃",
+    "names": [
+      "jack_o_lantern",
+    ],
+    "tags": [
+      "halloween",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "Christmas tree",
+    "emoji": "🎄",
+    "names": [
+      "christmas_tree",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "fireworks",
+    "emoji": "🎆",
+    "names": [
+      "fireworks",
+    ],
+    "tags": [
+      "festival",
+      "celebration",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "sparkler",
+    "emoji": "🎇",
+    "names": [
+      "sparkler",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "firecracker",
+    "emoji": "🧨",
+    "names": [
+      "firecracker",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "sparkles",
+    "emoji": "✨",
+    "names": [
+      "sparkles",
+    ],
+    "tags": [
+      "shiny",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "balloon",
+    "emoji": "🎈",
+    "names": [
+      "balloon",
+    ],
+    "tags": [
+      "party",
+      "birthday",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "party popper",
+    "emoji": "🎉",
+    "names": [
+      "tada",
+    ],
+    "tags": [
+      "hooray",
+      "party",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "confetti ball",
+    "emoji": "🎊",
+    "names": [
+      "confetti_ball",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "tanabata tree",
+    "emoji": "🎋",
+    "names": [
+      "tanabata_tree",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "pine decoration",
+    "emoji": "🎍",
+    "names": [
+      "bamboo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "Japanese dolls",
+    "emoji": "🎎",
+    "names": [
+      "dolls",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "carp streamer",
+    "emoji": "🎏",
+    "names": [
+      "flags",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "wind chime",
+    "emoji": "🎐",
+    "names": [
+      "wind_chime",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "moon viewing ceremony",
+    "emoji": "🎑",
+    "names": [
+      "rice_scene",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "red envelope",
+    "emoji": "🧧",
+    "names": [
+      "red_envelope",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "ribbon",
+    "emoji": "🎀",
+    "names": [
+      "ribbon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "wrapped gift",
+    "emoji": "🎁",
+    "names": [
+      "gift",
+    ],
+    "tags": [
+      "present",
+      "birthday",
+      "christmas",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "reminder ribbon",
+    "emoji": "🎗️",
+    "names": [
+      "reminder_ribbon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "admission tickets",
+    "emoji": "🎟️",
+    "names": [
+      "tickets",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "ticket",
+    "emoji": "🎫",
+    "names": [
+      "ticket",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "military medal",
+    "emoji": "🎖️",
+    "names": [
+      "medal_military",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "trophy",
+    "emoji": "🏆",
+    "names": [
+      "trophy",
+    ],
+    "tags": [
+      "award",
+      "contest",
+      "winner",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "sports medal",
+    "emoji": "🏅",
+    "names": [
+      "medal_sports",
+    ],
+    "tags": [
+      "gold",
+      "winner",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "1st place medal",
+    "emoji": "🥇",
+    "names": [
+      "1st_place_medal",
+    ],
+    "tags": [
+      "gold",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "2nd place medal",
+    "emoji": "🥈",
+    "names": [
+      "2nd_place_medal",
+    ],
+    "tags": [
+      "silver",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "3rd place medal",
+    "emoji": "🥉",
+    "names": [
+      "3rd_place_medal",
+    ],
+    "tags": [
+      "bronze",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "soccer ball",
+    "emoji": "⚽",
+    "names": [
+      "soccer",
+    ],
+    "tags": [
+      "sports",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "baseball",
+    "emoji": "⚾",
+    "names": [
+      "baseball",
+    ],
+    "tags": [
+      "sports",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "softball",
+    "emoji": "🥎",
+    "names": [
+      "softball",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "basketball",
+    "emoji": "🏀",
+    "names": [
+      "basketball",
+    ],
+    "tags": [
+      "sports",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "volleyball",
+    "emoji": "🏐",
+    "names": [
+      "volleyball",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "american football",
+    "emoji": "🏈",
+    "names": [
+      "football",
+    ],
+    "tags": [
+      "sports",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "rugby football",
+    "emoji": "🏉",
+    "names": [
+      "rugby_football",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "tennis",
+    "emoji": "🎾",
+    "names": [
+      "tennis",
+    ],
+    "tags": [
+      "sports",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "flying disc",
+    "emoji": "🥏",
+    "names": [
+      "flying_disc",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "bowling",
+    "emoji": "🎳",
+    "names": [
+      "bowling",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "cricket game",
+    "emoji": "🏏",
+    "names": [
+      "cricket_game",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "field hockey",
+    "emoji": "🏑",
+    "names": [
+      "field_hockey",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "ice hockey",
+    "emoji": "🏒",
+    "names": [
+      "ice_hockey",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "lacrosse",
+    "emoji": "🥍",
+    "names": [
+      "lacrosse",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "ping pong",
+    "emoji": "🏓",
+    "names": [
+      "ping_pong",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "badminton",
+    "emoji": "🏸",
+    "names": [
+      "badminton",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "boxing glove",
+    "emoji": "🥊",
+    "names": [
+      "boxing_glove",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "martial arts uniform",
+    "emoji": "🥋",
+    "names": [
+      "martial_arts_uniform",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "goal net",
+    "emoji": "🥅",
+    "names": [
+      "goal_net",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "flag in hole",
+    "emoji": "⛳",
+    "names": [
+      "golf",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "ice skate",
+    "emoji": "⛸️",
+    "names": [
+      "ice_skate",
+    ],
+    "tags": [
+      "skating",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "fishing pole",
+    "emoji": "🎣",
+    "names": [
+      "fishing_pole_and_fish",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "diving mask",
+    "emoji": "🤿",
+    "names": [
+      "diving_mask",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "running shirt",
+    "emoji": "🎽",
+    "names": [
+      "running_shirt_with_sash",
+    ],
+    "tags": [
+      "marathon",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "skis",
+    "emoji": "🎿",
+    "names": [
+      "ski",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "sled",
+    "emoji": "🛷",
+    "names": [
+      "sled",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "curling stone",
+    "emoji": "🥌",
+    "names": [
+      "curling_stone",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "bullseye",
+    "emoji": "🎯",
+    "names": [
+      "dart",
+    ],
+    "tags": [
+      "target",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "yo-yo",
+    "emoji": "🪀",
+    "names": [
+      "yo_yo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "kite",
+    "emoji": "🪁",
+    "names": [
+      "kite",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "water pistol",
+    "emoji": "🔫",
+    "names": [
+      "gun",
+    ],
+    "tags": [
+      "shoot",
+      "weapon",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "pool 8 ball",
+    "emoji": "🎱",
+    "names": [
+      "8ball",
+    ],
+    "tags": [
+      "pool",
+      "billiards",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "crystal ball",
+    "emoji": "🔮",
+    "names": [
+      "crystal_ball",
+    ],
+    "tags": [
+      "fortune",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "magic wand",
+    "emoji": "🪄",
+    "names": [
+      "magic_wand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "video game",
+    "emoji": "🎮",
+    "names": [
+      "video_game",
+    ],
+    "tags": [
+      "play",
+      "controller",
+      "console",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "joystick",
+    "emoji": "🕹️",
+    "names": [
+      "joystick",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "slot machine",
+    "emoji": "🎰",
+    "names": [
+      "slot_machine",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "game die",
+    "emoji": "🎲",
+    "names": [
+      "game_die",
+    ],
+    "tags": [
+      "dice",
+      "gambling",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "puzzle piece",
+    "emoji": "🧩",
+    "names": [
+      "jigsaw",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "teddy bear",
+    "emoji": "🧸",
+    "names": [
+      "teddy_bear",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "piñata",
+    "emoji": "🪅",
+    "names": [
+      "pinata",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "mirror ball",
+    "emoji": "🪩",
+    "names": [
+      "mirror_ball",
+    ],
+    "tags": [
+      "disco",
+      "party",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "nesting dolls",
+    "emoji": "🪆",
+    "names": [
+      "nesting_dolls",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "spade suit",
+    "emoji": "♠️",
+    "names": [
+      "spades",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "heart suit",
+    "emoji": "♥️",
+    "names": [
+      "hearts",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "diamond suit",
+    "emoji": "♦️",
+    "names": [
+      "diamonds",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "club suit",
+    "emoji": "♣️",
+    "names": [
+      "clubs",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "chess pawn",
+    "emoji": "♟️",
+    "names": [
+      "chess_pawn",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "joker",
+    "emoji": "🃏",
+    "names": [
+      "black_joker",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "mahjong red dragon",
+    "emoji": "🀄",
+    "names": [
+      "mahjong",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "flower playing cards",
+    "emoji": "🎴",
+    "names": [
+      "flower_playing_cards",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "performing arts",
+    "emoji": "🎭",
+    "names": [
+      "performing_arts",
+    ],
+    "tags": [
+      "theater",
+      "drama",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "framed picture",
+    "emoji": "🖼️",
+    "names": [
+      "framed_picture",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "artist palette",
+    "emoji": "🎨",
+    "names": [
+      "art",
+    ],
+    "tags": [
+      "design",
+      "paint",
+    ],
+  },
+  {
+    "category": "Activities",
+    "description": "thread",
+    "emoji": "🧵",
+    "names": [
+      "thread",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "sewing needle",
+    "emoji": "🪡",
+    "names": [
+      "sewing_needle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "yarn",
+    "emoji": "🧶",
+    "names": [
+      "yarn",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Activities",
+    "description": "knot",
+    "emoji": "🪢",
+    "names": [
+      "knot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "glasses",
+    "emoji": "👓",
+    "names": [
+      "eyeglasses",
+    ],
+    "tags": [
+      "glasses",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "sunglasses",
+    "emoji": "🕶️",
+    "names": [
+      "dark_sunglasses",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "goggles",
+    "emoji": "🥽",
+    "names": [
+      "goggles",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "lab coat",
+    "emoji": "🥼",
+    "names": [
+      "lab_coat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "safety vest",
+    "emoji": "🦺",
+    "names": [
+      "safety_vest",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "necktie",
+    "emoji": "👔",
+    "names": [
+      "necktie",
+    ],
+    "tags": [
+      "shirt",
+      "formal",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "t-shirt",
+    "emoji": "👕",
+    "names": [
+      "shirt",
+      "tshirt",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "jeans",
+    "emoji": "👖",
+    "names": [
+      "jeans",
+    ],
+    "tags": [
+      "pants",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "scarf",
+    "emoji": "🧣",
+    "names": [
+      "scarf",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "gloves",
+    "emoji": "🧤",
+    "names": [
+      "gloves",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "coat",
+    "emoji": "🧥",
+    "names": [
+      "coat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "socks",
+    "emoji": "🧦",
+    "names": [
+      "socks",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "dress",
+    "emoji": "👗",
+    "names": [
+      "dress",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "kimono",
+    "emoji": "👘",
+    "names": [
+      "kimono",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "sari",
+    "emoji": "🥻",
+    "names": [
+      "sari",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "one-piece swimsuit",
+    "emoji": "🩱",
+    "names": [
+      "one_piece_swimsuit",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "briefs",
+    "emoji": "🩲",
+    "names": [
+      "swim_brief",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "shorts",
+    "emoji": "🩳",
+    "names": [
+      "shorts",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "bikini",
+    "emoji": "👙",
+    "names": [
+      "bikini",
+    ],
+    "tags": [
+      "beach",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "woman’s clothes",
+    "emoji": "👚",
+    "names": [
+      "womans_clothes",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "folding hand fan",
+    "emoji": "🪭",
+    "names": [
+      "folding_hand_fan",
+    ],
+    "tags": [
+      "sensu",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "purse",
+    "emoji": "👛",
+    "names": [
+      "purse",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "handbag",
+    "emoji": "👜",
+    "names": [
+      "handbag",
+    ],
+    "tags": [
+      "bag",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "clutch bag",
+    "emoji": "👝",
+    "names": [
+      "pouch",
+    ],
+    "tags": [
+      "bag",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "shopping bags",
+    "emoji": "🛍️",
+    "names": [
+      "shopping",
+    ],
+    "tags": [
+      "bags",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "backpack",
+    "emoji": "🎒",
+    "names": [
+      "school_satchel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "thong sandal",
+    "emoji": "🩴",
+    "names": [
+      "thong_sandal",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "man’s shoe",
+    "emoji": "👞",
+    "names": [
+      "mans_shoe",
+      "shoe",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "running shoe",
+    "emoji": "👟",
+    "names": [
+      "athletic_shoe",
+    ],
+    "tags": [
+      "sneaker",
+      "sport",
+      "running",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "hiking boot",
+    "emoji": "🥾",
+    "names": [
+      "hiking_boot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "flat shoe",
+    "emoji": "🥿",
+    "names": [
+      "flat_shoe",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "high-heeled shoe",
+    "emoji": "👠",
+    "names": [
+      "high_heel",
+    ],
+    "tags": [
+      "shoe",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "woman’s sandal",
+    "emoji": "👡",
+    "names": [
+      "sandal",
+    ],
+    "tags": [
+      "shoe",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "ballet shoes",
+    "emoji": "🩰",
+    "names": [
+      "ballet_shoes",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "woman’s boot",
+    "emoji": "👢",
+    "names": [
+      "boot",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "hair pick",
+    "emoji": "🪮",
+    "names": [
+      "hair_pick",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "crown",
+    "emoji": "👑",
+    "names": [
+      "crown",
+    ],
+    "tags": [
+      "king",
+      "queen",
+      "royal",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "woman’s hat",
+    "emoji": "👒",
+    "names": [
+      "womans_hat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "top hat",
+    "emoji": "🎩",
+    "names": [
+      "tophat",
+    ],
+    "tags": [
+      "hat",
+      "classy",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "graduation cap",
+    "emoji": "🎓",
+    "names": [
+      "mortar_board",
+    ],
+    "tags": [
+      "education",
+      "college",
+      "university",
+      "graduation",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "billed cap",
+    "emoji": "🧢",
+    "names": [
+      "billed_cap",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "military helmet",
+    "emoji": "🪖",
+    "names": [
+      "military_helmet",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "rescue worker’s helmet",
+    "emoji": "⛑️",
+    "names": [
+      "rescue_worker_helmet",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "prayer beads",
+    "emoji": "📿",
+    "names": [
+      "prayer_beads",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "lipstick",
+    "emoji": "💄",
+    "names": [
+      "lipstick",
+    ],
+    "tags": [
+      "makeup",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "ring",
+    "emoji": "💍",
+    "names": [
+      "ring",
+    ],
+    "tags": [
+      "wedding",
+      "marriage",
+      "engaged",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "gem stone",
+    "emoji": "💎",
+    "names": [
+      "gem",
+    ],
+    "tags": [
+      "diamond",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "muted speaker",
+    "emoji": "🔇",
+    "names": [
+      "mute",
+    ],
+    "tags": [
+      "sound",
+      "volume",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "speaker low volume",
+    "emoji": "🔈",
+    "names": [
+      "speaker",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "speaker medium volume",
+    "emoji": "🔉",
+    "names": [
+      "sound",
+    ],
+    "tags": [
+      "volume",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "speaker high volume",
+    "emoji": "🔊",
+    "names": [
+      "loud_sound",
+    ],
+    "tags": [
+      "volume",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "loudspeaker",
+    "emoji": "📢",
+    "names": [
+      "loudspeaker",
+    ],
+    "tags": [
+      "announcement",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "megaphone",
+    "emoji": "📣",
+    "names": [
+      "mega",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "postal horn",
+    "emoji": "📯",
+    "names": [
+      "postal_horn",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "bell",
+    "emoji": "🔔",
+    "names": [
+      "bell",
+    ],
+    "tags": [
+      "sound",
+      "notification",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "bell with slash",
+    "emoji": "🔕",
+    "names": [
+      "no_bell",
+    ],
+    "tags": [
+      "volume",
+      "off",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "musical score",
+    "emoji": "🎼",
+    "names": [
+      "musical_score",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "musical note",
+    "emoji": "🎵",
+    "names": [
+      "musical_note",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "musical notes",
+    "emoji": "🎶",
+    "names": [
+      "notes",
+    ],
+    "tags": [
+      "music",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "studio microphone",
+    "emoji": "🎙️",
+    "names": [
+      "studio_microphone",
+    ],
+    "tags": [
+      "podcast",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "level slider",
+    "emoji": "🎚️",
+    "names": [
+      "level_slider",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "control knobs",
+    "emoji": "🎛️",
+    "names": [
+      "control_knobs",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "microphone",
+    "emoji": "🎤",
+    "names": [
+      "microphone",
+    ],
+    "tags": [
+      "sing",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "headphone",
+    "emoji": "🎧",
+    "names": [
+      "headphones",
+    ],
+    "tags": [
+      "music",
+      "earphones",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "radio",
+    "emoji": "📻",
+    "names": [
+      "radio",
+    ],
+    "tags": [
+      "podcast",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "saxophone",
+    "emoji": "🎷",
+    "names": [
+      "saxophone",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "accordion",
+    "emoji": "🪗",
+    "names": [
+      "accordion",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "guitar",
+    "emoji": "🎸",
+    "names": [
+      "guitar",
+    ],
+    "tags": [
+      "rock",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "musical keyboard",
+    "emoji": "🎹",
+    "names": [
+      "musical_keyboard",
+    ],
+    "tags": [
+      "piano",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "trumpet",
+    "emoji": "🎺",
+    "names": [
+      "trumpet",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "violin",
+    "emoji": "🎻",
+    "names": [
+      "violin",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "banjo",
+    "emoji": "🪕",
+    "names": [
+      "banjo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "drum",
+    "emoji": "🥁",
+    "names": [
+      "drum",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "long drum",
+    "emoji": "🪘",
+    "names": [
+      "long_drum",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "maracas",
+    "emoji": "🪇",
+    "names": [
+      "maracas",
+    ],
+    "tags": [
+      "shaker",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "flute",
+    "emoji": "🪈",
+    "names": [
+      "flute",
+    ],
+    "tags": [
+      "recorder",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "mobile phone",
+    "emoji": "📱",
+    "names": [
+      "iphone",
+    ],
+    "tags": [
+      "smartphone",
+      "mobile",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "mobile phone with arrow",
+    "emoji": "📲",
+    "names": [
+      "calling",
+    ],
+    "tags": [
+      "call",
+      "incoming",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "telephone",
+    "emoji": "☎️",
+    "names": [
+      "phone",
+      "telephone",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "telephone receiver",
+    "emoji": "📞",
+    "names": [
+      "telephone_receiver",
+    ],
+    "tags": [
+      "phone",
+      "call",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "pager",
+    "emoji": "📟",
+    "names": [
+      "pager",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "fax machine",
+    "emoji": "📠",
+    "names": [
+      "fax",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "battery",
+    "emoji": "🔋",
+    "names": [
+      "battery",
+    ],
+    "tags": [
+      "power",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "low battery",
+    "emoji": "🪫",
+    "names": [
+      "low_battery",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "electric plug",
+    "emoji": "🔌",
+    "names": [
+      "electric_plug",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "laptop",
+    "emoji": "💻",
+    "names": [
+      "computer",
+    ],
+    "tags": [
+      "desktop",
+      "screen",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "desktop computer",
+    "emoji": "🖥️",
+    "names": [
+      "desktop_computer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "printer",
+    "emoji": "🖨️",
+    "names": [
+      "printer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "keyboard",
+    "emoji": "⌨️",
+    "names": [
+      "keyboard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "computer mouse",
+    "emoji": "🖱️",
+    "names": [
+      "computer_mouse",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "trackball",
+    "emoji": "🖲️",
+    "names": [
+      "trackball",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "computer disk",
+    "emoji": "💽",
+    "names": [
+      "minidisc",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "floppy disk",
+    "emoji": "💾",
+    "names": [
+      "floppy_disk",
+    ],
+    "tags": [
+      "save",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "optical disk",
+    "emoji": "💿",
+    "names": [
+      "cd",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "dvd",
+    "emoji": "📀",
+    "names": [
+      "dvd",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "abacus",
+    "emoji": "🧮",
+    "names": [
+      "abacus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "movie camera",
+    "emoji": "🎥",
+    "names": [
+      "movie_camera",
+    ],
+    "tags": [
+      "film",
+      "video",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "film frames",
+    "emoji": "🎞️",
+    "names": [
+      "film_strip",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "film projector",
+    "emoji": "📽️",
+    "names": [
+      "film_projector",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "clapper board",
+    "emoji": "🎬",
+    "names": [
+      "clapper",
+    ],
+    "tags": [
+      "film",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "television",
+    "emoji": "📺",
+    "names": [
+      "tv",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "camera",
+    "emoji": "📷",
+    "names": [
+      "camera",
+    ],
+    "tags": [
+      "photo",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "camera with flash",
+    "emoji": "📸",
+    "names": [
+      "camera_flash",
+    ],
+    "tags": [
+      "photo",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "video camera",
+    "emoji": "📹",
+    "names": [
+      "video_camera",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "videocassette",
+    "emoji": "📼",
+    "names": [
+      "vhs",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "magnifying glass tilted left",
+    "emoji": "🔍",
+    "names": [
+      "mag",
+    ],
+    "tags": [
+      "search",
+      "zoom",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "magnifying glass tilted right",
+    "emoji": "🔎",
+    "names": [
+      "mag_right",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "candle",
+    "emoji": "🕯️",
+    "names": [
+      "candle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "light bulb",
+    "emoji": "💡",
+    "names": [
+      "bulb",
+    ],
+    "tags": [
+      "idea",
+      "light",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "flashlight",
+    "emoji": "🔦",
+    "names": [
+      "flashlight",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "red paper lantern",
+    "emoji": "🏮",
+    "names": [
+      "izakaya_lantern",
+      "lantern",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "diya lamp",
+    "emoji": "🪔",
+    "names": [
+      "diya_lamp",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "notebook with decorative cover",
+    "emoji": "📔",
+    "names": [
+      "notebook_with_decorative_cover",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "closed book",
+    "emoji": "📕",
+    "names": [
+      "closed_book",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "open book",
+    "emoji": "📖",
+    "names": [
+      "book",
+      "open_book",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "green book",
+    "emoji": "📗",
+    "names": [
+      "green_book",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "blue book",
+    "emoji": "📘",
+    "names": [
+      "blue_book",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "orange book",
+    "emoji": "📙",
+    "names": [
+      "orange_book",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "books",
+    "emoji": "📚",
+    "names": [
+      "books",
+    ],
+    "tags": [
+      "library",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "notebook",
+    "emoji": "📓",
+    "names": [
+      "notebook",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "ledger",
+    "emoji": "📒",
+    "names": [
+      "ledger",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "page with curl",
+    "emoji": "📃",
+    "names": [
+      "page_with_curl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "scroll",
+    "emoji": "📜",
+    "names": [
+      "scroll",
+    ],
+    "tags": [
+      "document",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "page facing up",
+    "emoji": "📄",
+    "names": [
+      "page_facing_up",
+    ],
+    "tags": [
+      "document",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "newspaper",
+    "emoji": "📰",
+    "names": [
+      "newspaper",
+    ],
+    "tags": [
+      "press",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "rolled-up newspaper",
+    "emoji": "🗞️",
+    "names": [
+      "newspaper_roll",
+    ],
+    "tags": [
+      "press",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "bookmark tabs",
+    "emoji": "📑",
+    "names": [
+      "bookmark_tabs",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "bookmark",
+    "emoji": "🔖",
+    "names": [
+      "bookmark",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "label",
+    "emoji": "🏷️",
+    "names": [
+      "label",
+    ],
+    "tags": [
+      "tag",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "money bag",
+    "emoji": "💰",
+    "names": [
+      "moneybag",
+    ],
+    "tags": [
+      "dollar",
+      "cream",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "coin",
+    "emoji": "🪙",
+    "names": [
+      "coin",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "yen banknote",
+    "emoji": "💴",
+    "names": [
+      "yen",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "dollar banknote",
+    "emoji": "💵",
+    "names": [
+      "dollar",
+    ],
+    "tags": [
+      "money",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "euro banknote",
+    "emoji": "💶",
+    "names": [
+      "euro",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "pound banknote",
+    "emoji": "💷",
+    "names": [
+      "pound",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "money with wings",
+    "emoji": "💸",
+    "names": [
+      "money_with_wings",
+    ],
+    "tags": [
+      "dollar",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "credit card",
+    "emoji": "💳",
+    "names": [
+      "credit_card",
+    ],
+    "tags": [
+      "subscription",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "receipt",
+    "emoji": "🧾",
+    "names": [
+      "receipt",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "chart increasing with yen",
+    "emoji": "💹",
+    "names": [
+      "chart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "envelope",
+    "emoji": "✉️",
+    "names": [
+      "envelope",
+    ],
+    "tags": [
+      "letter",
+      "email",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "e-mail",
+    "emoji": "📧",
+    "names": [
+      "email",
+      "e-mail",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "incoming envelope",
+    "emoji": "📨",
+    "names": [
+      "incoming_envelope",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "envelope with arrow",
+    "emoji": "📩",
+    "names": [
+      "envelope_with_arrow",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "outbox tray",
+    "emoji": "📤",
+    "names": [
+      "outbox_tray",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "inbox tray",
+    "emoji": "📥",
+    "names": [
+      "inbox_tray",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "package",
+    "emoji": "📦",
+    "names": [
+      "package",
+    ],
+    "tags": [
+      "shipping",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "closed mailbox with raised flag",
+    "emoji": "📫",
+    "names": [
+      "mailbox",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "closed mailbox with lowered flag",
+    "emoji": "📪",
+    "names": [
+      "mailbox_closed",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "open mailbox with raised flag",
+    "emoji": "📬",
+    "names": [
+      "mailbox_with_mail",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "open mailbox with lowered flag",
+    "emoji": "📭",
+    "names": [
+      "mailbox_with_no_mail",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "postbox",
+    "emoji": "📮",
+    "names": [
+      "postbox",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "ballot box with ballot",
+    "emoji": "🗳️",
+    "names": [
+      "ballot_box",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "pencil",
+    "emoji": "✏️",
+    "names": [
+      "pencil2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "black nib",
+    "emoji": "✒️",
+    "names": [
+      "black_nib",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "fountain pen",
+    "emoji": "🖋️",
+    "names": [
+      "fountain_pen",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "pen",
+    "emoji": "🖊️",
+    "names": [
+      "pen",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "paintbrush",
+    "emoji": "🖌️",
+    "names": [
+      "paintbrush",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "crayon",
+    "emoji": "🖍️",
+    "names": [
+      "crayon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "memo",
+    "emoji": "📝",
+    "names": [
+      "memo",
+      "pencil",
+    ],
+    "tags": [
+      "document",
+      "note",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "briefcase",
+    "emoji": "💼",
+    "names": [
+      "briefcase",
+    ],
+    "tags": [
+      "business",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "file folder",
+    "emoji": "📁",
+    "names": [
+      "file_folder",
+    ],
+    "tags": [
+      "directory",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "open file folder",
+    "emoji": "📂",
+    "names": [
+      "open_file_folder",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "card index dividers",
+    "emoji": "🗂️",
+    "names": [
+      "card_index_dividers",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "calendar",
+    "emoji": "📅",
+    "names": [
+      "date",
+    ],
+    "tags": [
+      "calendar",
+      "schedule",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "tear-off calendar",
+    "emoji": "📆",
+    "names": [
+      "calendar",
+    ],
+    "tags": [
+      "schedule",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "spiral notepad",
+    "emoji": "🗒️",
+    "names": [
+      "spiral_notepad",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "spiral calendar",
+    "emoji": "🗓️",
+    "names": [
+      "spiral_calendar",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "card index",
+    "emoji": "📇",
+    "names": [
+      "card_index",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "chart increasing",
+    "emoji": "📈",
+    "names": [
+      "chart_with_upwards_trend",
+    ],
+    "tags": [
+      "graph",
+      "metrics",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "chart decreasing",
+    "emoji": "📉",
+    "names": [
+      "chart_with_downwards_trend",
+    ],
+    "tags": [
+      "graph",
+      "metrics",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "bar chart",
+    "emoji": "📊",
+    "names": [
+      "bar_chart",
+    ],
+    "tags": [
+      "stats",
+      "metrics",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "clipboard",
+    "emoji": "📋",
+    "names": [
+      "clipboard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "pushpin",
+    "emoji": "📌",
+    "names": [
+      "pushpin",
+    ],
+    "tags": [
+      "location",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "round pushpin",
+    "emoji": "📍",
+    "names": [
+      "round_pushpin",
+    ],
+    "tags": [
+      "location",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "paperclip",
+    "emoji": "📎",
+    "names": [
+      "paperclip",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "linked paperclips",
+    "emoji": "🖇️",
+    "names": [
+      "paperclips",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "straight ruler",
+    "emoji": "📏",
+    "names": [
+      "straight_ruler",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "triangular ruler",
+    "emoji": "📐",
+    "names": [
+      "triangular_ruler",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "scissors",
+    "emoji": "✂️",
+    "names": [
+      "scissors",
+    ],
+    "tags": [
+      "cut",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "card file box",
+    "emoji": "🗃️",
+    "names": [
+      "card_file_box",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "file cabinet",
+    "emoji": "🗄️",
+    "names": [
+      "file_cabinet",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "wastebasket",
+    "emoji": "🗑️",
+    "names": [
+      "wastebasket",
+    ],
+    "tags": [
+      "trash",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "locked",
+    "emoji": "🔒",
+    "names": [
+      "lock",
+    ],
+    "tags": [
+      "security",
+      "private",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "unlocked",
+    "emoji": "🔓",
+    "names": [
+      "unlock",
+    ],
+    "tags": [
+      "security",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "locked with pen",
+    "emoji": "🔏",
+    "names": [
+      "lock_with_ink_pen",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "locked with key",
+    "emoji": "🔐",
+    "names": [
+      "closed_lock_with_key",
+    ],
+    "tags": [
+      "security",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "key",
+    "emoji": "🔑",
+    "names": [
+      "key",
+    ],
+    "tags": [
+      "lock",
+      "password",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "old key",
+    "emoji": "🗝️",
+    "names": [
+      "old_key",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "hammer",
+    "emoji": "🔨",
+    "names": [
+      "hammer",
+    ],
+    "tags": [
+      "tool",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "axe",
+    "emoji": "🪓",
+    "names": [
+      "axe",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "pick",
+    "emoji": "⛏️",
+    "names": [
+      "pick",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "hammer and pick",
+    "emoji": "⚒️",
+    "names": [
+      "hammer_and_pick",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "hammer and wrench",
+    "emoji": "🛠️",
+    "names": [
+      "hammer_and_wrench",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "dagger",
+    "emoji": "🗡️",
+    "names": [
+      "dagger",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "crossed swords",
+    "emoji": "⚔️",
+    "names": [
+      "crossed_swords",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "bomb",
+    "emoji": "💣",
+    "names": [
+      "bomb",
+    ],
+    "tags": [
+      "boom",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "boomerang",
+    "emoji": "🪃",
+    "names": [
+      "boomerang",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "bow and arrow",
+    "emoji": "🏹",
+    "names": [
+      "bow_and_arrow",
+    ],
+    "tags": [
+      "archery",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "shield",
+    "emoji": "🛡️",
+    "names": [
+      "shield",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "carpentry saw",
+    "emoji": "🪚",
+    "names": [
+      "carpentry_saw",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "wrench",
+    "emoji": "🔧",
+    "names": [
+      "wrench",
+    ],
+    "tags": [
+      "tool",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "screwdriver",
+    "emoji": "🪛",
+    "names": [
+      "screwdriver",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "nut and bolt",
+    "emoji": "🔩",
+    "names": [
+      "nut_and_bolt",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "gear",
+    "emoji": "⚙️",
+    "names": [
+      "gear",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "clamp",
+    "emoji": "🗜️",
+    "names": [
+      "clamp",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "balance scale",
+    "emoji": "⚖️",
+    "names": [
+      "balance_scale",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "white cane",
+    "emoji": "🦯",
+    "names": [
+      "probing_cane",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "link",
+    "emoji": "🔗",
+    "names": [
+      "link",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "chains",
+    "emoji": "⛓️",
+    "names": [
+      "chains",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "hook",
+    "emoji": "🪝",
+    "names": [
+      "hook",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "toolbox",
+    "emoji": "🧰",
+    "names": [
+      "toolbox",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "magnet",
+    "emoji": "🧲",
+    "names": [
+      "magnet",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "ladder",
+    "emoji": "🪜",
+    "names": [
+      "ladder",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "alembic",
+    "emoji": "⚗️",
+    "names": [
+      "alembic",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "test tube",
+    "emoji": "🧪",
+    "names": [
+      "test_tube",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "petri dish",
+    "emoji": "🧫",
+    "names": [
+      "petri_dish",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "dna",
+    "emoji": "🧬",
+    "names": [
+      "dna",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "microscope",
+    "emoji": "🔬",
+    "names": [
+      "microscope",
+    ],
+    "tags": [
+      "science",
+      "laboratory",
+      "investigate",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "telescope",
+    "emoji": "🔭",
+    "names": [
+      "telescope",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "satellite antenna",
+    "emoji": "📡",
+    "names": [
+      "satellite",
+    ],
+    "tags": [
+      "signal",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "syringe",
+    "emoji": "💉",
+    "names": [
+      "syringe",
+    ],
+    "tags": [
+      "health",
+      "hospital",
+      "needle",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "drop of blood",
+    "emoji": "🩸",
+    "names": [
+      "drop_of_blood",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "pill",
+    "emoji": "💊",
+    "names": [
+      "pill",
+    ],
+    "tags": [
+      "health",
+      "medicine",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "adhesive bandage",
+    "emoji": "🩹",
+    "names": [
+      "adhesive_bandage",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "crutch",
+    "emoji": "🩼",
+    "names": [
+      "crutch",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "stethoscope",
+    "emoji": "🩺",
+    "names": [
+      "stethoscope",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "x-ray",
+    "emoji": "🩻",
+    "names": [
+      "x_ray",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "door",
+    "emoji": "🚪",
+    "names": [
+      "door",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "elevator",
+    "emoji": "🛗",
+    "names": [
+      "elevator",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "mirror",
+    "emoji": "🪞",
+    "names": [
+      "mirror",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "window",
+    "emoji": "🪟",
+    "names": [
+      "window",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "bed",
+    "emoji": "🛏️",
+    "names": [
+      "bed",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "couch and lamp",
+    "emoji": "🛋️",
+    "names": [
+      "couch_and_lamp",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "chair",
+    "emoji": "🪑",
+    "names": [
+      "chair",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "toilet",
+    "emoji": "🚽",
+    "names": [
+      "toilet",
+    ],
+    "tags": [
+      "wc",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "plunger",
+    "emoji": "🪠",
+    "names": [
+      "plunger",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "shower",
+    "emoji": "🚿",
+    "names": [
+      "shower",
+    ],
+    "tags": [
+      "bath",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "bathtub",
+    "emoji": "🛁",
+    "names": [
+      "bathtub",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "mouse trap",
+    "emoji": "🪤",
+    "names": [
+      "mouse_trap",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "razor",
+    "emoji": "🪒",
+    "names": [
+      "razor",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "lotion bottle",
+    "emoji": "🧴",
+    "names": [
+      "lotion_bottle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "safety pin",
+    "emoji": "🧷",
+    "names": [
+      "safety_pin",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "broom",
+    "emoji": "🧹",
+    "names": [
+      "broom",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "basket",
+    "emoji": "🧺",
+    "names": [
+      "basket",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "roll of paper",
+    "emoji": "🧻",
+    "names": [
+      "roll_of_paper",
+    ],
+    "tags": [
+      "toilet",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "bucket",
+    "emoji": "🪣",
+    "names": [
+      "bucket",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "soap",
+    "emoji": "🧼",
+    "names": [
+      "soap",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "bubbles",
+    "emoji": "🫧",
+    "names": [
+      "bubbles",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "toothbrush",
+    "emoji": "🪥",
+    "names": [
+      "toothbrush",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "sponge",
+    "emoji": "🧽",
+    "names": [
+      "sponge",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "fire extinguisher",
+    "emoji": "🧯",
+    "names": [
+      "fire_extinguisher",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "shopping cart",
+    "emoji": "🛒",
+    "names": [
+      "shopping_cart",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "cigarette",
+    "emoji": "🚬",
+    "names": [
+      "smoking",
+    ],
+    "tags": [
+      "cigarette",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "coffin",
+    "emoji": "⚰️",
+    "names": [
+      "coffin",
+    ],
+    "tags": [
+      "funeral",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "headstone",
+    "emoji": "🪦",
+    "names": [
+      "headstone",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "funeral urn",
+    "emoji": "⚱️",
+    "names": [
+      "funeral_urn",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "nazar amulet",
+    "emoji": "🧿",
+    "names": [
+      "nazar_amulet",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "hamsa",
+    "emoji": "🪬",
+    "names": [
+      "hamsa",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "moai",
+    "emoji": "🗿",
+    "names": [
+      "moyai",
+    ],
+    "tags": [
+      "stone",
+    ],
+  },
+  {
+    "category": "Objects",
+    "description": "placard",
+    "emoji": "🪧",
+    "names": [
+      "placard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Objects",
+    "description": "identification card",
+    "emoji": "🪪",
+    "names": [
+      "identification_card",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "ATM sign",
+    "emoji": "🏧",
+    "names": [
+      "atm",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "litter in bin sign",
+    "emoji": "🚮",
+    "names": [
+      "put_litter_in_its_place",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "potable water",
+    "emoji": "🚰",
+    "names": [
+      "potable_water",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "wheelchair symbol",
+    "emoji": "♿",
+    "names": [
+      "wheelchair",
+    ],
+    "tags": [
+      "accessibility",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "men’s room",
+    "emoji": "🚹",
+    "names": [
+      "mens",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "women’s room",
+    "emoji": "🚺",
+    "names": [
+      "womens",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "restroom",
+    "emoji": "🚻",
+    "names": [
+      "restroom",
+    ],
+    "tags": [
+      "toilet",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "baby symbol",
+    "emoji": "🚼",
+    "names": [
+      "baby_symbol",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "water closet",
+    "emoji": "🚾",
+    "names": [
+      "wc",
+    ],
+    "tags": [
+      "toilet",
+      "restroom",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "passport control",
+    "emoji": "🛂",
+    "names": [
+      "passport_control",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "customs",
+    "emoji": "🛃",
+    "names": [
+      "customs",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "baggage claim",
+    "emoji": "🛄",
+    "names": [
+      "baggage_claim",
+    ],
+    "tags": [
+      "airport",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "left luggage",
+    "emoji": "🛅",
+    "names": [
+      "left_luggage",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "warning",
+    "emoji": "⚠️",
+    "names": [
+      "warning",
+    ],
+    "tags": [
+      "wip",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "children crossing",
+    "emoji": "🚸",
+    "names": [
+      "children_crossing",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "no entry",
+    "emoji": "⛔",
+    "names": [
+      "no_entry",
+    ],
+    "tags": [
+      "limit",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "prohibited",
+    "emoji": "🚫",
+    "names": [
+      "no_entry_sign",
+    ],
+    "tags": [
+      "block",
+      "forbidden",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "no bicycles",
+    "emoji": "🚳",
+    "names": [
+      "no_bicycles",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "no smoking",
+    "emoji": "🚭",
+    "names": [
+      "no_smoking",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "no littering",
+    "emoji": "🚯",
+    "names": [
+      "do_not_litter",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "non-potable water",
+    "emoji": "🚱",
+    "names": [
+      "non-potable_water",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "no pedestrians",
+    "emoji": "🚷",
+    "names": [
+      "no_pedestrians",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "no mobile phones",
+    "emoji": "📵",
+    "names": [
+      "no_mobile_phones",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "no one under eighteen",
+    "emoji": "🔞",
+    "names": [
+      "underage",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "radioactive",
+    "emoji": "☢️",
+    "names": [
+      "radioactive",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "biohazard",
+    "emoji": "☣️",
+    "names": [
+      "biohazard",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "up arrow",
+    "emoji": "⬆️",
+    "names": [
+      "arrow_up",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "up-right arrow",
+    "emoji": "↗️",
+    "names": [
+      "arrow_upper_right",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "right arrow",
+    "emoji": "➡️",
+    "names": [
+      "arrow_right",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "down-right arrow",
+    "emoji": "↘️",
+    "names": [
+      "arrow_lower_right",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "down arrow",
+    "emoji": "⬇️",
+    "names": [
+      "arrow_down",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "down-left arrow",
+    "emoji": "↙️",
+    "names": [
+      "arrow_lower_left",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "left arrow",
+    "emoji": "⬅️",
+    "names": [
+      "arrow_left",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "up-left arrow",
+    "emoji": "↖️",
+    "names": [
+      "arrow_upper_left",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "up-down arrow",
+    "emoji": "↕️",
+    "names": [
+      "arrow_up_down",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "left-right arrow",
+    "emoji": "↔️",
+    "names": [
+      "left_right_arrow",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "right arrow curving left",
+    "emoji": "↩️",
+    "names": [
+      "leftwards_arrow_with_hook",
+    ],
+    "tags": [
+      "return",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "left arrow curving right",
+    "emoji": "↪️",
+    "names": [
+      "arrow_right_hook",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "right arrow curving up",
+    "emoji": "⤴️",
+    "names": [
+      "arrow_heading_up",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "right arrow curving down",
+    "emoji": "⤵️",
+    "names": [
+      "arrow_heading_down",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "clockwise vertical arrows",
+    "emoji": "🔃",
+    "names": [
+      "arrows_clockwise",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "counterclockwise arrows button",
+    "emoji": "🔄",
+    "names": [
+      "arrows_counterclockwise",
+    ],
+    "tags": [
+      "sync",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "BACK arrow",
+    "emoji": "🔙",
+    "names": [
+      "back",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "END arrow",
+    "emoji": "🔚",
+    "names": [
+      "end",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "ON! arrow",
+    "emoji": "🔛",
+    "names": [
+      "on",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "SOON arrow",
+    "emoji": "🔜",
+    "names": [
+      "soon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "TOP arrow",
+    "emoji": "🔝",
+    "names": [
+      "top",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "place of worship",
+    "emoji": "🛐",
+    "names": [
+      "place_of_worship",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "atom symbol",
+    "emoji": "⚛️",
+    "names": [
+      "atom_symbol",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "om",
+    "emoji": "🕉️",
+    "names": [
+      "om",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "star of David",
+    "emoji": "✡️",
+    "names": [
+      "star_of_david",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "wheel of dharma",
+    "emoji": "☸️",
+    "names": [
+      "wheel_of_dharma",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "yin yang",
+    "emoji": "☯️",
+    "names": [
+      "yin_yang",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "latin cross",
+    "emoji": "✝️",
+    "names": [
+      "latin_cross",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "orthodox cross",
+    "emoji": "☦️",
+    "names": [
+      "orthodox_cross",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "star and crescent",
+    "emoji": "☪️",
+    "names": [
+      "star_and_crescent",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "peace symbol",
+    "emoji": "☮️",
+    "names": [
+      "peace_symbol",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "menorah",
+    "emoji": "🕎",
+    "names": [
+      "menorah",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "dotted six-pointed star",
+    "emoji": "🔯",
+    "names": [
+      "six_pointed_star",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "khanda",
+    "emoji": "🪯",
+    "names": [
+      "khanda",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Aries",
+    "emoji": "♈",
+    "names": [
+      "aries",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Taurus",
+    "emoji": "♉",
+    "names": [
+      "taurus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Gemini",
+    "emoji": "♊",
+    "names": [
+      "gemini",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Cancer",
+    "emoji": "♋",
+    "names": [
+      "cancer",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Leo",
+    "emoji": "♌",
+    "names": [
+      "leo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Virgo",
+    "emoji": "♍",
+    "names": [
+      "virgo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Libra",
+    "emoji": "♎",
+    "names": [
+      "libra",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Scorpio",
+    "emoji": "♏",
+    "names": [
+      "scorpius",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Sagittarius",
+    "emoji": "♐",
+    "names": [
+      "sagittarius",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Capricorn",
+    "emoji": "♑",
+    "names": [
+      "capricorn",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Aquarius",
+    "emoji": "♒",
+    "names": [
+      "aquarius",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Pisces",
+    "emoji": "♓",
+    "names": [
+      "pisces",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Ophiuchus",
+    "emoji": "⛎",
+    "names": [
+      "ophiuchus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "shuffle tracks button",
+    "emoji": "🔀",
+    "names": [
+      "twisted_rightwards_arrows",
+    ],
+    "tags": [
+      "shuffle",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "repeat button",
+    "emoji": "🔁",
+    "names": [
+      "repeat",
+    ],
+    "tags": [
+      "loop",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "repeat single button",
+    "emoji": "🔂",
+    "names": [
+      "repeat_one",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "play button",
+    "emoji": "▶️",
+    "names": [
+      "arrow_forward",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "fast-forward button",
+    "emoji": "⏩",
+    "names": [
+      "fast_forward",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "next track button",
+    "emoji": "⏭️",
+    "names": [
+      "next_track_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "play or pause button",
+    "emoji": "⏯️",
+    "names": [
+      "play_or_pause_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "reverse button",
+    "emoji": "◀️",
+    "names": [
+      "arrow_backward",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "fast reverse button",
+    "emoji": "⏪",
+    "names": [
+      "rewind",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "last track button",
+    "emoji": "⏮️",
+    "names": [
+      "previous_track_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "upwards button",
+    "emoji": "🔼",
+    "names": [
+      "arrow_up_small",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "fast up button",
+    "emoji": "⏫",
+    "names": [
+      "arrow_double_up",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "downwards button",
+    "emoji": "🔽",
+    "names": [
+      "arrow_down_small",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "fast down button",
+    "emoji": "⏬",
+    "names": [
+      "arrow_double_down",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "pause button",
+    "emoji": "⏸️",
+    "names": [
+      "pause_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "stop button",
+    "emoji": "⏹️",
+    "names": [
+      "stop_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "record button",
+    "emoji": "⏺️",
+    "names": [
+      "record_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "eject button",
+    "emoji": "⏏️",
+    "names": [
+      "eject_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "cinema",
+    "emoji": "🎦",
+    "names": [
+      "cinema",
+    ],
+    "tags": [
+      "film",
+      "movie",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "dim button",
+    "emoji": "🔅",
+    "names": [
+      "low_brightness",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "bright button",
+    "emoji": "🔆",
+    "names": [
+      "high_brightness",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "antenna bars",
+    "emoji": "📶",
+    "names": [
+      "signal_strength",
+    ],
+    "tags": [
+      "wifi",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "wireless",
+    "emoji": "🛜",
+    "names": [
+      "wireless",
+    ],
+    "tags": [
+      "wifi",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "vibration mode",
+    "emoji": "📳",
+    "names": [
+      "vibration_mode",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "mobile phone off",
+    "emoji": "📴",
+    "names": [
+      "mobile_phone_off",
+    ],
+    "tags": [
+      "mute",
+      "off",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "female sign",
+    "emoji": "♀️",
+    "names": [
+      "female_sign",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "male sign",
+    "emoji": "♂️",
+    "names": [
+      "male_sign",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "transgender symbol",
+    "emoji": "⚧️",
+    "names": [
+      "transgender_symbol",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "multiply",
+    "emoji": "✖️",
+    "names": [
+      "heavy_multiplication_x",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "plus",
+    "emoji": "➕",
+    "names": [
+      "heavy_plus_sign",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "minus",
+    "emoji": "➖",
+    "names": [
+      "heavy_minus_sign",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "divide",
+    "emoji": "➗",
+    "names": [
+      "heavy_division_sign",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "heavy equals sign",
+    "emoji": "🟰",
+    "names": [
+      "heavy_equals_sign",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "infinity",
+    "emoji": "♾️",
+    "names": [
+      "infinity",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "double exclamation mark",
+    "emoji": "‼️",
+    "names": [
+      "bangbang",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "exclamation question mark",
+    "emoji": "⁉️",
+    "names": [
+      "interrobang",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "red question mark",
+    "emoji": "❓",
+    "names": [
+      "question",
+    ],
+    "tags": [
+      "confused",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "white question mark",
+    "emoji": "❔",
+    "names": [
+      "grey_question",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "white exclamation mark",
+    "emoji": "❕",
+    "names": [
+      "grey_exclamation",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "red exclamation mark",
+    "emoji": "❗",
+    "names": [
+      "exclamation",
+      "heavy_exclamation_mark",
+    ],
+    "tags": [
+      "bang",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "wavy dash",
+    "emoji": "〰️",
+    "names": [
+      "wavy_dash",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "currency exchange",
+    "emoji": "💱",
+    "names": [
+      "currency_exchange",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "heavy dollar sign",
+    "emoji": "💲",
+    "names": [
+      "heavy_dollar_sign",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "medical symbol",
+    "emoji": "⚕️",
+    "names": [
+      "medical_symbol",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "recycling symbol",
+    "emoji": "♻️",
+    "names": [
+      "recycle",
+    ],
+    "tags": [
+      "environment",
+      "green",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "fleur-de-lis",
+    "emoji": "⚜️",
+    "names": [
+      "fleur_de_lis",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "trident emblem",
+    "emoji": "🔱",
+    "names": [
+      "trident",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "name badge",
+    "emoji": "📛",
+    "names": [
+      "name_badge",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese symbol for beginner",
+    "emoji": "🔰",
+    "names": [
+      "beginner",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "hollow red circle",
+    "emoji": "⭕",
+    "names": [
+      "o",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "check mark button",
+    "emoji": "✅",
+    "names": [
+      "white_check_mark",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "check box with check",
+    "emoji": "☑️",
+    "names": [
+      "ballot_box_with_check",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "check mark",
+    "emoji": "✔️",
+    "names": [
+      "heavy_check_mark",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "cross mark",
+    "emoji": "❌",
+    "names": [
+      "x",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "cross mark button",
+    "emoji": "❎",
+    "names": [
+      "negative_squared_cross_mark",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "curly loop",
+    "emoji": "➰",
+    "names": [
+      "curly_loop",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "double curly loop",
+    "emoji": "➿",
+    "names": [
+      "loop",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "part alternation mark",
+    "emoji": "〽️",
+    "names": [
+      "part_alternation_mark",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "eight-spoked asterisk",
+    "emoji": "✳️",
+    "names": [
+      "eight_spoked_asterisk",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "eight-pointed star",
+    "emoji": "✴️",
+    "names": [
+      "eight_pointed_black_star",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "sparkle",
+    "emoji": "❇️",
+    "names": [
+      "sparkle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "copyright",
+    "emoji": "©️",
+    "names": [
+      "copyright",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "registered",
+    "emoji": "®️",
+    "names": [
+      "registered",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "trade mark",
+    "emoji": "™️",
+    "names": [
+      "tm",
+    ],
+    "tags": [
+      "trademark",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: #",
+    "emoji": "#️⃣",
+    "names": [
+      "hash",
+    ],
+    "tags": [
+      "number",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: *",
+    "emoji": "*️⃣",
+    "names": [
+      "asterisk",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 0",
+    "emoji": "0️⃣",
+    "names": [
+      "zero",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 1",
+    "emoji": "1️⃣",
+    "names": [
+      "one",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 2",
+    "emoji": "2️⃣",
+    "names": [
+      "two",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 3",
+    "emoji": "3️⃣",
+    "names": [
+      "three",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 4",
+    "emoji": "4️⃣",
+    "names": [
+      "four",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 5",
+    "emoji": "5️⃣",
+    "names": [
+      "five",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 6",
+    "emoji": "6️⃣",
+    "names": [
+      "six",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 7",
+    "emoji": "7️⃣",
+    "names": [
+      "seven",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 8",
+    "emoji": "8️⃣",
+    "names": [
+      "eight",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 9",
+    "emoji": "9️⃣",
+    "names": [
+      "nine",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "keycap: 10",
+    "emoji": "🔟",
+    "names": [
+      "keycap_ten",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "input latin uppercase",
+    "emoji": "🔠",
+    "names": [
+      "capital_abcd",
+    ],
+    "tags": [
+      "letters",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "input latin lowercase",
+    "emoji": "🔡",
+    "names": [
+      "abcd",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "input numbers",
+    "emoji": "🔢",
+    "names": [
+      "1234",
+    ],
+    "tags": [
+      "numbers",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "input symbols",
+    "emoji": "🔣",
+    "names": [
+      "symbols",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "input latin letters",
+    "emoji": "🔤",
+    "names": [
+      "abc",
+    ],
+    "tags": [
+      "alphabet",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "A button (blood type)",
+    "emoji": "🅰️",
+    "names": [
+      "a",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "AB button (blood type)",
+    "emoji": "🆎",
+    "names": [
+      "ab",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "B button (blood type)",
+    "emoji": "🅱️",
+    "names": [
+      "b",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "CL button",
+    "emoji": "🆑",
+    "names": [
+      "cl",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "COOL button",
+    "emoji": "🆒",
+    "names": [
+      "cool",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "FREE button",
+    "emoji": "🆓",
+    "names": [
+      "free",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "information",
+    "emoji": "ℹ️",
+    "names": [
+      "information_source",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "ID button",
+    "emoji": "🆔",
+    "names": [
+      "id",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "circled M",
+    "emoji": "Ⓜ️",
+    "names": [
+      "m",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "NEW button",
+    "emoji": "🆕",
+    "names": [
+      "new",
+    ],
+    "tags": [
+      "fresh",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "NG button",
+    "emoji": "🆖",
+    "names": [
+      "ng",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "O button (blood type)",
+    "emoji": "🅾️",
+    "names": [
+      "o2",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "OK button",
+    "emoji": "🆗",
+    "names": [
+      "ok",
+    ],
+    "tags": [
+      "yes",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "P button",
+    "emoji": "🅿️",
+    "names": [
+      "parking",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "SOS button",
+    "emoji": "🆘",
+    "names": [
+      "sos",
+    ],
+    "tags": [
+      "help",
+      "emergency",
+    ],
+  },
+  {
+    "category": "Symbols",
+    "description": "UP! button",
+    "emoji": "🆙",
+    "names": [
+      "up",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "VS button",
+    "emoji": "🆚",
+    "names": [
+      "vs",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “here” button",
+    "emoji": "🈁",
+    "names": [
+      "koko",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “service charge” button",
+    "emoji": "🈂️",
+    "names": [
+      "sa",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “monthly amount” button",
+    "emoji": "🈷️",
+    "names": [
+      "u6708",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “not free of charge” button",
+    "emoji": "🈶",
+    "names": [
+      "u6709",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “reserved” button",
+    "emoji": "🈯",
+    "names": [
+      "u6307",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “bargain” button",
+    "emoji": "🉐",
+    "names": [
+      "ideograph_advantage",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “discount” button",
+    "emoji": "🈹",
+    "names": [
+      "u5272",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “free of charge” button",
+    "emoji": "🈚",
+    "names": [
+      "u7121",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “prohibited” button",
+    "emoji": "🈲",
+    "names": [
+      "u7981",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “acceptable” button",
+    "emoji": "🉑",
+    "names": [
+      "accept",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “application” button",
+    "emoji": "🈸",
+    "names": [
+      "u7533",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “passing grade” button",
+    "emoji": "🈴",
+    "names": [
+      "u5408",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “vacancy” button",
+    "emoji": "🈳",
+    "names": [
+      "u7a7a",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “congratulations” button",
+    "emoji": "㊗️",
+    "names": [
+      "congratulations",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “secret” button",
+    "emoji": "㊙️",
+    "names": [
+      "secret",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “open for business” button",
+    "emoji": "🈺",
+    "names": [
+      "u55b6",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "Japanese “no vacancy” button",
+    "emoji": "🈵",
+    "names": [
+      "u6e80",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "red circle",
+    "emoji": "🔴",
+    "names": [
+      "red_circle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "orange circle",
+    "emoji": "🟠",
+    "names": [
+      "orange_circle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "yellow circle",
+    "emoji": "🟡",
+    "names": [
+      "yellow_circle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "green circle",
+    "emoji": "🟢",
+    "names": [
+      "green_circle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "blue circle",
+    "emoji": "🔵",
+    "names": [
+      "large_blue_circle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "purple circle",
+    "emoji": "🟣",
+    "names": [
+      "purple_circle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "brown circle",
+    "emoji": "🟤",
+    "names": [
+      "brown_circle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "black circle",
+    "emoji": "⚫",
+    "names": [
+      "black_circle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "white circle",
+    "emoji": "⚪",
+    "names": [
+      "white_circle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "red square",
+    "emoji": "🟥",
+    "names": [
+      "red_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "orange square",
+    "emoji": "🟧",
+    "names": [
+      "orange_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "yellow square",
+    "emoji": "🟨",
+    "names": [
+      "yellow_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "green square",
+    "emoji": "🟩",
+    "names": [
+      "green_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "blue square",
+    "emoji": "🟦",
+    "names": [
+      "blue_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "purple square",
+    "emoji": "🟪",
+    "names": [
+      "purple_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "brown square",
+    "emoji": "🟫",
+    "names": [
+      "brown_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "black large square",
+    "emoji": "⬛",
+    "names": [
+      "black_large_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "white large square",
+    "emoji": "⬜",
+    "names": [
+      "white_large_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "black medium square",
+    "emoji": "◼️",
+    "names": [
+      "black_medium_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "white medium square",
+    "emoji": "◻️",
+    "names": [
+      "white_medium_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "black medium-small square",
+    "emoji": "◾",
+    "names": [
+      "black_medium_small_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "white medium-small square",
+    "emoji": "◽",
+    "names": [
+      "white_medium_small_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "black small square",
+    "emoji": "▪️",
+    "names": [
+      "black_small_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "white small square",
+    "emoji": "▫️",
+    "names": [
+      "white_small_square",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "large orange diamond",
+    "emoji": "🔶",
+    "names": [
+      "large_orange_diamond",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "large blue diamond",
+    "emoji": "🔷",
+    "names": [
+      "large_blue_diamond",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "small orange diamond",
+    "emoji": "🔸",
+    "names": [
+      "small_orange_diamond",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "small blue diamond",
+    "emoji": "🔹",
+    "names": [
+      "small_blue_diamond",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "red triangle pointed up",
+    "emoji": "🔺",
+    "names": [
+      "small_red_triangle",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "red triangle pointed down",
+    "emoji": "🔻",
+    "names": [
+      "small_red_triangle_down",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "diamond with a dot",
+    "emoji": "💠",
+    "names": [
+      "diamond_shape_with_a_dot_inside",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "radio button",
+    "emoji": "🔘",
+    "names": [
+      "radio_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "white square button",
+    "emoji": "🔳",
+    "names": [
+      "white_square_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Symbols",
+    "description": "black square button",
+    "emoji": "🔲",
+    "names": [
+      "black_square_button",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "chequered flag",
+    "emoji": "🏁",
+    "names": [
+      "checkered_flag",
+    ],
+    "tags": [
+      "milestone",
+      "finish",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "triangular flag",
+    "emoji": "🚩",
+    "names": [
+      "triangular_flag_on_post",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "crossed flags",
+    "emoji": "🎌",
+    "names": [
+      "crossed_flags",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "black flag",
+    "emoji": "🏴",
+    "names": [
+      "black_flag",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "white flag",
+    "emoji": "🏳️",
+    "names": [
+      "white_flag",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "rainbow flag",
+    "emoji": "🏳️‍🌈",
+    "names": [
+      "rainbow_flag",
+    ],
+    "tags": [
+      "pride",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "transgender flag",
+    "emoji": "🏳️‍⚧️",
+    "names": [
+      "transgender_flag",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "pirate flag",
+    "emoji": "🏴‍☠️",
+    "names": [
+      "pirate_flag",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Ascension Island",
+    "emoji": "🇦🇨",
+    "names": [
+      "ascension_island",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Andorra",
+    "emoji": "🇦🇩",
+    "names": [
+      "andorra",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: United Arab Emirates",
+    "emoji": "🇦🇪",
+    "names": [
+      "united_arab_emirates",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Afghanistan",
+    "emoji": "🇦🇫",
+    "names": [
+      "afghanistan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Antigua & Barbuda",
+    "emoji": "🇦🇬",
+    "names": [
+      "antigua_barbuda",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Anguilla",
+    "emoji": "🇦🇮",
+    "names": [
+      "anguilla",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Albania",
+    "emoji": "🇦🇱",
+    "names": [
+      "albania",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Armenia",
+    "emoji": "🇦🇲",
+    "names": [
+      "armenia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Angola",
+    "emoji": "🇦🇴",
+    "names": [
+      "angola",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Antarctica",
+    "emoji": "🇦🇶",
+    "names": [
+      "antarctica",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Argentina",
+    "emoji": "🇦🇷",
+    "names": [
+      "argentina",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: American Samoa",
+    "emoji": "🇦🇸",
+    "names": [
+      "american_samoa",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Austria",
+    "emoji": "🇦🇹",
+    "names": [
+      "austria",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Australia",
+    "emoji": "🇦🇺",
+    "names": [
+      "australia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Aruba",
+    "emoji": "🇦🇼",
+    "names": [
+      "aruba",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Åland Islands",
+    "emoji": "🇦🇽",
+    "names": [
+      "aland_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Azerbaijan",
+    "emoji": "🇦🇿",
+    "names": [
+      "azerbaijan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Bosnia & Herzegovina",
+    "emoji": "🇧🇦",
+    "names": [
+      "bosnia_herzegovina",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Barbados",
+    "emoji": "🇧🇧",
+    "names": [
+      "barbados",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Bangladesh",
+    "emoji": "🇧🇩",
+    "names": [
+      "bangladesh",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Belgium",
+    "emoji": "🇧🇪",
+    "names": [
+      "belgium",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Burkina Faso",
+    "emoji": "🇧🇫",
+    "names": [
+      "burkina_faso",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Bulgaria",
+    "emoji": "🇧🇬",
+    "names": [
+      "bulgaria",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Bahrain",
+    "emoji": "🇧🇭",
+    "names": [
+      "bahrain",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Burundi",
+    "emoji": "🇧🇮",
+    "names": [
+      "burundi",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Benin",
+    "emoji": "🇧🇯",
+    "names": [
+      "benin",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: St. Barthélemy",
+    "emoji": "🇧🇱",
+    "names": [
+      "st_barthelemy",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Bermuda",
+    "emoji": "🇧🇲",
+    "names": [
+      "bermuda",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Brunei",
+    "emoji": "🇧🇳",
+    "names": [
+      "brunei",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Bolivia",
+    "emoji": "🇧🇴",
+    "names": [
+      "bolivia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Caribbean Netherlands",
+    "emoji": "🇧🇶",
+    "names": [
+      "caribbean_netherlands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Brazil",
+    "emoji": "🇧🇷",
+    "names": [
+      "brazil",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Bahamas",
+    "emoji": "🇧🇸",
+    "names": [
+      "bahamas",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Bhutan",
+    "emoji": "🇧🇹",
+    "names": [
+      "bhutan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Bouvet Island",
+    "emoji": "🇧🇻",
+    "names": [
+      "bouvet_island",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Botswana",
+    "emoji": "🇧🇼",
+    "names": [
+      "botswana",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Belarus",
+    "emoji": "🇧🇾",
+    "names": [
+      "belarus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Belize",
+    "emoji": "🇧🇿",
+    "names": [
+      "belize",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Canada",
+    "emoji": "🇨🇦",
+    "names": [
+      "canada",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Cocos (Keeling) Islands",
+    "emoji": "🇨🇨",
+    "names": [
+      "cocos_islands",
+    ],
+    "tags": [
+      "keeling",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Congo - Kinshasa",
+    "emoji": "🇨🇩",
+    "names": [
+      "congo_kinshasa",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Central African Republic",
+    "emoji": "🇨🇫",
+    "names": [
+      "central_african_republic",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Congo - Brazzaville",
+    "emoji": "🇨🇬",
+    "names": [
+      "congo_brazzaville",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Switzerland",
+    "emoji": "🇨🇭",
+    "names": [
+      "switzerland",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Côte d’Ivoire",
+    "emoji": "🇨🇮",
+    "names": [
+      "cote_divoire",
+    ],
+    "tags": [
+      "ivory",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Cook Islands",
+    "emoji": "🇨🇰",
+    "names": [
+      "cook_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Chile",
+    "emoji": "🇨🇱",
+    "names": [
+      "chile",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Cameroon",
+    "emoji": "🇨🇲",
+    "names": [
+      "cameroon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: China",
+    "emoji": "🇨🇳",
+    "names": [
+      "cn",
+    ],
+    "tags": [
+      "china",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Colombia",
+    "emoji": "🇨🇴",
+    "names": [
+      "colombia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Clipperton Island",
+    "emoji": "🇨🇵",
+    "names": [
+      "clipperton_island",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Costa Rica",
+    "emoji": "🇨🇷",
+    "names": [
+      "costa_rica",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Cuba",
+    "emoji": "🇨🇺",
+    "names": [
+      "cuba",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Cape Verde",
+    "emoji": "🇨🇻",
+    "names": [
+      "cape_verde",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Curaçao",
+    "emoji": "🇨🇼",
+    "names": [
+      "curacao",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Christmas Island",
+    "emoji": "🇨🇽",
+    "names": [
+      "christmas_island",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Cyprus",
+    "emoji": "🇨🇾",
+    "names": [
+      "cyprus",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Czechia",
+    "emoji": "🇨🇿",
+    "names": [
+      "czech_republic",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Germany",
+    "emoji": "🇩🇪",
+    "names": [
+      "de",
+    ],
+    "tags": [
+      "flag",
+      "germany",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Diego Garcia",
+    "emoji": "🇩🇬",
+    "names": [
+      "diego_garcia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Djibouti",
+    "emoji": "🇩🇯",
+    "names": [
+      "djibouti",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Denmark",
+    "emoji": "🇩🇰",
+    "names": [
+      "denmark",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Dominica",
+    "emoji": "🇩🇲",
+    "names": [
+      "dominica",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Dominican Republic",
+    "emoji": "🇩🇴",
+    "names": [
+      "dominican_republic",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Algeria",
+    "emoji": "🇩🇿",
+    "names": [
+      "algeria",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Ceuta & Melilla",
+    "emoji": "🇪🇦",
+    "names": [
+      "ceuta_melilla",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Ecuador",
+    "emoji": "🇪🇨",
+    "names": [
+      "ecuador",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Estonia",
+    "emoji": "🇪🇪",
+    "names": [
+      "estonia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Egypt",
+    "emoji": "🇪🇬",
+    "names": [
+      "egypt",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Western Sahara",
+    "emoji": "🇪🇭",
+    "names": [
+      "western_sahara",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Eritrea",
+    "emoji": "🇪🇷",
+    "names": [
+      "eritrea",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Spain",
+    "emoji": "🇪🇸",
+    "names": [
+      "es",
+    ],
+    "tags": [
+      "spain",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Ethiopia",
+    "emoji": "🇪🇹",
+    "names": [
+      "ethiopia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: European Union",
+    "emoji": "🇪🇺",
+    "names": [
+      "eu",
+      "european_union",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Finland",
+    "emoji": "🇫🇮",
+    "names": [
+      "finland",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Fiji",
+    "emoji": "🇫🇯",
+    "names": [
+      "fiji",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Falkland Islands",
+    "emoji": "🇫🇰",
+    "names": [
+      "falkland_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Micronesia",
+    "emoji": "🇫🇲",
+    "names": [
+      "micronesia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Faroe Islands",
+    "emoji": "🇫🇴",
+    "names": [
+      "faroe_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: France",
+    "emoji": "🇫🇷",
+    "names": [
+      "fr",
+    ],
+    "tags": [
+      "france",
+      "french",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Gabon",
+    "emoji": "🇬🇦",
+    "names": [
+      "gabon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: United Kingdom",
+    "emoji": "🇬🇧",
+    "names": [
+      "gb",
+      "uk",
+    ],
+    "tags": [
+      "flag",
+      "british",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Grenada",
+    "emoji": "🇬🇩",
+    "names": [
+      "grenada",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Georgia",
+    "emoji": "🇬🇪",
+    "names": [
+      "georgia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: French Guiana",
+    "emoji": "🇬🇫",
+    "names": [
+      "french_guiana",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Guernsey",
+    "emoji": "🇬🇬",
+    "names": [
+      "guernsey",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Ghana",
+    "emoji": "🇬🇭",
+    "names": [
+      "ghana",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Gibraltar",
+    "emoji": "🇬🇮",
+    "names": [
+      "gibraltar",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Greenland",
+    "emoji": "🇬🇱",
+    "names": [
+      "greenland",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Gambia",
+    "emoji": "🇬🇲",
+    "names": [
+      "gambia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Guinea",
+    "emoji": "🇬🇳",
+    "names": [
+      "guinea",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Guadeloupe",
+    "emoji": "🇬🇵",
+    "names": [
+      "guadeloupe",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Equatorial Guinea",
+    "emoji": "🇬🇶",
+    "names": [
+      "equatorial_guinea",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Greece",
+    "emoji": "🇬🇷",
+    "names": [
+      "greece",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: South Georgia & South Sandwich Islands",
+    "emoji": "🇬🇸",
+    "names": [
+      "south_georgia_south_sandwich_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Guatemala",
+    "emoji": "🇬🇹",
+    "names": [
+      "guatemala",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Guam",
+    "emoji": "🇬🇺",
+    "names": [
+      "guam",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Guinea-Bissau",
+    "emoji": "🇬🇼",
+    "names": [
+      "guinea_bissau",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Guyana",
+    "emoji": "🇬🇾",
+    "names": [
+      "guyana",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Hong Kong SAR China",
+    "emoji": "🇭🇰",
+    "names": [
+      "hong_kong",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Heard & McDonald Islands",
+    "emoji": "🇭🇲",
+    "names": [
+      "heard_mcdonald_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Honduras",
+    "emoji": "🇭🇳",
+    "names": [
+      "honduras",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Croatia",
+    "emoji": "🇭🇷",
+    "names": [
+      "croatia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Haiti",
+    "emoji": "🇭🇹",
+    "names": [
+      "haiti",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Hungary",
+    "emoji": "🇭🇺",
+    "names": [
+      "hungary",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Canary Islands",
+    "emoji": "🇮🇨",
+    "names": [
+      "canary_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Indonesia",
+    "emoji": "🇮🇩",
+    "names": [
+      "indonesia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Ireland",
+    "emoji": "🇮🇪",
+    "names": [
+      "ireland",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Israel",
+    "emoji": "🇮🇱",
+    "names": [
+      "israel",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Isle of Man",
+    "emoji": "🇮🇲",
+    "names": [
+      "isle_of_man",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: India",
+    "emoji": "🇮🇳",
+    "names": [
+      "india",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: British Indian Ocean Territory",
+    "emoji": "🇮🇴",
+    "names": [
+      "british_indian_ocean_territory",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Iraq",
+    "emoji": "🇮🇶",
+    "names": [
+      "iraq",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Iran",
+    "emoji": "🇮🇷",
+    "names": [
+      "iran",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Iceland",
+    "emoji": "🇮🇸",
+    "names": [
+      "iceland",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Italy",
+    "emoji": "🇮🇹",
+    "names": [
+      "it",
+    ],
+    "tags": [
+      "italy",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Jersey",
+    "emoji": "🇯🇪",
+    "names": [
+      "jersey",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Jamaica",
+    "emoji": "🇯🇲",
+    "names": [
+      "jamaica",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Jordan",
+    "emoji": "🇯🇴",
+    "names": [
+      "jordan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Japan",
+    "emoji": "🇯🇵",
+    "names": [
+      "jp",
+    ],
+    "tags": [
+      "japan",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Kenya",
+    "emoji": "🇰🇪",
+    "names": [
+      "kenya",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Kyrgyzstan",
+    "emoji": "🇰🇬",
+    "names": [
+      "kyrgyzstan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Cambodia",
+    "emoji": "🇰🇭",
+    "names": [
+      "cambodia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Kiribati",
+    "emoji": "🇰🇮",
+    "names": [
+      "kiribati",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Comoros",
+    "emoji": "🇰🇲",
+    "names": [
+      "comoros",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: St. Kitts & Nevis",
+    "emoji": "🇰🇳",
+    "names": [
+      "st_kitts_nevis",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: North Korea",
+    "emoji": "🇰🇵",
+    "names": [
+      "north_korea",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: South Korea",
+    "emoji": "🇰🇷",
+    "names": [
+      "kr",
+    ],
+    "tags": [
+      "korea",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Kuwait",
+    "emoji": "🇰🇼",
+    "names": [
+      "kuwait",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Cayman Islands",
+    "emoji": "🇰🇾",
+    "names": [
+      "cayman_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Kazakhstan",
+    "emoji": "🇰🇿",
+    "names": [
+      "kazakhstan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Laos",
+    "emoji": "🇱🇦",
+    "names": [
+      "laos",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Lebanon",
+    "emoji": "🇱🇧",
+    "names": [
+      "lebanon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: St. Lucia",
+    "emoji": "🇱🇨",
+    "names": [
+      "st_lucia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Liechtenstein",
+    "emoji": "🇱🇮",
+    "names": [
+      "liechtenstein",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Sri Lanka",
+    "emoji": "🇱🇰",
+    "names": [
+      "sri_lanka",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Liberia",
+    "emoji": "🇱🇷",
+    "names": [
+      "liberia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Lesotho",
+    "emoji": "🇱🇸",
+    "names": [
+      "lesotho",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Lithuania",
+    "emoji": "🇱🇹",
+    "names": [
+      "lithuania",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Luxembourg",
+    "emoji": "🇱🇺",
+    "names": [
+      "luxembourg",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Latvia",
+    "emoji": "🇱🇻",
+    "names": [
+      "latvia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Libya",
+    "emoji": "🇱🇾",
+    "names": [
+      "libya",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Morocco",
+    "emoji": "🇲🇦",
+    "names": [
+      "morocco",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Monaco",
+    "emoji": "🇲🇨",
+    "names": [
+      "monaco",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Moldova",
+    "emoji": "🇲🇩",
+    "names": [
+      "moldova",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Montenegro",
+    "emoji": "🇲🇪",
+    "names": [
+      "montenegro",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: St. Martin",
+    "emoji": "🇲🇫",
+    "names": [
+      "st_martin",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Madagascar",
+    "emoji": "🇲🇬",
+    "names": [
+      "madagascar",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Marshall Islands",
+    "emoji": "🇲🇭",
+    "names": [
+      "marshall_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: North Macedonia",
+    "emoji": "🇲🇰",
+    "names": [
+      "macedonia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Mali",
+    "emoji": "🇲🇱",
+    "names": [
+      "mali",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Myanmar (Burma)",
+    "emoji": "🇲🇲",
+    "names": [
+      "myanmar",
+    ],
+    "tags": [
+      "burma",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Mongolia",
+    "emoji": "🇲🇳",
+    "names": [
+      "mongolia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Macao SAR China",
+    "emoji": "🇲🇴",
+    "names": [
+      "macau",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Northern Mariana Islands",
+    "emoji": "🇲🇵",
+    "names": [
+      "northern_mariana_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Martinique",
+    "emoji": "🇲🇶",
+    "names": [
+      "martinique",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Mauritania",
+    "emoji": "🇲🇷",
+    "names": [
+      "mauritania",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Montserrat",
+    "emoji": "🇲🇸",
+    "names": [
+      "montserrat",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Malta",
+    "emoji": "🇲🇹",
+    "names": [
+      "malta",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Mauritius",
+    "emoji": "🇲🇺",
+    "names": [
+      "mauritius",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Maldives",
+    "emoji": "🇲🇻",
+    "names": [
+      "maldives",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Malawi",
+    "emoji": "🇲🇼",
+    "names": [
+      "malawi",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Mexico",
+    "emoji": "🇲🇽",
+    "names": [
+      "mexico",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Malaysia",
+    "emoji": "🇲🇾",
+    "names": [
+      "malaysia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Mozambique",
+    "emoji": "🇲🇿",
+    "names": [
+      "mozambique",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Namibia",
+    "emoji": "🇳🇦",
+    "names": [
+      "namibia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: New Caledonia",
+    "emoji": "🇳🇨",
+    "names": [
+      "new_caledonia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Niger",
+    "emoji": "🇳🇪",
+    "names": [
+      "niger",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Norfolk Island",
+    "emoji": "🇳🇫",
+    "names": [
+      "norfolk_island",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Nigeria",
+    "emoji": "🇳🇬",
+    "names": [
+      "nigeria",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Nicaragua",
+    "emoji": "🇳🇮",
+    "names": [
+      "nicaragua",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Netherlands",
+    "emoji": "🇳🇱",
+    "names": [
+      "netherlands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Norway",
+    "emoji": "🇳🇴",
+    "names": [
+      "norway",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Nepal",
+    "emoji": "🇳🇵",
+    "names": [
+      "nepal",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Nauru",
+    "emoji": "🇳🇷",
+    "names": [
+      "nauru",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Niue",
+    "emoji": "🇳🇺",
+    "names": [
+      "niue",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: New Zealand",
+    "emoji": "🇳🇿",
+    "names": [
+      "new_zealand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Oman",
+    "emoji": "🇴🇲",
+    "names": [
+      "oman",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Panama",
+    "emoji": "🇵🇦",
+    "names": [
+      "panama",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Peru",
+    "emoji": "🇵🇪",
+    "names": [
+      "peru",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: French Polynesia",
+    "emoji": "🇵🇫",
+    "names": [
+      "french_polynesia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Papua New Guinea",
+    "emoji": "🇵🇬",
+    "names": [
+      "papua_new_guinea",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Philippines",
+    "emoji": "🇵🇭",
+    "names": [
+      "philippines",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Pakistan",
+    "emoji": "🇵🇰",
+    "names": [
+      "pakistan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Poland",
+    "emoji": "🇵🇱",
+    "names": [
+      "poland",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: St. Pierre & Miquelon",
+    "emoji": "🇵🇲",
+    "names": [
+      "st_pierre_miquelon",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Pitcairn Islands",
+    "emoji": "🇵🇳",
+    "names": [
+      "pitcairn_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Puerto Rico",
+    "emoji": "🇵🇷",
+    "names": [
+      "puerto_rico",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Palestinian Territories",
+    "emoji": "🇵🇸",
+    "names": [
+      "palestinian_territories",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Portugal",
+    "emoji": "🇵🇹",
+    "names": [
+      "portugal",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Palau",
+    "emoji": "🇵🇼",
+    "names": [
+      "palau",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Paraguay",
+    "emoji": "🇵🇾",
+    "names": [
+      "paraguay",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Qatar",
+    "emoji": "🇶🇦",
+    "names": [
+      "qatar",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Réunion",
+    "emoji": "🇷🇪",
+    "names": [
+      "reunion",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Romania",
+    "emoji": "🇷🇴",
+    "names": [
+      "romania",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Serbia",
+    "emoji": "🇷🇸",
+    "names": [
+      "serbia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Russia",
+    "emoji": "🇷🇺",
+    "names": [
+      "ru",
+    ],
+    "tags": [
+      "russia",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Rwanda",
+    "emoji": "🇷🇼",
+    "names": [
+      "rwanda",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Saudi Arabia",
+    "emoji": "🇸🇦",
+    "names": [
+      "saudi_arabia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Solomon Islands",
+    "emoji": "🇸🇧",
+    "names": [
+      "solomon_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Seychelles",
+    "emoji": "🇸🇨",
+    "names": [
+      "seychelles",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Sudan",
+    "emoji": "🇸🇩",
+    "names": [
+      "sudan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Sweden",
+    "emoji": "🇸🇪",
+    "names": [
+      "sweden",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Singapore",
+    "emoji": "🇸🇬",
+    "names": [
+      "singapore",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: St. Helena",
+    "emoji": "🇸🇭",
+    "names": [
+      "st_helena",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Slovenia",
+    "emoji": "🇸🇮",
+    "names": [
+      "slovenia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Svalbard & Jan Mayen",
+    "emoji": "🇸🇯",
+    "names": [
+      "svalbard_jan_mayen",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Slovakia",
+    "emoji": "🇸🇰",
+    "names": [
+      "slovakia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Sierra Leone",
+    "emoji": "🇸🇱",
+    "names": [
+      "sierra_leone",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: San Marino",
+    "emoji": "🇸🇲",
+    "names": [
+      "san_marino",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Senegal",
+    "emoji": "🇸🇳",
+    "names": [
+      "senegal",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Somalia",
+    "emoji": "🇸🇴",
+    "names": [
+      "somalia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Suriname",
+    "emoji": "🇸🇷",
+    "names": [
+      "suriname",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: South Sudan",
+    "emoji": "🇸🇸",
+    "names": [
+      "south_sudan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: São Tomé & Príncipe",
+    "emoji": "🇸🇹",
+    "names": [
+      "sao_tome_principe",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: El Salvador",
+    "emoji": "🇸🇻",
+    "names": [
+      "el_salvador",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Sint Maarten",
+    "emoji": "🇸🇽",
+    "names": [
+      "sint_maarten",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Syria",
+    "emoji": "🇸🇾",
+    "names": [
+      "syria",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Eswatini",
+    "emoji": "🇸🇿",
+    "names": [
+      "swaziland",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Tristan da Cunha",
+    "emoji": "🇹🇦",
+    "names": [
+      "tristan_da_cunha",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Turks & Caicos Islands",
+    "emoji": "🇹🇨",
+    "names": [
+      "turks_caicos_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Chad",
+    "emoji": "🇹🇩",
+    "names": [
+      "chad",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: French Southern Territories",
+    "emoji": "🇹🇫",
+    "names": [
+      "french_southern_territories",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Togo",
+    "emoji": "🇹🇬",
+    "names": [
+      "togo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Thailand",
+    "emoji": "🇹🇭",
+    "names": [
+      "thailand",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Tajikistan",
+    "emoji": "🇹🇯",
+    "names": [
+      "tajikistan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Tokelau",
+    "emoji": "🇹🇰",
+    "names": [
+      "tokelau",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Timor-Leste",
+    "emoji": "🇹🇱",
+    "names": [
+      "timor_leste",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Turkmenistan",
+    "emoji": "🇹🇲",
+    "names": [
+      "turkmenistan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Tunisia",
+    "emoji": "🇹🇳",
+    "names": [
+      "tunisia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Tonga",
+    "emoji": "🇹🇴",
+    "names": [
+      "tonga",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Turkey",
+    "emoji": "🇹🇷",
+    "names": [
+      "tr",
+    ],
+    "tags": [
+      "turkey",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Trinidad & Tobago",
+    "emoji": "🇹🇹",
+    "names": [
+      "trinidad_tobago",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Tuvalu",
+    "emoji": "🇹🇻",
+    "names": [
+      "tuvalu",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Taiwan",
+    "emoji": "🇹🇼",
+    "names": [
+      "taiwan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Tanzania",
+    "emoji": "🇹🇿",
+    "names": [
+      "tanzania",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Ukraine",
+    "emoji": "🇺🇦",
+    "names": [
+      "ukraine",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Uganda",
+    "emoji": "🇺🇬",
+    "names": [
+      "uganda",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: U.S. Outlying Islands",
+    "emoji": "🇺🇲",
+    "names": [
+      "us_outlying_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: United Nations",
+    "emoji": "🇺🇳",
+    "names": [
+      "united_nations",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: United States",
+    "emoji": "🇺🇸",
+    "names": [
+      "us",
+    ],
+    "tags": [
+      "flag",
+      "united",
+      "america",
+    ],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Uruguay",
+    "emoji": "🇺🇾",
+    "names": [
+      "uruguay",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Uzbekistan",
+    "emoji": "🇺🇿",
+    "names": [
+      "uzbekistan",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Vatican City",
+    "emoji": "🇻🇦",
+    "names": [
+      "vatican_city",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: St. Vincent & Grenadines",
+    "emoji": "🇻🇨",
+    "names": [
+      "st_vincent_grenadines",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Venezuela",
+    "emoji": "🇻🇪",
+    "names": [
+      "venezuela",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: British Virgin Islands",
+    "emoji": "🇻🇬",
+    "names": [
+      "british_virgin_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: U.S. Virgin Islands",
+    "emoji": "🇻🇮",
+    "names": [
+      "us_virgin_islands",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Vietnam",
+    "emoji": "🇻🇳",
+    "names": [
+      "vietnam",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Vanuatu",
+    "emoji": "🇻🇺",
+    "names": [
+      "vanuatu",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Wallis & Futuna",
+    "emoji": "🇼🇫",
+    "names": [
+      "wallis_futuna",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Samoa",
+    "emoji": "🇼🇸",
+    "names": [
+      "samoa",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Kosovo",
+    "emoji": "🇽🇰",
+    "names": [
+      "kosovo",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Yemen",
+    "emoji": "🇾🇪",
+    "names": [
+      "yemen",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Mayotte",
+    "emoji": "🇾🇹",
+    "names": [
+      "mayotte",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: South Africa",
+    "emoji": "🇿🇦",
+    "names": [
+      "south_africa",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Zambia",
+    "emoji": "🇿🇲",
+    "names": [
+      "zambia",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Zimbabwe",
+    "emoji": "🇿🇼",
+    "names": [
+      "zimbabwe",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: England",
+    "emoji": "🏴󠁧󠁢󠁥󠁮󠁧󠁿",
+    "names": [
+      "england",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Scotland",
+    "emoji": "🏴󠁧󠁢󠁳󠁣󠁴󠁿",
+    "names": [
+      "scotland",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "Flags",
+    "description": "flag: Wales",
+    "emoji": "🏴󠁧󠁢󠁷󠁬󠁳󠁿",
+    "names": [
+      "wales",
+    ],
+    "tags": [],
+  },
+  {
+    "category": "ReadMe",
+    "description": "an owlbert for any occasion",
+    "emoji": "",
+    "names": [
+      "owlbert",
+    ],
+    "tags": [
+      "owlbert",
+    ],
+  },
+  {
+    "category": "ReadMe",
+    "description": "owlbert carrying books",
+    "emoji": "",
+    "names": [
+      "owlbert-books",
+    ],
+    "tags": [
+      "owlbert",
+    ],
+  },
+  {
+    "category": "ReadMe",
+    "description": "owlbert with a respirator",
+    "emoji": "",
+    "names": [
+      "owlbert-mask",
+    ],
+    "tags": [
+      "owlbert",
+    ],
+  },
+  {
+    "category": "ReadMe",
+    "description": "owlbert reading",
+    "emoji": "",
+    "names": [
+      "owlbert-reading",
+    ],
+    "tags": [
+      "owlbert",
+    ],
+  },
+  {
+    "category": "ReadMe",
+    "description": "owlbert thinking",
+    "emoji": "",
+    "names": [
+      "owlbert-thinking",
+    ],
+    "tags": [
+      "owlbert",
+    ],
+  },
+]
+`;

--- a/__tests__/lib/owlmoji.test.ts
+++ b/__tests__/lib/owlmoji.test.ts
@@ -1,0 +1,33 @@
+import { nameToEmoji } from 'gemoji';
+
+import Owlmoji from '../../lib/owlmoji';
+
+describe('Owlmoji', () => {
+  describe('kind', () => {
+    it('returns "gemoji" for a gemoji name', () => {
+      expect(Owlmoji.kind('smile')).toBe('gemoji');
+    });
+
+    it('returns "fontawesome" for a fa- name', () => {
+      expect(Owlmoji.kind('fa-owl')).toBe('fontawesome');
+    });
+
+    it('returns "owlmoji" for an owlmoji name', () => {
+      expect(Owlmoji.kind('owlbert')).toBe('owlmoji');
+      expect(Owlmoji.kind('owlbert-books')).toBe('owlmoji');
+    });
+
+    it('returns null for an unknown name', () => {
+      expect(Owlmoji.kind('notarealmoji')).toBeNull();
+    });
+  });
+
+  it('exposes nameToEmoji from gemoji', () => {
+    expect(Owlmoji.nameToEmoji).toBe(nameToEmoji);
+    expect(Owlmoji.nameToEmoji.smile).toBe('😄');
+  });
+
+  it('owlmoji collection matches the snapshot', () => {
+    expect(Owlmoji.owlmoji).toMatchSnapshot();
+  });
+});

--- a/lib/owlmoji.ts
+++ b/lib/owlmoji.ts
@@ -52,5 +52,5 @@ export default class Owlmoji {
 
   static nameToEmoji = nameToEmoji;
 
-  static owlmoji = gemoji.concat(owlmoji).sort((a, b) => a.names[0].localeCompare(b.names[0]));
+  static owlmoji = gemoji.concat(owlmoji);
 }


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

In https://github.com/readmeio/markdown/pull/1114 I added parity for @readme/mdx to expose full emoji list like we do in the legacy package. 

But I noticed pulling this into the UI that the emoji list is sorted differently:
| Before (uses `@readme/markdown`) | After (uses `@readme/mdx`) |
| --- | --- |
| <img width="375" alt="image" src="https://github.com/user-attachments/assets/f939387d-a73b-4eca-b91b-37d0c453a6d6" /> | <img width="372" alt="image" src="https://github.com/user-attachments/assets/18bd898c-59f9-4088-8e47-5b0f68ea815e" /> |

I'd changed this line
https://github.com/readmeio/markdown/blob/f369acff29394bc0cc172a9d0ffc918ac478960e/lib/owlmoji.js#L48

to use `localCompare`
https://github.com/readmeio/markdown/blob/bff213de097d8f215de104dc8f533e7433e42edd/lib/owlmoji.ts#L55

because the sort is performed on strings, you can't use arithmetic operations in a sort on strings like `.sort((a, b) => a.names[0] - b.names[0]);`. I don't think this code in the legacy package is actually sorting anything!

SO, I removed it.


## 🧰 Changes
- Remove sort code because the legacy package doesn't actually sort
- Add unit tests for the Owlmoji stuff to prevent this confusion in the future.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
