### PR TITLE
fix: proper spacing in empty callouts

### DIFF
--- a/__tests__/components/Callout.test.tsx
+++ b/__tests__/components/Callout.test.tsx
@@ -31,6 +31,31 @@ describe('Callout', () => {
     expect(screen.queryByText('Title')).toBeNull();
   });
 
+  it('does not render empty heading when empty and no body children', () => {
+    const { container } = render(
+      <Callout empty icon="📘" theme="info">
+        <p></p>
+      </Callout>,
+    );
+
+    expect(container.querySelector('.callout-heading.empty')).not.toBeInTheDocument();
+    const icon = container.querySelector('.callout-icon');
+    expect(icon).toBeInTheDocument();
+    expect(icon?.nextElementSibling).toBeNull();
+  });
+
+  it('renders empty heading when empty but has body children', () => {
+    const { container } = render(
+      <Callout empty icon="📘" theme="info">
+        <p></p>
+        <p>Body content</p>
+      </Callout>,
+    );
+
+    expect(container.querySelector('.callout-heading.empty')).toBeInTheDocument();
+    expect(screen.getByText('Body content')).toBeVisible();
+  });
+
   describe('mdxish', () => {
     it('renders a callout with no title with no empty blank heading', () => {
       const md = `<Callout theme="info" icon="📘">

--- a/components/Callout/index.tsx
+++ b/components/Callout/index.tsx
@@ -41,7 +41,8 @@ const Callout = (props: Props) => {
 
   const icon = props.icon;
   const isEmoji = icon && emojiRegex().test(icon);
-  const heading = empty ? <p className={'callout-heading empty'}></p> : children[0];
+  const hasBody = children.length > 1;
+  const heading = empty ? (hasBody ? <p className={'callout-heading empty'}></p> : null) : children[0];
   const theme = props.theme || (icon && themes[icon]) || 'default';
 
   return (


### PR DESCRIPTION
| 🎫 Resolve RM-15724 |
| :-----------------: |

## 🎯 What does this PR do?

Fixed an issue where empty callouts where being squished

## 🧪 QA tips

Both empty and filled callouts should have the same dimensions and not be squished

```
> 📘 sdf

> 📘 
```

## 📸 Screenshot or Loom

In monorepo:
<img width="1919" height="991" alt="Screenshot 2026-04-13 at 18 17 06" src="https://github.com/user-attachments/assets/0988297d-fa8b-4f51-bff0-8c43a6bb6061" />

In demo app:
Before | After
-- | --
<img width="1151" height="992" alt="Screenshot 2026-04-13 at 18 17 54" src="https://github.com/user-attachments/assets/f00d7a1e-5410-4488-a839-93acdaed30da" /> | <img width="1151" height="992" alt="Screenshot 2026-04-13 at 18 17 27" src="https://github.com/user-attachments/assets/24e5220f-ae9e-44d7-8d00-95d2b5229810" />

