### PR TITLE
fix: emoji context

### DIFF
--- a/__tests__/parsers/gemoji.test.ts
+++ b/__tests__/parsers/gemoji.test.ts
@@ -61,4 +61,20 @@ describe('gemoji parser', () => {
 
     expect(mdast(markdown).children[0].children[0].value).toMatch(/:unknown-emoji:/);
   });
+
+  /**
+   * Our custom gemoji regex should allow escaping gemojis. However, we're
+   * forced to use an extra backslash, as the mdx parser removes the original
+   * backslash from the sequence `\:`
+   */
+  const escapingTests = [
+    ['\\:joy:', '😂'],
+    ['\\\\:joy:', '\\:joy:'],
+    ['\\\\\\:joy:', '\\:joy:'],
+    ['\\\\\\\\:joy:', '😂'],
+  ];
+
+  it.each(escapingTests)('should parse an escape sequence "%s" as "%s"', (string, expected) => {
+    expect(mdast(string).children[0].children[0].value).toBe(expected);
+  });
 });

--- a/__tests__/parsers/gemoji.test.ts
+++ b/__tests__/parsers/gemoji.test.ts
@@ -62,19 +62,11 @@ describe('gemoji parser', () => {
     expect(mdast(markdown).children[0].children[0].value).toMatch(/:unknown-emoji:/);
   });
 
-  /**
-   * Our custom gemoji regex should allow escaping gemojis. However, we're
-   * forced to use an extra backslash, as the mdx parser removes the original
-   * backslash from the sequence `\:`
-   */
-  const escapingTests = [
-    ['\\:joy:', '😂'],
-    ['\\\\:joy:', '\\:joy:'],
-    ['\\\\\\:joy:', '\\:joy:'],
-    ['\\\\\\\\:joy:', '😂'],
-  ];
+  const beforeTests = ['letter', '1', '.', ':', "'", '!', '?', ',', ';', '(', '[', ')', ']', '}'];
 
-  it.each(escapingTests)('should parse an escape sequence "%s" as "%s"', (string, expected) => {
-    expect(mdast(string).children[0].children[0].value).toBe(expected);
+  it.each(beforeTests)('should not render an emoji following a "%s"', string => {
+    const tree = mdast(`${string}:joy:`);
+
+    expect(tree.children[0].children[0].value).toBe(`${string}:joy:`);
   });
 });

--- a/processor/transform/gemoji+.ts
+++ b/processor/transform/gemoji+.ts
@@ -6,8 +6,8 @@ import { findAndReplace } from 'mdast-util-find-and-replace';
 import { NodeTypes } from '../../enums';
 import Owlmoji from '../../lib/owlmoji';
 
-const regex = /(?<!\\)(?:\\\\)*:(?<name>\+1|[-\w]+):/g;
-?:
+const regex = /(?<=^|\s):(?<name>\+1|[-\w]+):/g;
+
 const gemojiReplacer = (_, name: string) => {
   switch (Owlmoji.kind(name)) {
     case 'gemoji': {

--- a/processor/transform/gemoji+.ts
+++ b/processor/transform/gemoji+.ts
@@ -6,8 +6,8 @@ import { findAndReplace } from 'mdast-util-find-and-replace';
 import { NodeTypes } from '../../enums';
 import Owlmoji from '../../lib/owlmoji';
 
-const regex = /:(?<name>\+1|[-\w]+):/g;
-
+const regex = /(?<!\\)(?:\\\\)*:(?<name>\+1|[-\w]+):/g;
+?:
 const gemojiReplacer = (_, name: string) => {
   switch (Owlmoji.kind(name)) {
     case 'gemoji': {


### PR DESCRIPTION
| [![PR App][icn]][demo] | RM-13827 |
| :--------------------: | :------: |

## 🧰 Changes

Prevents rendering gemoji's unless preceded by a space or at the start of a line.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg

**BREAKING CHANGE**: Changes how emoji's are parsed in markdown.
