### PR TITLE
fix: remove use of `crypto.randomUUID`

### DIFF
--- a/__tests__/components/test.js
+++ b/__tests__/components/test.js
@@ -6,6 +6,10 @@ const markdown = require('../../index');
 const { silenceConsole } = require('../helpers');
 
 describe('Data Replacements', () => {
+  beforeAll(() => {
+    jest.spyOn(global.Math, 'random').mockReturnValue(0.1234);
+  });
+
   it('Variables', () => {
     const { container } = render(
       React.createElement(
@@ -39,7 +43,7 @@ describe('Data Replacements', () => {
       ),
     );
     expect(container).toContainHTML(
-      '<p><span id="tooltip-trigger-mock-uuid-12345"><span class="GlossaryItem-trigger">term</span></span></p>',
+      '<p><span id="tooltip-trigger-0.1234"><span class="GlossaryItem-trigger">term</span></span></p>',
     );
   });
 });

--- a/components/Tooltip/index.jsx
+++ b/components/Tooltip/index.jsx
@@ -14,7 +14,7 @@ export default function Tooltip({ children, ...rest }) {
   const [triggerTarget, setTriggerTarget] = React.useState(null);
 
   const triggerId = React.useMemo(() => {
-    return `tooltip-trigger-${crypto.randomUUID()}`;
+    return `tooltip-trigger-${Math.random()}`;
   }, []);
 
   React.useEffect(() => {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,9 +1,1 @@
 import '@testing-library/jest-dom';
-
-Object.defineProperty(global, 'crypto', {
-  value: {
-    randomUUID: () => {
-      return 'mock-uuid-12345'; // Return a fixed UUID for testing
-    },
-  },
-});


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix CX-2117
:-------------------:|:----------:

## 🧰 Changes

#1174 introduced the use of `crypto.randomUUID` which isn't available in `markdown-legacy`'s runtime env. Error revealed when trying to bump the version in the main app:

<img width="574" height="183" alt="Screenshot 2025-08-12 at 2 55 29 PM" src="https://github.com/user-attachments/assets/25a71e05-a032-422a-9920-2da6bf5e1f42" />


## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
