### PR TITLE
chore: export gemoji regex

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -16,3 +16,4 @@ export { compile, exports, hast, run, mdast, mdastV6, mdx, migrate, plain, remar
 export { default as Owlmoji } from './lib/owlmoji';
 export { Components, utils };
 export { tailwindCompiler } from './utils/tailwind-compiler';
+export { regex as gemojiRegex } from './processor/transform/gemoji+';

--- a/processor/transform/gemoji+.ts
+++ b/processor/transform/gemoji+.ts
@@ -6,7 +6,7 @@ import { findAndReplace } from 'mdast-util-find-and-replace';
 import { NodeTypes } from '../../enums';
 import Owlmoji from '../../lib/owlmoji';
 
-const regex = /(?<=^|\s):(?<name>\+1|[-\w]+):/g;
+export const regex = /(?<=^|\s):(?<name>\+1|[-\w]+):/g;
 
 const gemojiReplacer = (_, name: string) => {
   switch (Owlmoji.kind(name)) {


### PR DESCRIPTION
| [![PR App][icn]][demo] | Ref RM-13850 |
| :--------------------: | :----------: |

## 🧰 Changes

Export the gemoji regex so we can use it in the markdown editor.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
