### PR TITLE
chore(components): add PostmanRunButton

### DIFF
--- a/components/PostmanRunButton/index.tsx
+++ b/components/PostmanRunButton/index.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react';
+
+interface PostmanRunButtonProps {
+  action: string;
+  collectionId: string;
+  collectionUrl: string;
+  visibility: string;
+}
+
+const PostmanRunButton = ({
+  collectionId = '', // Add your collection ID here
+  collectionUrl = '', // Add your collection URL here
+  visibility = 'public',
+  action = 'collection/fork',
+}: PostmanRunButtonProps) => {
+  useEffect(() => {
+    // Only run on client-side
+    if (typeof window !== 'undefined') {
+      const scriptFunction = function noIdeaWhatThisShouldBeCalledOrDoesOne(p, o, s, t, m) {
+        if (!p[s]) {
+          p[s] = function noIdeaWhatThisShouldBeCalledOrDoesTwo(...args) {
+            const postmanRunObject = p[t] || (p[t] = []);
+            postmanRunObject.push(args);
+          };
+        }
+        if (!o.getElementById(s + t)) {
+          const scriptElement = o.createElement('script');
+          scriptElement.id = s + t;
+          scriptElement.async = 1;
+          scriptElement.src = m;
+          o.getElementsByTagName('head')[0].appendChild(scriptElement);
+        }
+      };
+
+      // Execute the script function directly
+      scriptFunction(window, document, '_pm', 'PostmanRunObject', 'https://run.pstmn.io/button.js');
+
+      return () => {
+        // Cleanup if needed
+        const scriptElement = document.getElementById('_pmPostmanRunObject');
+        if (scriptElement) document.head.removeChild(scriptElement);
+      };
+    }
+    return undefined;
+  }, []);
+
+  return (
+    <div className="my-4">
+      <div
+        className="postman-run-button"
+        data-postman-action={action}
+        data-postman-collection-url={collectionUrl}
+        data-postman-var-1={collectionId}
+        data-postman-visibility={visibility}
+      />
+    </div>
+  );
+};
+
+export default PostmanRunButton;

--- a/components/PostmanRunButton/readme.md
+++ b/components/PostmanRunButton/readme.md
@@ -1,0 +1,26 @@
+# Postman Run Button
+
+Add a Postman Run Button to your documentation, allowing users to fork a Postman collection. This is duped from [the version in our Marketplace](https://github.com/readmeio/marketplace/tree/main/components/PostmanRunButton) so our users can easily insert it via the editor.
+
+### Usage
+
+```mdx
+<PostmanRunButton 
+  collectionId="123456-abcd-efgh-ijkl" 
+  collectionUrl="entityId=123456-abcd-efgh-ijkl&entityType=collection&workspaceId=abcdef-1234-5678"
+/>
+```
+
+### How to Find Your Collection ID and URL
+
+1. Open your collection in Postman
+2. Click "Share" button at the top right of your collection
+3. Go to the "Via API" tab
+4. You'll find your Collection ID in the URL or in the API response
+5. The Collection URL contains parameters after the main URL (starting with "entityId=")
+
+### Props
+
+- `collectionId` (required): The ID of your Postman collection (e.g., "123456-abcd-efgh-ijkl")
+- `collectionUrl` (required): The URL parameters for your collection, typically in this format: 
+  `entityId=YOUR_COLLECTION_ID&entityType=collection&workspaceId=YOUR_WORKSPACE_ID`

--- a/components/index.ts
+++ b/components/index.ts
@@ -16,3 +16,4 @@ export { default as Tabs, Tab } from './Tabs';
 export { default as TailwindRoot } from './TailwindRoot';
 export { default as TailwindStyle } from './TailwindStyle';
 export { default as TutorialTile } from './TutorialTile';
+export { default as PostmanRunButton } from './PostmanRunButton';


### PR DESCRIPTION
## 🧰 Changes

- [x] add the `<PostmanRunButton>` to our internal components[^1] so our users can easily insert it via the editor
- [ ] make sure this component is usable in the editor, but is *not* displayed in the slash menu[^2]

[^1]: duped from [the version in our Marketplace](https://github.com/readmeio/marketplace/tree/main/components/PostmanRunButton)
[^2]: may need your expertise on this one @kellyjosephprice once this hits in ReadMe proper!