### PR TITLE
fix: import material-palenight theme

### DIFF
--- a/components/CodeTabs/style.scss
+++ b/components/CodeTabs/style.scss
@@ -1,5 +1,6 @@
 @import '~codemirror/lib/codemirror.css';
 @import '~codemirror/theme/neo.css';
+@import '~codemirror/theme/material-palenight.css';
 
 @mixin CodeTabs {
   $bgc-pre: #f6f8fa;


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-XYZ |
| :--------------------: | :--------: |

## 🧰 Changes

Attempts to fix a lack of light mode syntax highlighting.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
