### PR TITLE
chore(deps): moving `syntax-highlighter` and `variable` off peerDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@readme/emojis": "^6.0.0",
+        "@readme/syntax-highlighter": "^14.1.0",
+        "@readme/variable": "^18.0.0",
         "copy-to-clipboard": "^3.3.2",
         "core-js": "^3.36.1",
         "debug": "^4.3.4",
@@ -118,8 +120,6 @@
       },
       "peerDependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@readme/syntax-highlighter": "^14.1.0",
-        "@readme/variable": "^18.0.0",
         "@tippyjs/react": "^4.1.0",
         "acorn": "v8.13.0",
         "react": "18.x",
@@ -6542,7 +6542,6 @@
       "resolved": "https://registry.npmjs.org/@readme/syntax-highlighter/-/syntax-highlighter-14.1.0.tgz",
       "integrity": "sha512-X3WMGKoDacLH4UB8RaxMbuOrhttOArKAFUjEilCvTGaQaVtpk8JPtdCHwsbL4a7cJvtroNeWc4ffMbwGvkU27Q==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "codemirror": "^5.54.0",
         "codemirror-graphql": "1.0.2",
@@ -6563,7 +6562,6 @@
       "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-18.0.0.tgz",
       "integrity": "sha512-x48m+iBizRJ77pCppOzsqctcUSJuRCR/tCWJss+4NIuLHIWUXYwfA9IwF4/sjGIOTRsiFXoj4llXE37WysKuSQ==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "classnames": "^2.2.6",
         "prop-types": "^15.8.1"
@@ -11205,8 +11203,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/clean-regexp": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "dependencies": {
     "@mdx-js/mdx": "^3.0.0",
     "@readme/emojis": "^6.0.0",
+    "@readme/syntax-highlighter": "^14.1.0",
+    "@readme/variable": "^18.0.0",
     "copy-to-clipboard": "^3.3.2",
     "core-js": "^3.36.1",
     "debug": "^4.3.4",
@@ -65,8 +67,6 @@
   },
   "peerDependencies": {
     "@mdx-js/react": "^3.0.0",
-    "@readme/syntax-highlighter": "^14.1.0",
-    "@readme/variable": "^18.0.0",
     "@tippyjs/react": "^4.1.0",
     "acorn": "v8.13.0",
     "react": "18.x",


### PR DESCRIPTION
## 🧰 Changes

We've been having some real problems with peer dependencies lately when trying to upgrade this package in our monorepo. Let's try to move `@readme/syntax-highlighter` and `@readme/variable` away from that.
