### PR TITLE
feat: Rename TutorialTile to Recipe and ensure backwards compatibility 

### DIFF
--- a/components/Recipe.tsx
+++ b/components/Recipe.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 // We render a placeholder in this library, as the actual implemenation is
 // deeply tied to the main app
-const TutorialTile = () => {
+const Recipe = () => {
   const style = {
     height: '50px',
     border: '1px solid var(--color-border-default, rgba(black, 0.1))',
@@ -43,4 +43,4 @@ const TutorialTile = () => {
   );
 };
 
-export default TutorialTile;
+export default Recipe;

--- a/components/index.ts
+++ b/components/index.ts
@@ -15,4 +15,4 @@ export { default as TableOfContents } from './TableOfContents';
 export { default as Tabs, Tab } from './Tabs';
 export { default as TailwindRoot } from './TailwindRoot';
 export { default as TailwindStyle } from './TailwindStyle';
-export { default as TutorialTile } from './TutorialTile';
+export { default as Recipe } from './TutorialTile';

--- a/lib/utils/makeUseMdxComponents.ts
+++ b/lib/utils/makeUseMdxComponents.ts
@@ -24,6 +24,8 @@ const makeUseMDXComponents = (more: ReturnType<UseMdxComponents> = {}): UseMdxCo
     'html-block': Components.HTMLBlock,
     'image-block': Components.Image,
     'table-of-contents': Components.TableOfContents,
+    // Ensures backwards compatibility with historical TutoirialTile component
+    'TutorialTile': Components.Recipe,
     ...headings,
     ...more,
   };

--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -45,6 +45,7 @@ const readmeToMdx = (): Transform => tree => {
     });
   });
 
+  // Converts tutorial tiles to Recipe components in the migration process
   visit(tree, NodeTypes.tutorialTile, (tile, index, parent) => {
     const { ...attrs } = tile;
 

--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -50,8 +50,8 @@ const readmeToMdx = (): Transform => tree => {
 
     parent.children.splice(index, 1, {
       type: 'mdxJsxFlowElement',
-      name: 'TutorialTile',
-      attributes: toAttributes(attrs, ['backgroundColor', 'emoji', 'id', 'link', 'slug', 'title']),
+      name: 'Recipe',
+      attributes: toAttributes(attrs, ['slug', 'title']),
       children: [],
     });
   });


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-13044
:-------------------:|:----------:

## 🧰 Changes
- renames the `TutorialTile` component to `Recipe`
- adds mapping from ``TutorialTile` to `Recipe` to ensure backwards compatibility 
- modifies migration transformer to return `<Recipe>` from tutorial tile node 

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
