### PR TITLE
fix: update glossary to use tooltip with mutation observer

### DIFF
--- a/__tests__/Glossary.test.tsx
+++ b/__tests__/Glossary.test.tsx
@@ -11,7 +11,7 @@ test('should output a glossary item if the term exists', () => {
   const trigger = container.querySelector('.GlossaryItem-trigger');
   expect(trigger).toHaveTextContent(term);
   if (trigger) {
-    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseEnter(trigger.parentElement!);
   }
   const tooltipContent = screen.getByText(definition, { exact: false });
   expect(tooltipContent).toHaveTextContent(`${term} - ${definition}`);
@@ -25,7 +25,7 @@ test('should be case insensitive', () => {
   const trigger = container.querySelector('.GlossaryItem-trigger');
   expect(trigger).toHaveTextContent('acme');
   if (trigger) {
-    fireEvent.mouseEnter(trigger);
+    fireEvent.mouseEnter(trigger.parentElement!);
   }
   const tooltipContent = screen.getByText(definition, { exact: false });
   expect(tooltipContent).toHaveTextContent(`${term} - ${definition}`);

--- a/components/Glossary/index.tsx
+++ b/components/Glossary/index.tsx
@@ -1,9 +1,9 @@
 import type { GlossaryTerm } from '../../contexts/GlossaryTerms';
 
-import Tooltip from '@tippyjs/react';
 import React, { useContext } from 'react';
 
 import GlossaryContext from '../../contexts/GlossaryTerms';
+import Tooltip from '../Tooltip';
 
 interface Props extends React.PropsWithChildren {
   term?: string;

--- a/components/Tooltip/index.tsx
+++ b/components/Tooltip/index.tsx
@@ -1,0 +1,61 @@
+import Tippy from '@tippyjs/react';
+import React, { useEffect, useMemo, useRef, useState, type ComponentProps } from 'react';
+
+type TooltipProps = ComponentProps<typeof Tippy>;
+
+/**
+ * A custom wrapper around `@tippyjs/react` that attaches a MutationObserver to
+ * listen for changes of the trigger element's DOM tree.
+ * 
+ * This is necessary for features like translation, where we initially render a
+ * Glossary term in English but then replace it with the translated term, which
+ * creates a stale Tippy reference.
+ */ 
+export default function Tooltip({ children, ...rest }: TooltipProps) {
+  const triggerRef = useRef<HTMLElement>(null);
+  const [triggerTarget, setTriggerTarget] = useState<HTMLElement|null>(null);
+
+  const triggerId = useMemo(() => {
+    return `tooltip-trigger-${crypto.randomUUID()}`;
+  }, []);
+
+  useEffect(() => {
+    if (!triggerRef.current?.parentElement) return () => {};
+
+    const observer = new MutationObserver((records: MutationRecord[]) => {
+      records.forEach(record => {
+        // was the node tree changed?
+        if (record.type === 'childList') {
+          record.addedNodes.forEach(node => {
+            // was the node for the tooltip trigger replaced?
+            if(node instanceof HTMLElement && node.id === triggerId)  {
+              // if it was, update our reference to it
+              setTriggerTarget(node);
+            }
+          });
+        } 
+      });
+    });
+
+    observer.observe(triggerRef.current.parentElement, {
+      subtree: true,
+      childList: true,
+    });
+
+    return () => observer.disconnect();
+  }, [setTriggerTarget, triggerId, triggerTarget]);
+
+  const getReferenceClientRect = useMemo(() => {
+    return triggerTarget ? () => triggerTarget.getBoundingClientRect() : undefined;
+  }, [triggerTarget]);
+
+  return (
+    <Tippy 
+      getReferenceClientRect={getReferenceClientRect}
+      triggerTarget={triggerTarget}
+      {...rest}
+    >
+      <span ref={triggerRef} id={triggerId}>{children}</span>
+    </Tippy>
+  );
+}

--- a/example/Doc.tsx
+++ b/example/Doc.tsx
@@ -26,14 +26,17 @@ Object.entries(components).forEach(async ([tag, body]) => {
 
 const terms = [
   {
+    _id: '1',
     term: 'demo',
     definition: 'a thing that breaks on presentation',
   },
   {
+     _id: '2',
     term: 'exogenous',
     definition: 'relating to or developing from external factors',
   },
   {
+     _id: '3',
     term: 'endogenous',
     definition: 'having an internal cause or origin',
   },


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix CX-2117
:-------------------:|:----------:

## 🧰 Changes

- Creates a `Tooltip` component that is a wrapper around `@tippyjs/react` and attaches a mutation observer to the trigger element
- Update `Glossary` to use the new `Tooltip` so that when something like translations blows away its DOM tree, it can get an updated reference to the new trigger node


## 🧬 QA & Testing

Tried replicating this in the local `markdown` app since we can't `npm link` this package to the main app. I will check the fix again in my local after a new markdown version is published! 

### Before

https://github.com/user-attachments/assets/45015a35-db0c-4b36-8af3-a6560be145ea

### After

https://github.com/user-attachments/assets/984ed7df-c43b-413d-b5f5-d57800dcebe0

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
