### PR TITLE
feat: better callout defaults

### DIFF
--- a/__tests__/compilers/callout.test.ts
+++ b/__tests__/compilers/callout.test.ts
@@ -49,10 +49,6 @@ describe('callouts compiler', () => {
   });
 
   it('compiles callouts with icons + theme', () => {
-    const markdown = `<Callout icon="fad fa-wagon-covered" theme="warn">
-  test
-</Callout>`;
-
     const mockAst = {
       type: 'root',
       children: [
@@ -64,18 +60,6 @@ describe('callouts compiler', () => {
                 {
                   type: 'text',
                   value: 'test',
-                  position: {
-                    start: {
-                      line: 2,
-                      column: 3,
-                      offset: 53,
-                    },
-                    end: {
-                      line: 2,
-                      column: 7,
-                      offset: 57,
-                    },
-                  },
                 },
               ],
             },
@@ -92,6 +76,76 @@ describe('callouts compiler', () => {
         },
       ],
     };
+    const markdown = `
+<Callout icon="fad fa-wagon-covered" theme="warn">
+  test
+</Callout>`.trim();
+
+    expect(mdx(mockAst as Root).trim()).toBe(markdown);
+  });
+
+  it('compiles a callout with only a theme set', () => {
+    const mockAst = {
+      type: 'root',
+      children: [
+        {
+          children: [
+            {
+              type: 'heading',
+              depth: 3,
+              children: [
+                {
+                  type: 'text',
+                  value: 'test',
+                },
+              ],
+            },
+          ],
+          type: 'rdme-callout',
+          data: {
+            hName: 'Callout',
+            hProperties: {
+              empty: false,
+              theme: 'warn',
+            },
+          },
+        },
+      ],
+    };
+    const markdown = '> 🚧 test';
+
+    expect(mdx(mockAst as Root).trim()).toBe(markdown);
+  });
+
+  it('compiles a callout with only an icon set', () => {
+    const mockAst = {
+      type: 'root',
+      children: [
+        {
+          children: [
+            {
+              type: 'heading',
+              depth: 3,
+              children: [
+                {
+                  type: 'text',
+                  value: 'test',
+                },
+              ],
+            },
+          ],
+          type: 'rdme-callout',
+          data: {
+            hName: 'Callout',
+            hProperties: {
+              icon: '🚧',
+              empty: false,
+            },
+          },
+        },
+      ],
+    };
+    const markdown = '> 🚧 test';
 
     expect(mdx(mockAst as Root).trim()).toBe(markdown);
   });

--- a/__tests__/transformers/callouts.test.ts
+++ b/__tests__/transformers/callouts.test.ts
@@ -72,41 +72,34 @@ describe('callouts transformer', () => {
 
   it('can parse a jsx callout into a rdme-callout', () => {
     const md = `
+<Callout icon="📘" theme="info">
+### This is a callout
+</Callout>`;
+
+    const tree = mdast(md);
+
+    expect(tree.children[0]).toHaveProperty('type', 'rdme-callout');
+  });
+
+  it.skip('can parse a jsx callout and sets a default icon', () => {
+    const md = `
 <Callout theme="info">
 ### This is a callout
 </Callout>`;
 
     const tree = mdast(md);
-    removePosition(tree, { force: true });
 
-    expect(tree).toMatchInlineSnapshot(`
-      {
-        "children": [
-          {
-            "children": [
-              {
-                "children": [
-                  {
-                    "type": "text",
-                    "value": "This is a callout",
-                  },
-                ],
-                "depth": 3,
-                "type": "heading",
-              },
-            ],
-            "data": {
-              "hName": "Callout",
-              "hProperties": {
-                "icon": undefined,
-                "theme": "info",
-              },
-            },
-            "type": "rdme-callout",
-          },
-        ],
-        "type": "root",
-      }
-    `);
+    expect(tree.children[0]).toHaveProperty('icon', '📘');
+  });
+
+  it.skip('can parse a jsx callout and set a theme from the icon', () => {
+    const md = `
+<Callout icon="📘">
+### This is a callout
+</Callout>`;
+
+    const tree = mdast(md);
+
+    expect(tree.children[0]).toHaveProperty('theme', 'info');
   });
 });

--- a/__tests__/transformers/callouts.test.ts
+++ b/__tests__/transformers/callouts.test.ts
@@ -81,7 +81,7 @@ describe('callouts transformer', () => {
     expect(tree.children[0]).toHaveProperty('type', 'rdme-callout');
   });
 
-  it.skip('can parse a jsx callout and sets a default icon', () => {
+  it('can parse a jsx callout and sets a default icon', () => {
     const md = `
 <Callout theme="info">
 ### This is a callout
@@ -89,10 +89,10 @@ describe('callouts transformer', () => {
 
     const tree = mdast(md);
 
-    expect(tree.children[0]).toHaveProperty('icon', '📘');
+    expect(tree.children[0].data.hProperties).toHaveProperty('icon', '📘');
   });
 
-  it.skip('can parse a jsx callout and set a theme from the icon', () => {
+  it('can parse a jsx callout and set a theme from the icon', () => {
     const md = `
 <Callout icon="📘">
 ### This is a callout
@@ -100,6 +100,6 @@ describe('callouts transformer', () => {
 
     const tree = mdast(md);
 
-    expect(tree.children[0]).toHaveProperty('theme', 'info');
+    expect(tree.children[0].data.hProperties).toHaveProperty('theme', 'info');
   });
 });

--- a/__tests__/transformers/callouts.test.ts
+++ b/__tests__/transformers/callouts.test.ts
@@ -69,4 +69,44 @@ describe('callouts transformer', () => {
     expect(tree.children[0].data.hProperties.empty).toBeUndefined();
     expect(tree.children[0].children[0].children[1].type).toBe('strong');
   });
+
+  it('can parse a jsx callout into a rdme-callout', () => {
+    const md = `
+<Callout theme="info">
+### This is a callout
+</Callout>`;
+
+    const tree = mdast(md);
+    removePosition(tree, { force: true });
+
+    expect(tree).toMatchInlineSnapshot(`
+      {
+        "children": [
+          {
+            "children": [
+              {
+                "children": [
+                  {
+                    "type": "text",
+                    "value": "This is a callout",
+                  },
+                ],
+                "depth": 3,
+                "type": "heading",
+              },
+            ],
+            "data": {
+              "hName": "Callout",
+              "hProperties": {
+                "icon": undefined,
+                "theme": "info",
+              },
+            },
+            "type": "rdme-callout",
+          },
+        ],
+        "type": "root",
+      }
+    `);
+  });
 });

--- a/processor/transform/callouts.ts
+++ b/processor/transform/callouts.ts
@@ -4,7 +4,6 @@ import type { Callout } from 'types';
 import emojiRegex from 'emoji-regex';
 import { visit } from 'unist-util-visit';
 
-
 import { themes } from '../../components/Callout';
 import { NodeTypes } from '../../enums';
 

--- a/processor/transform/readme-components.ts
+++ b/processor/transform/readme-components.ts
@@ -7,7 +7,7 @@ import type { Callout, EmbedBlock, HTMLBlock, ImageBlock, Tableau } from 'types'
 
 import { visit, SKIP } from 'unist-util-visit';
 
-import { themes } from '../../components/Callout';
+import { defaultIcons, themes } from '../../components/Callout';
 import { NodeTypes } from '../../enums';
 import { mdast } from '../../lib';
 import { getAttrs, isMDXElement, getChildren, formatHTML } from '../utils';
@@ -163,7 +163,8 @@ const coerceJsxToMd =
       return SKIP;
     } else if (node.name === 'Callout') {
       const attrs = getAttrs<Callout['data']['hProperties']>(node);
-      const { icon, empty } = getAttrs<Callout['data']['hProperties']>(node);
+      const { empty } = attrs;
+      const icon = attrs.icon || defaultIcons[attrs.theme];
       const theme = attrs.theme || themes[icon] || 'default';
 
       const mdNode: Callout = {

--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -7,7 +7,7 @@ import type { Variable, HTMLBlock } from 'types';
 import emojiRegex from 'emoji-regex';
 import { visit } from 'unist-util-visit';
 
-import { themes } from '../../components/Callout';
+import { defaultIcons, themes } from '../../components/Callout';
 import { NodeTypes } from '../../enums';
 import { toAttributes } from '../utils';
 
@@ -21,18 +21,24 @@ const readmeToMdx = (): Transform => tree => {
   });
 
   visit(tree, 'rdme-callout', (node, index, parent) => {
-    const isEmoji = emojiRegex().test(node.data.hProperties.icon);
     const isEmpty = node.data.hProperties?.empty;
     const isH3 = node.children[0].type === 'heading' && node.children[0].depth === 3;
+    let { icon, theme } = node.data.hProperties;
+    if (!icon) icon = defaultIcons[theme];
+    if (!theme) theme = themes[icon] || 'default';
+    const isEmoji = emojiRegex().test(icon);
 
     // return the usual markdown if there is an emoji and the icon theme matches our default theme
-    if ((isEmpty || isH3) && isEmoji && themes[node.data.hProperties.icon] === node.data.hProperties.theme) {
+    if ((isEmpty || isH3) && isEmoji && themes[icon] === theme) {
       if (isH3) {
         node.children[0] = {
           type: 'paragraph',
           children: 'children' in node.children[0] ? node.children[0].children : [],
         } as Paragraph;
       }
+
+      node.data.hProperties.icon = icon;
+      node.data.hProperties.theme = theme;
 
       return;
     }


### PR DESCRIPTION
| [![PR App][icn]][demo] | Ref RM-12848 |
| :--------------------: | :----------: |

## 🧰 Changes

Updates the callout transformers to better default to markdown.

- Allows a JSX `Callout` to only define a theme or an icon.
- Saves a callout to markdown when only an icon is defined. This is the default behavior from the editor.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
