### PR TITLE
chore: update ci versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
           - lts/-1
           - lts/*
           - latest
-        react: [16, 17, 18, 19]
+        react: [18, 19]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
           - lts/-1
           - lts/*
           - latest
-        react: [16, 17, 18]
+        react: [16, 17, 18, 19]
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
         react: [18]
 
     steps:


### PR DESCRIPTION
| [![PR App][icn]][demo] |
| :--------------------: |

## 🧰 Changes

Update the CI version matrices.

This adds react 19 to the unit tests, and switches to only running one visual test suite. If the visual test suites failed, their artifact uploads would sometimes conflict.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg

BREAKING CHANGE: This will officially drop support for react@<18