### PR TITLE
fix(mdxish): handle user vars on standalone lines in tables

### DIFF
--- a/__tests__/lib/mdxish/variables-text.test.ts
+++ b/__tests__/lib/mdxish/variables-text.test.ts
@@ -113,6 +113,69 @@ describe('variablesTextTransformer', () => {
     });
   });
 
+  describe('inside JSX table cells', () => {
+    it('parses {user.name} on its own line inside a <Table> cell', () => {
+      const tree = mdxish(`<Table>
+  <thead>
+    <tr>
+      <th>Header</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+{user.name}
+      </td>
+    </tr>
+  </tbody>
+</Table>`);
+      const variables = findAllElementsByTagName(tree, 'variable');
+      expect(variables).toHaveLength(1);
+      expect(variables[0].properties?.name).toBe('name');
+    });
+
+    it('parses {user.name} in both <th> and <td> cells', () => {
+      const tree = mdxish(`<Table>
+  <thead>
+    <tr>
+      <th>
+        {user.name}
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+{user.email}
+      </td>
+    </tr>
+  </tbody>
+</Table>`);
+      const variables = findAllElementsByTagName(tree, 'variable');
+      expect(variables).toHaveLength(2);
+      expect(variables[0].properties?.name).toBe('name');
+      expect(variables[1].properties?.name).toBe('email');
+    });
+
+    it('parses inline {user.name} alongside text in a <Table> cell', () => {
+      const tree = mdxish(`<Table>
+  <thead>
+    <tr>
+      <th>Header</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Hello {user.name}!</td>
+    </tr>
+  </tbody>
+</Table>`);
+      const variables = findAllElementsByTagName(tree, 'variable');
+      expect(variables).toHaveLength(1);
+      expect(variables[0].properties?.name).toBe('name');
+    });
+  });
+
   describe('code block protection', () => {
     it('does not parse {user.name} inside a fenced code block', () => {
       const tree = mdxish('```\n{user.name}\n```');

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
       },
       {
         "path": "dist/main.node.js",
-        "maxSize": "860KB"
+        "maxSize": "861KB"
       }
     ]
   },

--- a/processor/transform/mdxish/variables-text.ts
+++ b/processor/transform/mdxish/variables-text.ts
@@ -1,6 +1,6 @@
 import type { Variable } from '../../../types';
 import type { Parent, Text } from 'mdast';
-import type { MdxTextExpression } from 'mdast-util-mdx-expression';
+import type { MdxFlowExpression, MdxTextExpression } from 'mdast-util-mdx-expression';
 import type { Plugin } from 'unified';
 
 import { visit } from 'unist-util-visit';
@@ -31,23 +31,31 @@ function makeVariableNode(varName: string, rawValue: string): Variable {
 
 /**
  * A remark plugin that parses {user.<field>} patterns from text nodes and
- * mdxTextExpression nodes, creating Variable nodes for runtime resolution.
+ * mdx expression nodes, creating Variable nodes for runtime resolution.
  *
- * Handles both:
+ * Handles:
  * - `text` nodes: when safeMode is true or after expression evaluation
  * - `mdxTextExpression` nodes: when mdxExpression has parsed {user.*} before evaluation
+ * - `mdxFlowExpression` nodes: when {user.*} appears on its own line (e.g. inside JSX table cells)
  *
  * Supports any user field: name, email, email_verified, exp, iat, etc.
  */
+function visitExpressionNode(node: MdxFlowExpression | MdxTextExpression, index: number | undefined, parent: Parent) {
+  if (index === undefined || !parent) return;
+  const wrapped = `{${(node.value ?? '').trim()}}`;
+  const matches = [...wrapped.matchAll(USER_VAR_REGEX)];
+  if (matches.length !== 1) return;
+  const varName = matches[0][1] || matches[0][2];
+  parent.children.splice(index, 1, makeVariableNode(varName, wrapped));
+}
+
 const variablesTextTransformer: Plugin = () => tree => {
-  // Handle mdxTextExpression nodes (e.g. {user.name} parsed by mdxExpression)
   visit(tree, 'mdxTextExpression', (node: MdxTextExpression, index, parent: Parent) => {
-    if (index === undefined || !parent) return;
-    const wrapped = `{${(node.value ?? '').trim()}}`; // Wrap the expression value in {} to match the USER_VAR_REGEX pattern
-    const matches = [...wrapped.matchAll(USER_VAR_REGEX)];
-    if (matches.length !== 1) return;
-    const varName = matches[0][1] || matches[0][2];
-    parent.children.splice(index, 1, makeVariableNode(varName, wrapped));
+    visitExpressionNode(node, index, parent);
+  });
+
+  visit(tree, 'mdxFlowExpression', (node: MdxFlowExpression, index, parent: Parent) => {
+    visitExpressionNode(node, index, parent);
   });
 
   visit(tree, 'text', (node: Text, index, parent: Parent) => {


### PR DESCRIPTION
| 🎫 Resolve RM-15997 |
| :-----------------: |

## 🎯 What does this PR do?

Standlone `{user.` vars werent being properly parsed in`<Table>` cells. This PR fixes that issue by allowing variable transformer to also visit mdx flow elements

> [!NOTE]
The same issue is still happening with `<table>`. That will be solved when this PR gets merged in: #1403 

## 🧪 QA tips

```
<Table>
  <thead>
    <tr>
      <th>
        {user.name}
      </th>
      <th>
        {user.name} hello
      </th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
{user.name}
      </td>
    </tr>
  </tbody>
</Table>

| hello |
| -- |
| {user.name}|
| {user.name} hello|

{user.name}
```

## 📸 Screenshot or Loom

Before | After
-- | --
<img width="1077" height="369" alt="Screenshot 2026-04-06 at 17 48 10" src="https://github.com/user-attachments/assets/ff1b3fcd-3ab1-4932-ae89-596aa60574c1" /> | <img width="1079" height="372" alt="Screenshot 2026-04-06 at 17 47 49" src="https://github.com/user-attachments/assets/9291208d-1286-4b32-af68-4485fb66eb45" />

