### PR TITLE
fix: legacy callout typo

### DIFF
--- a/components/Callout/style.scss
+++ b/components/Callout/style.scss
@@ -126,7 +126,7 @@
 
     // legacy icon behavior (changes in superhub)
     .callout-icon {
-      margin-left: calc(-#{$l-offset} - 0.5rem);
+      margin-left: calc(-#{$l-offset} - 0.5em);
     }
 
     &:before {


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

I used rem instead of em :(

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
