### PR TITLE
feat: remove glossary as special block

### DIFF
--- a/__tests__/transformers/readme-components.test.ts
+++ b/__tests__/transformers/readme-components.test.ts
@@ -76,15 +76,6 @@ Second
     expect(tree.children[0].name).toBe('Callout');
   });
 
-  it('converts Glossary components to markdown nodes', () => {
-    const mdx = `
-<Glossary>Demo</Glossary>
-`;
-
-    const tree = mdast(mdx);
-    expect(tree.children[0].children[0].type).toBe('readme-glossary-item');
-  });
-
   it('converts variable phrasing expressions to markdown nodes', () => {
     const mdx = '{user.name}';
 

--- a/processor/compile/compatibility.ts
+++ b/processor/compile/compatibility.ts
@@ -76,6 +76,8 @@ const embedToEmbedBlock = (node: CompatEmbed) => {
 const compatibility = (node: CompatNodes) => {
   switch (node.type) {
     case NodeTypes.glossary: {
+      // Glossary terms will no longer be serialized as special node types in the Editor but we want to ensure that we compile historical
+      // data correctly
       const term = node.data?.hProperties?.term || node.children[0].value;
       return `<Glossary>${term}</Glossary>`;
     }

--- a/processor/transform/readme-components.ts
+++ b/processor/transform/readme-components.ts
@@ -18,7 +18,6 @@ const types = {
   Code: 'code',
   CodeTabs: NodeTypes.codeTabs,
   EmbedBlock: NodeTypes['embed-block'],
-  Glossary: NodeTypes.glossary,
   ImageBlock: NodeTypes.imageBlock,
   HTMLBlock: NodeTypes.htmlBlock,
   Table: 'table',


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-12670
:-------------------:|:----------:

## 🧰 Changes
In an effort to simplify the Editor blocks, we're transitioning the `Glossary` term from having a special UI to being displayed as plain MDX. 
This removes the logic that transforms `<Glossary>` mdx tags into a special node type. 

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
