### PR TITLE
fix: adds focus outline to code tabs

### DIFF
--- a/components/CodeTabs/style.scss
+++ b/components/CodeTabs/style.scss
@@ -52,6 +52,7 @@
 
       &:focus-visible {
         outline: 3px solid var(--color-focus-ring);
+        outline-offset: -3px;
       }
     }
   }

--- a/components/CodeTabs/style.scss
+++ b/components/CodeTabs/style.scss
@@ -49,6 +49,10 @@
       font: inherit;
       font-size: 0.75em;
       cursor: pointer;
+
+      &:focus-visible {
+        outline: 3px solid var(--color-focus-ring);
+      }
     }
   }
 

--- a/components/Tabs/style.scss
+++ b/components/Tabs/style.scss
@@ -3,7 +3,7 @@
     border-bottom: solid var(--color-border-default, #{rgba(black, 0.1)});
     margin-bottom: 15px;
   }
-  
+
   &-tab {
     background: none;
     border: 0;

--- a/example/styles/theme.scss
+++ b/example/styles/theme.scss
@@ -31,7 +31,7 @@
   --color-border-default: rgba(var(--black-rgb), 0.1);
   --color-border-muted: rgba(var(--black-rgb), 0.05);
   --color-skeleton: var(--gray90); // Used to define the background color of the <Skeleton /> component
-  --color-focus-ring: rgba($blue, 0.25); // Used to define the color of the focus ring (outline) on focusable elements
+  --color-focus-ring: #{rgba($blue, 0.25)}; // Used to define the color of the focus ring (outline) on focusable elements
 
   // Inputs
   --color-input-background: var(--white);
@@ -56,7 +56,7 @@
   --color-text-muted: var(--gray80);
   --color-text-minimum: var(--gray70);
   --color-text-minimum-hover: var(--gray80);
-  --color-text-minimum-icon: rgba($gray70, 0.6);
+  --color-text-minimum-icon: #{rgba($gray70, 0.6)};
   --color-border-default: rgba(white, 0.1);
   --color-border-muted: rgba(white, 0.05);
   --color-skeleton: var(--gray20);


### PR DESCRIPTION
[![PR App][icn]][demo] | Fix RM-XYZ
:-------------------:|:----------:

## 🧰 Changes

Adds focus state to code tabs.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].


[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
