### PR TITLE
fix(mdxish): Add compact heading preprocessor

### DIFF
--- a/__tests__/transformers/normalize-compact-headings.test.ts
+++ b/__tests__/transformers/normalize-compact-headings.test.ts
@@ -1,3 +1,8 @@
+import type { Element } from 'hast';
+
+import { visit } from 'unist-util-visit';
+
+import { mdxish } from '../../lib/mdxish';
 import { normalizeCompactHeadings } from '../../processor/transform/mdxish/normalize-compact-headings';
 
 describe('normalizeCompactHeadings', () => {
@@ -8,10 +13,6 @@ describe('normalizeCompactHeadings', () => {
 
     it('should add space after ## for compact h2', () => {
       expect(normalizeCompactHeadings('##Header')).toBe('## Header');
-    });
-
-    it('should add space after ### for compact h3', () => {
-      expect(normalizeCompactHeadings('###Header')).toBe('### Header');
     });
 
     it('should handle all heading levels up to h6', () => {
@@ -74,7 +75,7 @@ describe('normalizeCompactHeadings', () => {
     });
   });
 
-  describe('text before hashtag (Dimas feedback)', () => {
+  describe('text before hashtag', () => {
     it('should NOT modify mid-line # (text before hashtag)', () => {
       const input = 'Some text #hashtag on same line';
       expect(normalizeCompactHeadings(input)).toBe(input);
@@ -158,6 +159,48 @@ describe('normalizeCompactHeadings', () => {
     it('should handle empty headings', () => {
       expect(normalizeCompactHeadings('#')).toBe('#');
       expect(normalizeCompactHeadings('# ')).toBe('# ');
+    });
+  });
+
+  describe('full mdxish pipeline', () => {
+    it('should render compact headings as proper heading elements', () => {
+      const md = '#CompactH1\n\n##CompactH2\n\n###CompactH3';
+      const tree = mdxish(md);
+
+      const h1s: Element[] = [];
+      const h2s: Element[] = [];
+      const h3s: Element[] = [];
+      visit(tree, 'element', (node: Element) => {
+        if (node.tagName === 'h1') h1s.push(node);
+        if (node.tagName === 'h2') h2s.push(node);
+        if (node.tagName === 'h3') h3s.push(node);
+      });
+
+      expect(h1s).toHaveLength(1);
+      expect(h2s).toHaveLength(1);
+      expect(h3s).toHaveLength(1);
+    });
+
+    it('should not convert hashtags in code blocks to headings', () => {
+      const md = '#Heading\n\n```\n#NotAHeading\n```';
+      const tree = mdxish(md);
+
+      const h1s: Element[] = [];
+      visit(tree, 'element', (node: Element) => {
+        if (node.tagName === 'h1') h1s.push(node);
+      });
+      expect(h1s).toHaveLength(1);
+    });
+
+    it('should preserve code block content with hashtags', () => {
+      const md = '```python\n#Comment\nprint("hello")\n```';
+      const tree = mdxish(md);
+
+      const h1s: Element[] = [];
+      visit(tree, 'element', (node: Element) => {
+        if (node.tagName === 'h1') h1s.push(node);
+      });
+      expect(h1s).toHaveLength(0);
     });
   });
 });

--- a/__tests__/transformers/normalize-compact-headings.test.ts
+++ b/__tests__/transformers/normalize-compact-headings.test.ts
@@ -1,0 +1,122 @@
+import { normalizeCompactHeadings } from '../../processor/transform/mdxish/normalize-compact-headings';
+
+describe('normalizeCompactHeadings', () => {
+  describe('basic heading normalization', () => {
+    it('should add space after # for compact h1', () => {
+      expect(normalizeCompactHeadings('#Header')).toBe('# Header');
+    });
+
+    it('should add space after ## for compact h2', () => {
+      expect(normalizeCompactHeadings('##Header')).toBe('## Header');
+    });
+
+    it('should add space after ### for compact h3', () => {
+      expect(normalizeCompactHeadings('###Header')).toBe('### Header');
+    });
+
+    it('should handle all heading levels up to h6', () => {
+      expect(normalizeCompactHeadings('######H6')).toBe('###### H6');
+    });
+
+    it('should not modify headings with existing space', () => {
+      expect(normalizeCompactHeadings('# Header')).toBe('# Header');
+      expect(normalizeCompactHeadings('## Header')).toBe('## Header');
+      expect(normalizeCompactHeadings('### Header')).toBe('### Header');
+    });
+
+    it('should handle multiple headings', () => {
+      const input = '#H1\nText\n##H2';
+      const expected = '# H1\nText\n## H2';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+
+    it('should handle mixed proper and compact headings', () => {
+      const input = '# Proper\n\n##Compact\n\nParagraph text\n\n### Also Proper';
+      const expected = '# Proper\n\n## Compact\n\nParagraph text\n\n### Also Proper';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+  });
+
+  describe('protected blocks (code blocks)', () => {
+    it('should NOT modify # inside fenced code blocks with backticks', () => {
+      const input = '#Heading\n\n```python\n#Comment\n```';
+      const expected = '# Heading\n\n```python\n#Comment\n```';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+
+    it('should NOT modify ## inside code blocks', () => {
+      const input = '```\n##Not a heading\n###Also not\n```';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should handle code blocks with language specifier', () => {
+      const input = '#H1\n```javascript\n#NotHeading\n```\n##H2';
+      const expected = '# H1\n```javascript\n#NotHeading\n```\n## H2';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+
+    it('should handle multiple code blocks', () => {
+      const input = '#H1\n```\n#Code1\n```\n##H2\n```\n#Code2\n```\n###H3';
+      const expected = '# H1\n```\n#Code1\n```\n## H2\n```\n#Code2\n```\n### H3';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+
+    it('should NOT modify indented code blocks (4 spaces)', () => {
+      const input = '#Heading\n\n    #IndentedCode';
+      const expected = '# Heading\n\n    #IndentedCode';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+
+    it('should NOT modify tab-indented code blocks', () => {
+      const input = '#Heading\n\n\t#TabIndentedCode';
+      const expected = '# Heading\n\n\t#TabIndentedCode';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should NOT modify mid-line # (text before hashtag)', () => {
+      const input = 'Some text #hashtag on same line';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should NOT modify # in middle of paragraph', () => {
+      const input = 'Use #tags and ##double tags in text';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should NOT modify escaped \\# at start of line', () => {
+      const input = '\\#NotAHeading';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should handle escaped # followed by real heading', () => {
+      const input = '\\#Escaped\n\n#RealHeading';
+      const expected = '\\#Escaped\n\n# RealHeading';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+
+    it('should NOT modify more than 6 # symbols', () => {
+      const input = '#######NotAHeading';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should handle empty content', () => {
+      expect(normalizeCompactHeadings('')).toBe('');
+    });
+
+    it('should handle content with no headings', () => {
+      const input = 'Just some text\nwith multiple lines\nand no headings';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should handle # followed by another #', () => {
+      expect(normalizeCompactHeadings('## Header')).toBe('## Header');
+    });
+
+    it('should handle empty headings', () => {
+      expect(normalizeCompactHeadings('#')).toBe('#');
+      expect(normalizeCompactHeadings('# ')).toBe('# ');
+    });
+  });
+});

--- a/__tests__/transformers/normalize-compact-headings.test.ts
+++ b/__tests__/transformers/normalize-compact-headings.test.ts
@@ -74,7 +74,7 @@ describe('normalizeCompactHeadings', () => {
     });
   });
 
-  describe('edge cases', () => {
+  describe('text before hashtag (Dimas feedback)', () => {
     it('should NOT modify mid-line # (text before hashtag)', () => {
       const input = 'Some text #hashtag on same line';
       expect(normalizeCompactHeadings(input)).toBe(input);
@@ -85,8 +85,36 @@ describe('normalizeCompactHeadings', () => {
       expect(normalizeCompactHeadings(input)).toBe(input);
     });
 
+    it('should NOT modify # after punctuation on same line', () => {
+      const input = 'Hello! #hashtag';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should NOT modify inline # with numbers', () => {
+      const input = 'Issue #123 is fixed';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should NOT modify # in URLs', () => {
+      const input = 'Visit https://example.com#section for more';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should handle heading after line with mid-line #', () => {
+      const input = 'Check issue #42\n#ActualHeading';
+      const expected = 'Check issue #42\n# ActualHeading';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+  });
+
+  describe('escaped hashtag (Dimas feedback)', () => {
     it('should NOT modify escaped \\# at start of line', () => {
       const input = '\\#NotAHeading';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+
+    it('should NOT modify escaped \\## at start of line', () => {
+      const input = '\\##NotAHeading';
       expect(normalizeCompactHeadings(input)).toBe(input);
     });
 
@@ -96,6 +124,19 @@ describe('normalizeCompactHeadings', () => {
       expect(normalizeCompactHeadings(input)).toBe(expected);
     });
 
+    it('should handle multiple escaped # lines', () => {
+      const input = '\\#First\n\\#Second\n#ActualHeading';
+      const expected = '\\#First\n\\#Second\n# ActualHeading';
+      expect(normalizeCompactHeadings(input)).toBe(expected);
+    });
+
+    it('should NOT modify backslash-escaped # mid-line', () => {
+      const input = 'Use \\#escaped in text';
+      expect(normalizeCompactHeadings(input)).toBe(input);
+    });
+  });
+
+  describe('other edge cases', () => {
     it('should NOT modify more than 6 # symbols', () => {
       const input = '#######NotAHeading';
       expect(normalizeCompactHeadings(input)).toBe(input);

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -39,6 +39,7 @@ import mdxishSelfClosingBlocks from '../processor/transform/mdxish/mdxish-self-c
 import { processSnakeCaseComponent } from '../processor/transform/mdxish/mdxish-snake-case-components';
 import mdxishTables from '../processor/transform/mdxish/mdxish-tables';
 import mdxishTablesToJsx from '../processor/transform/mdxish/mdxish-tables-to-jsx';
+import { normalizeCompactHeadings } from '../processor/transform/mdxish/normalize-compact-headings';
 import normalizeEmphasisAST from '../processor/transform/mdxish/normalize-malformed-md-syntax';
 import { normalizeTableSeparator } from '../processor/transform/mdxish/normalize-table-separator';
 import {
@@ -113,6 +114,7 @@ function preprocessContent(
   let result = normalizeTableSeparator(content);
   result = terminateHtmlFlowBlocks(result);
   result = closeSelfClosingHtmlTags(result);
+  result = normalizeCompactHeadings(result);
   result = safeMode ? result : preprocessJSXExpressions(result, jsxContext);
 
   return processSnakeCaseComponent(result, { knownComponents });

--- a/processor/transform/mdxish/normalize-compact-headings.ts
+++ b/processor/transform/mdxish/normalize-compact-headings.ts
@@ -1,15 +1,11 @@
 import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
 
 /**
- * Preprocessor to normalize compact ATX headings.
+ * Preprocessor to normalize compact headings.
  *
- * CommonMark requires whitespace after # for ATX headings, but users often omit it.
- * This preprocessor adds the space while being careful not to modify:
- * - Content inside fenced code blocks (protected via protectCodeBlocks)
- * - Escaped hashtags (\#)
- * - Mid-line hashtags (text #hashtag)
- * - Indented code blocks (4 spaces or tab)
- *
+ * CommonMark requires whitespace after # for headings, but users often omit it.
+ * This preprocessor adds the space while
+ * 
  * Examples:
  * - `#Header` → `# Header`
  * - `##Title` → `## Title`

--- a/processor/transform/mdxish/normalize-compact-headings.ts
+++ b/processor/transform/mdxish/normalize-compact-headings.ts
@@ -4,7 +4,10 @@ import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/
  * Preprocessor to normalize compact headings.
  *
  * CommonMark requires whitespace after # for headings, but users often omit it.
- * This preprocessor adds the space while
+ * This preprocessor adds the space while being careful not to modify:
+ * - Content inside fenced code blocks (protected via protectCodeBlocks)
+ * - Escaped hashtags (\#)
+ * - Mid-line hashtags (text #hashtag)
  * 
  * Examples:
  * - `#Header` → `# Header`
@@ -12,7 +15,6 @@ import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/
  * - `######H6` → `###### H6`
  */
 export function normalizeCompactHeadings(content: string): string {
-  // Protect code blocks from modification
   const { protectedContent, protectedCode } = protectCodeBlocks(content);
 
   const normalizedLines = protectedContent.split('\n').map(line => {
@@ -32,6 +34,5 @@ export function normalizeCompactHeadings(content: string): string {
     return line;
   });
 
-  // Restore protected code blocks
   return restoreCodeBlocks(normalizedLines.join('\n'), protectedCode);
 }

--- a/processor/transform/mdxish/normalize-compact-headings.ts
+++ b/processor/transform/mdxish/normalize-compact-headings.ts
@@ -1,0 +1,43 @@
+import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
+
+/**
+ * Preprocessor to normalize compact ATX headings.
+ *
+ * CommonMark requires whitespace after # for ATX headings, but users often omit it.
+ * This preprocessor adds the space while being careful not to modify:
+ * - Content inside fenced code blocks (protected via protectCodeBlocks)
+ * - Escaped hashtags (\#)
+ * - Mid-line hashtags (text #hashtag)
+ * - Indented code blocks (4 spaces or tab)
+ *
+ * Examples:
+ * - `#Header` → `# Header`
+ * - `##Title` → `## Title`
+ * - `######H6` → `###### H6`
+ * - `# Already spaced` → `# Already spaced` (unchanged)
+ * - `\#Escaped` → `\#Escaped` (unchanged)
+ */
+export function normalizeCompactHeadings(content: string): string {
+  // Protect code blocks from modification
+  const { protectedContent, protectedCode } = protectCodeBlocks(content);
+
+  const normalizedLines = protectedContent.split('\n').map(line => {
+
+    // Skip escaped hashtags
+    if (line.startsWith('\\#')) {
+      return line;
+    }
+
+    // Match compact heading: start of line, 1-6 #, followed by non-space/non-# character
+    const headingMatch = line.match(/^(#{1,6})([^\s#])/);
+    if (headingMatch) {
+      // Insert space after hashtags: "##Header" → "## Header"
+      return `${headingMatch[1]} ${line.slice(headingMatch[1].length)}`;
+    }
+
+    return line;
+  });
+
+  // Restore protected code blocks
+  return restoreCodeBlocks(normalizedLines.join('\n'), protectedCode);
+}

--- a/processor/transform/mdxish/normalize-compact-headings.ts
+++ b/processor/transform/mdxish/normalize-compact-headings.ts
@@ -14,8 +14,6 @@ import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/
  * - `#Header` → `# Header`
  * - `##Title` → `## Title`
  * - `######H6` → `###### H6`
- * - `# Already spaced` → `# Already spaced` (unchanged)
- * - `\#Escaped` → `\#Escaped` (unchanged)
  */
 export function normalizeCompactHeadings(content: string): string {
   // Protect code blocks from modification


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

### Issue
There's an issue with customer migrating from legacy rdmd since the legacy engine renders heading syntax without a space, but mdx and mdxish do not
https://linear.app/readme-io/issue/RM-16028/typing-for-heading-needs-a-space-to-be-correctly-treated-as-a-heading#comment-01d1c6f6

### Solution
As micromark can't process compact heading, I've made a `normalizeCompactHeadings()` preprocessor to normalize compact heading to normal heading format so it can process

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ]

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
