### PR TITLE
fix: preserve target attribute on links

### DIFF
--- a/__tests__/lib/compile.test.ts
+++ b/__tests__/lib/compile.test.ts
@@ -1,4 +1,14 @@
-import { compile } from '../../index';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { compile, run } from '../../index';
+
+const renderMarkdown = (doc: string) => {
+  const code = compile(doc, { format: 'md' });
+  const mod = run(code, { format: 'md' });
+  const { container } = render(React.createElement(mod.default));
+  return container.querySelector('a');
+};
 
 describe('compile', () => {
   describe("{ format: 'md' }", () => {
@@ -7,6 +17,26 @@ describe('compile', () => {
 
       const tree = compile(md, { format: 'md' });
       expect(tree).toMatch(/href: "doc:getting-started"/);
+    });
+
+    it('preserves target on raw HTML anchors', () => {
+      const anchor = renderMarkdown('<a href="https://example.com" target="_blank">test</a>');
+
+      expect(anchor).toHaveAttribute('href', 'https://example.com');
+      expect(anchor).toHaveAttribute('target', '_blank');
+    });
+
+    it('preserves internal reference protocols on raw HTML anchors', () => {
+      const anchor = renderMarkdown('<a href="ref:getting-started" target="_blank">test</a>');
+
+      expect(anchor).toHaveAttribute('href', 'ref:getting-started');
+      expect(anchor).toHaveAttribute('target', '_blank');
+    });
+
+    it('sanitizes unsafe protocols on raw HTML anchors', () => {
+      const anchor = renderMarkdown('<a href="javascript:alert(1)">test</a>');
+
+      expect(anchor).not.toHaveAttribute('href', 'javascript:alert(1)');
     });
   });
 });

--- a/lib/compile.ts
+++ b/lib/compile.ts
@@ -27,7 +27,12 @@ export type CompileOpts = CompileOptions & {
 };
 
 const sanitizeSchema = deepmerge(defaultSchema, {
-  protocols: ['doc', 'ref', 'blog', 'changelog', 'page'],
+  attributes: {
+    a: ['target'],
+  },
+  protocols: {
+    href: ['doc', 'ref', 'blog', 'changelog', 'page'],
+  },
 });
 
 const compile = (


### PR DESCRIPTION
| 🎫 Resolve [CX-2812](https://linear.app/readme-io/issue/CX-2812/setting-the-target-attribute-for-a-link-in-api-reference-description) |
| :-----------------: |

## 🎯 What does this PR do?

Issue: `target=_blank` ignored for the links in the API definition description and always wraps as `_self` 

This fixes API reference descriptions losing link target attributes when rendered through @readme/markdown in rmdx markdown mode. The change updates the markdown sanitization schema to preserve a[target] while still sanitizing href protocols.

## 🧪 QA tips


https://github.com/user-attachments/assets/a18d44c9-a63b-4833-9030-57337eef4d1c

