### PR TITLE
refactor: move numbered lists for 1 -> a -> i

### DIFF
--- a/styles/gfm.scss
+++ b/styles/gfm.scss
@@ -209,14 +209,14 @@
 
   ol ol,
   ul ol {
-    list-style-type: lower-roman;
+    list-style-type: lower-alpha;
   }
 
   ol ol ol,
   ol ul ol,
   ul ol ol,
   ul ul ol {
-    list-style-type: lower-alpha;
+    list-style-type: lower-roman;
   }
 
   dd {


### PR DESCRIPTION
| 🎫 Resolve RM-16032 |
| :-----------------: |

## 🎯 What does this PR do?

Switches numbered lists from `1. -> i. -> a.` to `1. -> a. -> i.`

## 🧪 QA tips

Paste this

```
1. First level
   1. Second level
      1. Third level
```

you should see the correctly ordered nested lists

## 📸 Screenshot or Loom

### Before 
<img width="1265" height="207" alt="Screenshot 2026-04-16 at 01 16 52" src="https://github.com/user-attachments/assets/9fa7f7f4-bc22-4b75-a916-9956da4569ec" />

### After
<img width="1252" height="222" alt="Screenshot 2026-04-16 at 01 17 03" src="https://github.com/user-attachments/assets/191d40a1-b8be-4a00-8071-60603d1d56a6" />

Some screenshots in the monorepo

View Mode | Edit Mode
-- | --
<img width="1919" height="993" alt="Screenshot 2026-04-16 at 01 31 48" src="https://github.com/user-attachments/assets/6339f9a3-bbd1-4035-948d-8c306a4edf43" /> | <img width="1918" height="991" alt="Screenshot 2026-04-16 at 01 31 42" src="https://github.com/user-attachments/assets/c163e48b-b718-4274-92a7-5fb5b4219449" />
