### PR TITLE
fix: readme protocol links

### DIFF
--- a/__tests__/lib/compile.test.ts
+++ b/__tests__/lib/compile.test.ts
@@ -1,0 +1,12 @@
+import { compile } from '../../index';
+
+describe('compile', () => {
+  describe("{ format: 'md' }", () => {
+    it('returns plain text of markdown components', () => {
+      const md = '[link to doc](doc:getting-started)';
+
+      const tree = compile(md, { format: 'md' });
+      expect(tree).toMatch(/href: "doc:getting-started"/);
+    });
+  });
+});

--- a/lib/compile.ts
+++ b/lib/compile.ts
@@ -2,8 +2,9 @@ import type { CompileOptions } from '@mdx-js/mdx';
 import type { PluggableList } from 'unified';
 
 import { compileSync as mdxCompileSync } from '@mdx-js/mdx';
+import deepmerge from 'deepmerge';
 import rehypeRaw from 'rehype-raw';
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 
@@ -21,6 +22,10 @@ export type CompileOpts = CompileOptions & {
 };
 
 const { codeTabsTransformer, ...transforms } = defaultTransforms;
+
+const sanitizeSchema = deepmerge(defaultSchema, {
+  protocols: ['doc', 'ref', 'blog', 'changelog', 'page'],
+});
 
 const compile = (
   text: string,
@@ -58,7 +63,7 @@ const compile = (
         passThrough: ['mdxjsEsm'],
       },
     ]);
-    rehypePlugins.push(rehypeSanitize);
+    rehypePlugins.push([rehypeSanitize, sanitizeSchema]);
   }
 
   try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@readme/variable": "^18.0.0",
         "copy-to-clipboard": "^3.3.2",
         "debug": "^4.3.4",
+        "deepmerge": "^4.3.1",
         "emoji-regex": "^10.2.1",
         "estree-util-value-to-estree": "^3.1.1",
         "gemoji": "^8.1.0",
@@ -13028,7 +13029,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@readme/variable": "^18.0.0",
     "copy-to-clipboard": "^3.3.2",
     "debug": "^4.3.4",
+    "deepmerge": "^4.3.1",
     "emoji-regex": "^10.2.1",
     "estree-util-value-to-estree": "^3.1.1",
     "gemoji": "^8.1.0",


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-XYZ |
| :--------------------: | :--------: |

## 🧰 Changes

Fixes sanitization of readme style protocol links `[label](doc:slug)`.

We recently switched our plain markdown parsing to use the latest version of this package with `{ format: 'md' }`. We want to eventually remove `@readme/markdown@6`, but it also helped reduce our bundle size. In the process, we failed to port over our custom sanitization schema. For the most part, I think this is fine to drop support for old, custom markdown features. But it does break our custom protocol links, which at least one enterprise customer was using.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
