### PR TITLE
fix: try adding tooltip check for client

### DIFF
--- a/components/Tooltip/index.jsx
+++ b/components/Tooltip/index.jsx
@@ -18,7 +18,7 @@ export default function Tooltip({ children, ...rest }) {
   }, []);
 
   React.useEffect(() => {
-    if (!triggerRef.current?.parentElement) return () => {};
+    if (typeof window === 'undefined' || !triggerRef.current?.parentElement) return () => {};
 
     const observer = new MutationObserver(records => {
       records.forEach(record => {


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix CX-2117
:-------------------:|:----------:

## 🧰 Changes

A last attempt to solve [the issue described in this thread](https://linear.app/readme-io/issue/CX-2117/glossary-popup-not-appearing-in-translated-pages#comment-6ab2666a). Maybe something about client and server hydration mismatches is the cause?

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
