### PR TITLE
fix: remove prop types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,8 @@
 {
-  "extends": [
-    "@readme/eslint-config",
-    "@readme/eslint-config/react"
-  ],
+  "extends": ["@readme/eslint-config", "@readme/eslint-config/react"],
   "parser": "@babel/eslint-parser",
-  "root": true
+  "root": true,
+  "rules": {
+    "react/prop-types": "off",
+  },
 }

--- a/__tests__/__snapshots__/index.test.js.snap
+++ b/__tests__/__snapshots__/index.test.js.snap
@@ -296,10 +296,7 @@ exports[`export multiple Markdown renderers renders custom React components 1`] 
   
 
   <Callout
-    attributes={null}
-    calloutStyle="info"
     icon="❗️"
-    node={null}
     theme="error"
     title="UhOh"
     value="Lorem ipsum dolor sit amet consectetur adipisicing elit."

--- a/__tests__/components/test.js
+++ b/__tests__/components/test.js
@@ -3,7 +3,6 @@ const { cleanup, fireEvent, render } = require('@testing-library/react');
 const React = require('react');
 
 const markdown = require('../../index');
-const { silenceConsole } = require('../helpers');
 
 describe('Data Replacements', () => {
   beforeAll(() => {
@@ -134,13 +133,9 @@ describe('Components', () => {
       rdmd: '[](https://www.nytimes.com/2020/05/03/us/politics/george-w-bush-coronavirus-unity.html "@embed")',
     };
 
-    silenceConsole()(error => {
-      Object.values(fixtures).map(fx => {
-        const { container } = render(markdown.react(fx));
-        return expect(container.innerHTML).toMatchSnapshot();
-      });
-
-      expect(error).toHaveBeenCalledTimes(1);
+    Object.values(fixtures).map(fx => {
+      const { container } = render(markdown.react(fx));
+      return expect(container.innerHTML).toMatchSnapshot();
     });
   });
 

--- a/__tests__/lib/registerCustomComponents.test.js
+++ b/__tests__/lib/registerCustomComponents.test.js
@@ -16,6 +16,9 @@ const customComponents = {
   },
 };
 
+customComponents.a.propTypes = { attrToConcatToSafelist: true };
+customComponents.twoWords.propTypes = { attrToBeSafelisted: true };
+
 describe('Custom Component Registrar', () => {
   let registered;
   let sanitize;

--- a/__tests__/lib/registerCustomComponents.test.js
+++ b/__tests__/lib/registerCustomComponents.test.js
@@ -1,4 +1,3 @@
-const PropTypes = require('prop-types');
 const React = require('react');
 
 const registerCustomComponents = require('../../lib/registerCustomComponents');
@@ -16,9 +15,6 @@ const customComponents = {
     return <span>I should be registered as “two-words”</span>;
   },
 };
-
-customComponents.a.propTypes = { attrToConcatToSafelist: PropTypes.any };
-customComponents.twoWords.propTypes = { attrToBeSafelisted: PropTypes.any };
 
 describe('Custom Component Registrar', () => {
   let registered;

--- a/components/Anchor.jsx
+++ b/components/Anchor.jsx
@@ -1,4 +1,3 @@
-const PropTypes = require('prop-types');
 const React = require('react');
 
 const BaseUrlContext = require('../contexts/BaseUrl');
@@ -48,8 +47,7 @@ function docLink(href) {
   };
 }
 
-function Anchor(props) {
-  const { baseUrl, children, href, target, title, ...attrs } = props;
+function Anchor({ baseUrl = '/', href = '', target = '', title = '', children, ...attrs }) {
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading
     <a {...attrs} href={getHref(href, baseUrl)} target={target} title={title} {...docLink(href)}>
@@ -57,22 +55,6 @@ function Anchor(props) {
     </a>
   );
 }
-
-Anchor.propTypes = {
-  baseUrl: PropTypes.string,
-  children: PropTypes.node.isRequired,
-  download: PropTypes.string,
-  href: PropTypes.string,
-  target: PropTypes.string,
-  title: PropTypes.string,
-};
-
-Anchor.defaultProps = {
-  baseUrl: '/',
-  href: '',
-  target: '',
-  title: '',
-};
 
 const AnchorWithContext = props => (
   <BaseUrlContext.Consumer>{baseUrl => <Anchor baseUrl={baseUrl} {...props} />}</BaseUrlContext.Consumer>

--- a/components/Callout/index.jsx
+++ b/components/Callout/index.jsx
@@ -1,8 +1,7 @@
-const PropTypes = require('prop-types');
 const React = require('react');
 
 const Callout = props => {
-  const { attributes, theme, icon } = props;
+  const { attributes = null, theme, icon } = props;
   const [title, ...content] = !props.title ? [null, props.children] : props.children;
 
   return (
@@ -15,22 +14,6 @@ const Callout = props => {
       {content}
     </blockquote>
   );
-};
-
-Callout.propTypes = {
-  attributes: PropTypes.shape({}),
-  calloutStyle: PropTypes.string,
-  children: PropTypes.arrayOf(PropTypes.any).isRequired,
-  icon: PropTypes.string,
-  node: PropTypes.shape(),
-  theme: PropTypes.string,
-  title: PropTypes.string,
-};
-
-Callout.defaultProps = {
-  attributes: null,
-  calloutStyle: 'info',
-  node: null,
 };
 
 Callout.sanitize = sanitizeSchema => {

--- a/components/Code/index.jsx
+++ b/components/Code/index.jsx
@@ -1,5 +1,4 @@
 const copy = require('copy-to-clipboard');
-const PropTypes = require('prop-types');
 const React = require('react');
 
 const useHydrated = require('../../hooks/useHydrated');
@@ -32,15 +31,7 @@ function CopyCode({ codeRef, rootClass = 'rdmd-code-copy', className = '' }) {
   return <button ref={button} aria-label="Copy Code" className={`${rootClass} ${className}`} onClick={copier} />;
 }
 
-CopyCode.propTypes = {
-  className: PropTypes.string,
-  codeRef: PropTypes.oneOfType([PropTypes.func, PropTypes.shape({ current: PropTypes.instanceOf(React.Element) })])
-    .isRequired,
-  rootClass: PropTypes.string,
-};
-
-function Code(props) {
-  const { children, className, copyButtons, lang, meta, theme } = props;
+function Code({ children, className = '', copyButtons = true, lang = '', meta = '', theme }) {
   const isHydrated = useHydrated();
 
   const langClass = className.search(/lang(?:uage)?-\w+/) >= 0 ? className.match(/\s?lang(?:uage)?-(\w+)/)[1] : '';
@@ -81,22 +72,6 @@ function CreateCode({ copyButtons, theme }) {
   // eslint-disable-next-line react/display-name
   return props => <Code {...props} copyButtons={copyButtons} theme={theme} />;
 }
-
-Code.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.string),
-  className: PropTypes.string,
-  copyButtons: PropTypes.bool,
-  lang: PropTypes.string,
-  meta: PropTypes.string,
-  theme: PropTypes.string,
-};
-
-Code.defaultProps = {
-  className: '',
-  copyButtons: true,
-  lang: '',
-  meta: '',
-};
 
 CreateCode.sanitize = sanitizeSchema => {
   // This is for code blocks class name

--- a/components/CodeTabs/index.jsx
+++ b/components/CodeTabs/index.jsx
@@ -1,5 +1,4 @@
 const { uppercase } = require('@readme/syntax-highlighter');
-const PropTypes = require('prop-types');
 const React = require('react');
 const { useState } = require('react');
 
@@ -44,11 +43,6 @@ const CodeTabs = props => {
       </div>
     </div>
   );
-};
-
-CodeTabs.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.any).isRequired,
-  theme: PropTypes.string,
 };
 
 function CreateCodeTabs({ theme }) {

--- a/components/Embed/index.jsx
+++ b/components/Embed/index.jsx
@@ -1,12 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading, jsx-a11y/iframe-has-title */
-const propTypes = require('prop-types');
 const React = require('react');
 
 const Favicon = ({ src, alt = 'favicon', ...attr }) => <img {...attr} alt={alt} height="14" src={src} width="14" />;
-Favicon.propTypes = {
-  alt: propTypes.string,
-  src: propTypes.string,
-};
 
 class Embed extends React.Component {
   render() {
@@ -62,19 +57,6 @@ class Embed extends React.Component {
   }
 }
 
-Embed.propTypes = {
-  children: propTypes.oneOfType([propTypes.string, propTypes.array, propTypes.shape({}), propTypes.element]),
-  favicon: propTypes.string,
-  height: propTypes.string,
-  html: propTypes.string,
-  iframe: propTypes.any,
-  image: propTypes.string,
-  lazy: propTypes.bool,
-  provider: propTypes.string,
-  title: propTypes.string,
-  url: propTypes.oneOfType([propTypes.string, propTypes.shape({})]),
-  width: propTypes.string,
-};
 Embed.defaultProps = {
   height: '300px',
   width: '100%',

--- a/components/GlossaryItem/index.jsx
+++ b/components/GlossaryItem/index.jsx
@@ -1,5 +1,4 @@
 const Tooltip = require('@tippyjs/react').default;
-const PropTypes = require('prop-types');
 const React = require('react');
 
 const GlossaryContext = require('../../contexts/GlossaryTerms');
@@ -83,13 +82,6 @@ function GlossaryItem({ term, terms }) {
     </Tooltip>
   );
 }
-
-GlossaryItem.propTypes = {
-  term: PropTypes.string.isRequired,
-  terms: PropTypes.arrayOf(
-    PropTypes.shape({ definition: PropTypes.string.isRequired, term: PropTypes.string.isRequired }),
-  ).isRequired,
-};
 
 // eslint-disable-next-line react/display-name
 module.exports = props => (

--- a/components/HTMLBlock/index.jsx
+++ b/components/HTMLBlock/index.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-eval
  */
 const escape = require('lodash.escape');
-const PropTypes = require('prop-types');
 const React = require('react');
 
 const MATCH_SCRIPT_TAGS = /<script\b[^>]*>([\s\S]*?)<\/script *>\n?/gim;
@@ -45,12 +44,6 @@ class HTMLBlock extends React.PureComponent {
 HTMLBlock.defaultProps = {
   runScripts: false,
   safeMode: false,
-};
-
-HTMLBlock.propTypes = {
-  html: PropTypes.string,
-  runScripts: PropTypes.any,
-  safeMode: PropTypes.bool,
 };
 
 const CreateHtmlBlock =

--- a/components/Heading/index.jsx
+++ b/components/Heading/index.jsx
@@ -8,8 +8,7 @@ function Heading({ align = '', id = '', level = 2, tag, showAnchorIcons = true, 
     align,
   };
 
-  // eslint-disable-next-line no-param-reassign
-  children = [
+  const childrenWithAnchor = [
     <div key={`heading-anchor-${id}`} className="heading-anchor anchor waypoint" id={id} />,
     <div key={`heading-text-${id}`} className="heading-text">
       {children}
@@ -18,7 +17,7 @@ function Heading({ align = '', id = '', level = 2, tag, showAnchorIcons = true, 
 
   if (showAnchorIcons) {
     const headingText = children[1];
-    children.push(
+    childrenWithAnchor.push(
       // eslint-disable-next-line jsx-a11y/anchor-has-content
       <a
         key={`heading-anchor-icon-${id}`}
@@ -29,7 +28,7 @@ function Heading({ align = '', id = '', level = 2, tag, showAnchorIcons = true, 
     );
   }
 
-  return React.createElement(tag, attrs, children);
+  return React.createElement(tag, attrs, childrenWithAnchor);
 }
 
 function CreateHeading(level, { showAnchorIcons }) {

--- a/components/Heading/index.jsx
+++ b/components/Heading/index.jsx
@@ -1,30 +1,30 @@
-const PropTypes = require('prop-types');
 const React = require('react');
 
-function Heading({ tag, showAnchorIcons, ...props }) {
-  if (!props.children) return '';
+function Heading({ align = '', id = '', level = 2, tag, showAnchorIcons = true, children }) {
+  if (!children) return '';
 
   const attrs = {
-    className: `heading heading-${props.level} header-scroll`,
-    align: props.align,
+    className: `heading heading-${level} header-scroll`,
+    align,
   };
 
-  const children = [
-    <div key={`heading-anchor-${props.id}`} className="heading-anchor anchor waypoint" id={props.id} />,
-    <div key={`heading-text-${props.id}`} className="heading-text">
-      {props.children}
+  // eslint-disable-next-line no-param-reassign
+  children = [
+    <div key={`heading-anchor-${id}`} className="heading-anchor anchor waypoint" id={id} />,
+    <div key={`heading-text-${id}`} className="heading-text">
+      {children}
     </div>,
   ];
 
   if (showAnchorIcons) {
-    const headingText = props.children[1];
+    const headingText = children[1];
     children.push(
       // eslint-disable-next-line jsx-a11y/anchor-has-content
       <a
-        key={`heading-anchor-icon-${props.id}`}
+        key={`heading-anchor-icon-${id}`}
         aria-label={`Skip link to ${headingText}`}
         className="heading-anchor-icon fa fa-anchor"
-        href={`#${props.id}`}
+        href={`#${id}`}
       />,
     );
   }
@@ -36,21 +36,5 @@ function CreateHeading(level, { showAnchorIcons }) {
   // eslint-disable-next-line react/display-name
   return props => <Heading {...props} level={level} showAnchorIcons={showAnchorIcons} tag={`h${level}`} />;
 }
-
-Heading.propTypes = {
-  align: PropTypes.oneOf(['left', 'center', 'right', '']),
-  children: PropTypes.array.isRequired,
-  id: PropTypes.string.isRequired,
-  level: PropTypes.number,
-  showAnchorIcons: PropTypes.bool,
-  tag: PropTypes.string.isRequired,
-};
-
-Heading.defaultProps = {
-  align: '',
-  id: '',
-  level: 2,
-  showAnchorIcons: true,
-};
 
 module.exports = CreateHeading;

--- a/components/Image/index.jsx
+++ b/components/Image/index.jsx
@@ -1,6 +1,4 @@
 /* eslint-disable no-param-reassign, react/jsx-props-no-spreading, no-fallthrough */
-
-const PropTypes = require('prop-types');
 const React = require('react');
 
 class Image extends React.Component {
@@ -70,18 +68,6 @@ class Image extends React.Component {
     );
   }
 }
-
-Image.propTypes = {
-  align: PropTypes.string,
-  alt: PropTypes.string,
-  caption: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  className: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
-  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  lazy: PropTypes.bool,
-  src: PropTypes.string.isRequired,
-  title: PropTypes.string,
-  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-};
 
 Image.defaultProps = {
   align: '',

--- a/components/Style.jsx
+++ b/components/Style.jsx
@@ -1,4 +1,3 @@
-const PropTypes = require('prop-types');
 const React = require('react');
 
 const Style = ({ children, safeMode }) => {
@@ -9,11 +8,6 @@ const Style = ({ children, safeMode }) => {
   ) : (
     <style>{children}</style>
   );
-};
-
-Style.propTypes = {
-  children: PropTypes.node,
-  safeMode: PropTypes.bool,
 };
 
 const CreateStyle =

--- a/components/Table/index.jsx
+++ b/components/Table/index.jsx
@@ -1,4 +1,3 @@
-const PropTypes = require('prop-types');
 const React = require('react');
 
 function Table(props) {
@@ -11,9 +10,5 @@ function Table(props) {
     </div>
   );
 }
-
-Table.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.node).isRequired,
-};
 
 module.exports = Table;

--- a/components/TableOfContents/index.jsx
+++ b/components/TableOfContents/index.jsx
@@ -1,4 +1,3 @@
-const PropTypes = require('prop-types');
 const React = require('react');
 
 function TableOfContents({ children }) {
@@ -17,9 +16,5 @@ function TableOfContents({ children }) {
     </nav>
   );
 }
-
-TableOfContents.propTypes = {
-  children: PropTypes.element,
-};
 
 module.exports = TableOfContents;

--- a/example/Demo.jsx
+++ b/example/Demo.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 
 import markdown, { reactProcessor, reactTOC, utils } from '../index';
@@ -78,15 +77,6 @@ function DemoContent({ ci, children, fixture, name, onChange, opts }) {
   );
 }
 
-DemoContent.propTypes = {
-  children: PropTypes.node.isRequired,
-  ci: PropTypes.bool,
-  fixture: PropTypes.string,
-  name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
-  opts: PropTypes.object,
-};
-
 function Demo({ opts }) {
   return (
     <GlossaryContext.Provider value={terms}>
@@ -117,9 +107,5 @@ function Demo({ opts }) {
     </GlossaryContext.Provider>
   );
 }
-
-Demo.propTypes = {
-  opts: PropTypes.object,
-};
 
 export default Demo;

--- a/example/Fixtures/index.jsx
+++ b/example/Fixtures/index.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import syntaxFixtures from './docs';
@@ -60,12 +59,6 @@ const Fixtures = ({ lazyImages, render, safeMode, selected, getRoute, setQuery }
   );
 
   return render({ children: fields, name, fixture, onChange, options });
-};
-
-Fixtures.propTypes = {
-  getRoute: PropTypes.func.isRequired,
-  render: PropTypes.func.isRequired,
-  selected: PropTypes.string,
 };
 
 export default Fixtures;

--- a/index.js
+++ b/index.js
@@ -170,7 +170,6 @@ export function plain(text, opts = {}, components = {}) {
 /**
  *  return a React VDOM component tree
  */
-// eslint-disable-next-line react/prop-types
 const PinWrap = ({ children }) => <div className="pin">{children}</div>; // @todo: move this to it's own component
 
 export function reactProcessor(opts = {}, components = {}) {

--- a/lib/createElement/index.js
+++ b/lib/createElement/index.js
@@ -6,7 +6,6 @@ const createElement =
   opts =>
   // eslint-disable-next-line react/display-name
   (type, props, ...children) => {
-    // eslint-disable-next-line react/prop-types
     const rdmdType = type === 'div' && props?.className === 'code-tabs' ? CreateCodeTabs(opts) : type;
 
     return React.createElement(rdmdType, props, ...children);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@readme/markdown",
+  "name": "@readme/markdown-legacy",
   "version": "6.88.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@readme/markdown",
+      "name": "@readme/markdown-legacy",
       "version": "6.88.5",
       "license": "MIT",
       "dependencies": {
@@ -20,7 +20,6 @@
         "parse-entities": "^4.0.1",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
-        "prop-types": "^15.8.1",
         "rehype-raw": "^5.1.0",
         "rehype-react": "^6.2.1",
         "rehype-sanitize": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "parse-entities": "^4.0.1",
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
-    "prop-types": "^15.8.1",
     "rehype-raw": "^5.1.0",
     "rehype-react": "^6.2.1",
     "rehype-sanitize": "^4.0.0",


### PR DESCRIPTION
| [![PR App][icn]][demo] | Fix RM-XYZ |
| :--------------------: | :--------: |

## 🧰 Changes

Removes the `prop-types` package.

Since it's deprecated in react >= 18, it's complaining a lot in the main codebase.

## 🧬 QA & Testing

- [Broken on production][prod].
- [Working in this PR app][demo].

[demo]: https://markdown-pr-PR_NUMBER.herokuapp.com
[prod]: https://SUBDOMAIN.readme.io
[icn]: https://user-images.githubusercontent.com/886627/160426047-1bee9488-305a-4145-bb2b-09d8b757d38a.svg
