### PR TITLE
fix: toc refresh on load

### DIFF
--- a/__tests__/components/TableOfContents.test.jsx
+++ b/__tests__/components/TableOfContents.test.jsx
@@ -187,6 +187,52 @@ describe('Table of Contents', () => {
       expect(firstLink.classList.contains('active')).toBe(true);
       expect(secondLink.classList.contains('active')).toBe(false);
     });
+
+    it('should rebuild linkMap when children change (page navigation)', async () => {
+      // Simulate page navigation: TOC re-renders with new children
+      // but the TableOfContents instance persists (same position in tree).
+      // The click handler must recognize the NEW heading IDs.
+
+      // Add new headings to the DOM for "page 2"
+      ['new-heading-1', 'new-heading-2'].forEach(id => {
+        const el = document.createElement('h2');
+        el.id = id;
+        el.getBoundingClientRect = () => ({ top: 100, height: 30 });
+        scrollContainer.appendChild(el);
+      });
+
+      const { container, rerender } = render(
+        <TableOfContents>
+          <a href="#heading-1">Heading 1</a>
+          <a href="#heading-2">Heading 2</a>
+          <a href="#heading-3">Heading 3</a>
+        </TableOfContents>,
+      );
+
+      await act(async () => {});
+
+      // "Navigate" to a new page — rerender with different children
+      rerender(
+        <TableOfContents>
+          <a href="#new-heading-1">New Heading 1</a>
+          <a href="#new-heading-2">New Heading 2</a>
+        </TableOfContents>,
+      );
+
+      // Wait for effects to detect the content change and rebuild
+      await act(async () => {});
+
+      const links = container.querySelectorAll('a');
+      const newLink = [...links].find(a => a.getAttribute('href') === '#new-heading-1');
+
+      // Click a link from the new page — the handler should recognize it
+      act(() => {
+        newLink.click();
+      });
+
+      expect(newLink.classList.contains('active')).toBe(true);
+      expect(window.location.hash).toBe('#new-heading-1');
+    });
   });
 
   it('renders with rm-ToC class', () => {

--- a/components/TableOfContents/index.tsx
+++ b/components/TableOfContents/index.tsx
@@ -42,18 +42,23 @@ function getScrollParent(el: HTMLElement): HTMLElement | Window {
  * corresponding TOC links so the reader always knows where they are.
  */
 function useScrollHighlight(navRef: React.RefObject<HTMLElement | null>) {
-  const [linkCount, setLinkCount] = useState(0);
+  const [tocKey, setTocKey] = useState('');
 
+  // Re-check after every render so we detect when children change
+  // (e.g. after page navigation). Only triggers a re-render when the
+  // set of TOC link hrefs actually differs.
   useEffect(() => {
     const nav = navRef.current;
     if (!nav) return;
-    const count = nav.querySelectorAll('a[href^="#"]').length;
-    setLinkCount(count);
-  }, [navRef]);
+    const key = Array.from(nav.querySelectorAll<HTMLAnchorElement>('a[href^="#"]'))
+      .map(a => a.getAttribute('href'))
+      .join('\0');
+    setTocKey(key);
+  });
 
   useEffect(() => {
     const nav = navRef.current;
-    if (!nav || typeof IntersectionObserver === 'undefined' || linkCount === 0) return undefined;
+    if (!nav || typeof IntersectionObserver === 'undefined' || !tocKey) return undefined;
 
     const linkMap = buildLinkMap(nav);
     if (linkMap.size === 0) return undefined;
@@ -172,7 +177,7 @@ function useScrollHighlight(navRef: React.RefObject<HTMLElement | null>) {
       scrollTarget.removeEventListener('scroll', onScroll);
       nav.removeEventListener('click', onClick);
     };
-  }, [navRef, linkCount]);
+  }, [navRef, tocKey]);
 }
 
 function TableOfContents({ children }: React.PropsWithChildren) {


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

In #1425 we fixed an issue with the ToC clicks not appending id to the URL due to `preventDefault()` behavior. I believe this bug was there since the initial TOC work, but `preventDefault` actually masked the bug b/c the hashes weren’t being appended.

This change forces the toc to re-render on page navigation.

## 🧪 QA tips

This can only be QA'd [locally](https://github.com/readmeio/markdown?tab=readme-ov-file#local-development-and-testing) or in the readme repo.

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
