### PR TITLE
fix(mdxish): legacy glossary syntax in callout title crashing

### DIFF
--- a/__tests__/lib/render-mdxish/Callouts.test.tsx
+++ b/__tests__/lib/render-mdxish/Callouts.test.tsx
@@ -197,6 +197,22 @@ describe('Callouts', () => {
     expect(container.textContent).toContain('Test');
   });
 
+  it('renders <<glossary:*>> terms in callout title without error', () => {
+    const md = `> 📘 Login hint encoded in a <<glossary:JWT>> token
+>
+> Body`;
+    const terms = [{ term: 'JWT', definition: 'JSON Web Token' }];
+
+    const hast = mdxish(md);
+    const mod = renderMdxish(hast, { terms });
+    const { container } = render(<mod.default />);
+
+    expect(container.querySelector('.callout.callout_info')).toBeInTheDocument();
+    expect(container.textContent).toContain('Login hint encoded in a');
+    expect(container.textContent).toContain('JWT');
+    expect(container.textContent).toContain('Body');
+  });
+
   it('renders mdx {user.*} variables in callout title without error', () => {
     const md = `> 🚧 Hello {user.name}
 >

--- a/processor/transform/callouts.ts
+++ b/processor/transform/callouts.ts
@@ -26,12 +26,13 @@ const toMarkdownExtensions = [
   gfmToMarkdown(),
   // For mdx variable syntaxes (e.g., {user.name})
   mdxExpressionToMarkdown(),
-  // Important: This is required and would crash the parser if there's no variable, gemoji, or fa-icon node handler
+  // Important: This is required and would crash the parser if there's no variable, gemoji, fa-icon, or glossary node handler
   {
     handlers: {
       [NodeTypes.variable]: variable,
       [NodeTypes.emoji]: gemoji,
       [NodeTypes.i]: compatibility,
+      [NodeTypes.glossary]: compatibility,
     },
   },
 ];


### PR DESCRIPTION
| 🎫 Resolve CX-3117 |
| :-----------------: |

## 🎯 What does this PR do?

Fixes a crash in the MDXish pipeline where using `<<glossary:...>>` inside a callout title caused the whole page to fail rendering in view mode. 

The root cause was the callout transformer's title `toMarkdown` roundtrip had no handler registered for `readme-glossary-item`, so `mdast-util-to-markdown` threw `Cannot handle unknown node` whenever a glossary term appeared in a callout title. 

The fix is just to register the existing `compatibility` handler (which already knows how to serialize `NodeTypes.glossary` as `<Glossary>{term}</Glossary>`) on the callout `toMarkdownExtensions`.

## 🧪 QA tips

In MDXish rendering, create a block quote callout with the legacy glossary syntax in the title. It shouldn't crash anymore
```
> 📘 I am in a <<glossary:parliament>>!
>
> Hello

> 📘 I am in a <<glossary:parliament>>!
```