### PR TITLE
fix: fix nested callout styling being overriden

### DIFF
--- a/components/Callout/style.scss
+++ b/components/Callout/style.scss
@@ -88,7 +88,7 @@
     border-color: var(--border, var(--markdown-edge, #eee));
   }
 
-  blockquote {
+  blockquote:not(.callout) {
     color: var(--color-text-default, var(--text));
     border-color: var(--border);
     border-width: 3px;


### PR DESCRIPTION
| 🎫 Resolve RM-16036 |
| :-----------------: |

## 🎯 What does this PR do?

Nested callouts like 
```
> 📘 Title
>
> > 📘 Title
> >
> > body
>
> body
```

were not being rendered correctly in terms of styling. the CSS for regular blockquotes was overriding the styles we had for our custom Callout components

## 🧪 QA tips

```
> 📘 Title
>
> > 📘 Title
> >
> > body
>
> body
```
All nested callouts should have proper callout stylings

## 📸 Screenshot or Loom
### Before 
<img width="1678" height="328" alt="Screenshot 2026-04-08 at 11 18 11" src="https://github.com/user-attachments/assets/cf7a3448-b4c5-4f40-bb82-3e5de519ce3e" />

### After
<img width="1674" height="355" alt="Screenshot 2026-04-08 at 11 17 50" src="https://github.com/user-attachments/assets/4750ff51-9ba6-4c02-a735-d0f164edb01d" />

