### PR TITLE
chore: remove react 19 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
           - lts/-1
           - lts/*
           - latest
-        react: [18, 19]
+        react: [18]
     steps:
       - uses: actions/checkout@v4
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -118,12 +118,12 @@
       },
       "peerDependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@readme/syntax-highlighter": "^14.0.0",
-        "@readme/variable": "^17.0.0",
+        "@readme/syntax-highlighter": "^14.1.0",
+        "@readme/variable": "^18.0.0",
         "@tippyjs/react": "^4.1.0",
         "acorn": "v8.13.0",
-        "react": "18.x || 19.x",
-        "react-dom": "18.x || 19.x"
+        "react": "18.x",
+        "react-dom": "18.x"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -5611,6 +5611,27 @@
         "react-dom": "16.x || 17.x || 18.x"
       }
     },
+    "node_modules/@readme/markdown-legacy/node_modules/@readme/syntax-highlighter": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-13.1.0.tgz",
+      "integrity": "sha512-qJbKxYNGKIL8D1G10WsCfhAWjbtb+7x5RU8YWMbH/3sno2dVPuYhjwMOuAlu55UzJ9u5/TfGiZuAUpg1RqTGSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "codemirror": "^5.54.0",
+        "codemirror-graphql": "1.0.2",
+        "prop-types": "^15.7.2",
+        "react-codemirror2": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@readme/variable": "^16.2.0",
+        "react": "16.x || 17.x || 18.x",
+        "react-dom": "16.x || 17.x || 18.x"
+      }
+    },
     "node_modules/@readme/markdown-legacy/node_modules/@types/hast": {
       "version": "2.3.10",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
@@ -6517,10 +6538,11 @@
       }
     },
     "node_modules/@readme/syntax-highlighter": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-14.0.0.tgz",
-      "integrity": "sha512-HSgSAaijgpvMI2Fp4PujqCDMIOSGRRr2owWYdbiFWuQKBraaxAiGBbTfVRbK0QwaxVfMSVu5nJpziOBAEwTtyw==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-14.1.0.tgz",
+      "integrity": "sha512-X3WMGKoDacLH4UB8RaxMbuOrhttOArKAFUjEilCvTGaQaVtpk8JPtdCHwsbL4a7cJvtroNeWc4ffMbwGvkU27Q==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "codemirror": "^5.54.0",
         "codemirror-graphql": "1.0.2",
@@ -6531,15 +6553,15 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@readme/variable": "^17.0.0",
+        "@readme/variable": "^18.0.0",
         "react": "18.x",
         "react-dom": "18.x"
       }
     },
     "node_modules/@readme/variable": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-17.0.0.tgz",
-      "integrity": "sha512-6Z153DoguwUTcsaRjFfc4dHpylED1ZaIbxk0k6GkAOhv17gxxt6sXUepp+BSk+NMd/YLsJ0CK/srvjRckf3ivA==",
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-18.0.0.tgz",
+      "integrity": "sha512-x48m+iBizRJ77pCppOzsqctcUSJuRCR/tCWJss+4NIuLHIWUXYwfA9IwF4/sjGIOTRsiFXoj4llXE37WysKuSQ==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -6550,8 +6572,8 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "react": "18.x || 19.x",
-        "react-dom": "18.x || 19.x"
+        "react": "18.x",
+        "react-dom": "18.x"
       }
     },
     "node_modules/@remix-run/router": {

--- a/package.json
+++ b/package.json
@@ -65,12 +65,12 @@
   },
   "peerDependencies": {
     "@mdx-js/react": "^3.0.0",
-    "@readme/syntax-highlighter": "^14.0.0",
-    "@readme/variable": "^17.0.0",
+    "@readme/syntax-highlighter": "^14.1.0",
+    "@readme/variable": "^18.0.0",
     "@tippyjs/react": "^4.1.0",
     "acorn": "v8.13.0",
-    "react": "18.x || 19.x",
-    "react-dom": "18.x || 19.x"
+    "react": "18.x",
+    "react-dom": "18.x"
   },
   "devDependencies": {
     "@babel/core": "^7.21.4",
@@ -157,8 +157,9 @@
     "mermaid": "^11.3.0"
   },
   "overrides": {
-    "conventional-changelog-conventionalcommits": ">= 8.0.0",
-    "@readme/syntax-highlighter": "^14.0.0",
-    "@readme/variable": "^17.0.0"
+    "@readme/markdown-legacy": {
+      "@readme/variable": "^18.0.0"
+    },
+    "conventional-changelog-conventionalcommits": ">= 8.0.0"
   }
 }


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-XYZ |
| :--------------------: | :--------: |

## 🧰 Changes

Removes support for `react@19`.

_Hoping_ this fixes downstream dependency issues.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg

BREAKING_CHANGE: Removes support for `react@19`.
