### PR TITLE
chore: update readme deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,8 +122,8 @@
         "@readme/variable": "^17.0.0",
         "@tippyjs/react": "^4.1.0",
         "acorn": "v8.13.0",
-        "react": "16.x || 17.x || 18.x",
-        "react-dom": "16.x || 17.x || 18.x"
+        "react": "18.x || 19.x",
+        "react-dom": "18.x || 19.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,8 +118,8 @@
       },
       "peerDependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@readme/syntax-highlighter": "^13.1.0",
-        "@readme/variable": "^16.1.0",
+        "@readme/syntax-highlighter": "^14.0.0",
+        "@readme/variable": "^17.0.0",
         "@tippyjs/react": "^4.1.0",
         "acorn": "v8.13.0",
         "react": "16.x || 17.x || 18.x",
@@ -6517,9 +6517,10 @@
       }
     },
     "node_modules/@readme/syntax-highlighter": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-13.1.0.tgz",
-      "integrity": "sha512-qJbKxYNGKIL8D1G10WsCfhAWjbtb+7x5RU8YWMbH/3sno2dVPuYhjwMOuAlu55UzJ9u5/TfGiZuAUpg1RqTGSw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-14.0.0.tgz",
+      "integrity": "sha512-HSgSAaijgpvMI2Fp4PujqCDMIOSGRRr2owWYdbiFWuQKBraaxAiGBbTfVRbK0QwaxVfMSVu5nJpziOBAEwTtyw==",
+      "license": "ISC",
       "dependencies": {
         "codemirror": "^5.54.0",
         "codemirror-graphql": "1.0.2",
@@ -6527,29 +6528,30 @@
         "react-codemirror2": "^8.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@readme/variable": "^16.2.0",
-        "react": "16.x || 17.x || 18.x",
-        "react-dom": "16.x || 17.x || 18.x"
+        "@readme/variable": "^17.0.0",
+        "react": "18.x",
+        "react-dom": "18.x"
       }
     },
     "node_modules/@readme/variable": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-16.2.0.tgz",
-      "integrity": "sha512-Kx9oDBKIkUHAdOuq6751WcBd0/bJPWQsQrwbpwzSPwR966cyxm4FmkHOQ6xlNrUG3MjcEGHdyHnjBwiqC5igKw==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-17.0.0.tgz",
+      "integrity": "sha512-6Z153DoguwUTcsaRjFfc4dHpylED1ZaIbxk0k6GkAOhv17gxxt6sXUepp+BSk+NMd/YLsJ0CK/srvjRckf3ivA==",
+      "license": "ISC",
       "peer": true,
       "dependencies": {
         "classnames": "^2.2.6",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "react": "16.x || 17.x || 18.x",
-        "react-dom": "16.x || 17.x || 18.x"
+        "react": "18.x || 19.x",
+        "react-dom": "18.x || 19.x"
       }
     },
     "node_modules/@remix-run/router": {
@@ -11181,6 +11183,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/clean-regexp": {

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "@readme/variable": "^17.0.0",
     "@tippyjs/react": "^4.1.0",
     "acorn": "v8.13.0",
-    "react": "16.x || 17.x || 18.x",
-    "react-dom": "16.x || 17.x || 18.x"
+    "react": "18.x || 19.x",
+    "react-dom": "18.x || 19.x"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   },
   "peerDependencies": {
     "@mdx-js/react": "^3.0.0",
-    "@readme/syntax-highlighter": "^13.1.0",
-    "@readme/variable": "^16.1.0",
+    "@readme/syntax-highlighter": "^14.0.0",
+    "@readme/variable": "^17.0.0",
     "@tippyjs/react": "^4.1.0",
     "acorn": "v8.13.0",
     "react": "16.x || 17.x || 18.x",
@@ -157,6 +157,8 @@
     "mermaid": "^11.3.0"
   },
   "overrides": {
-    "conventional-changelog-conventionalcommits": ">= 8.0.0"
+    "conventional-changelog-conventionalcommits": ">= 8.0.0",
+    "@readme/syntax-highlighter": "^14.0.0",
+    "@readme/variable": "^17.0.0"
   }
 }


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-XYZ |
| :--------------------: | :--------: |

## 🧰 Changes

Updates `@readme/variable` and `@readme/syntax-highlighter`

I added them to the `overrides` field, to be compatible with `@readme/markdown@v6` which is used in tests.

I also forgot to update the `react` peer dep versions.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
