### PR TITLE
fix: use magic block tokenizer when parsing JSX component children

### DIFF
--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -1946,4 +1946,29 @@ asdasdasd
       expect(toHtml(heading)).toContain('<a href="https://example.com">link</a>');
     });
   });
+
+  describe('magic blocks inside JSX components', () => {
+    it('should parse image block inside a Tabs component child', () => {
+      const md = `
+<Tabs>
+<Tab title="Foo">
+
+[block:image]{"images":[{"image":["https://example.com/image.png","","Alt text"],"align":"left","sizing":"50%"}]}[/block]
+
+</Tab>
+</Tabs>
+`;
+      const ast = mdxish(md);
+      const tabs = ast.children[0] as Element;
+      expect(tabs.tagName).toBe('Tabs');
+
+      const tab = tabs.children[0] as Element;
+      expect(tab.tagName).toBe('Tab');
+
+      const img = toHtml(tab);
+      expect(img).toContain('<img');
+      expect(img).toContain('example.com/image.png');
+      expect(img).not.toContain('[block:image]');
+    });
+  });
 });

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -7,8 +7,10 @@ import { unified } from 'unified';
 
 import { emptyTaskListItemFromMarkdown } from '../../../../lib/mdast-util/empty-task-list-item';
 import { legacyVariableFromMarkdown } from '../../../../lib/mdast-util/legacy-variable';
+import { magicBlockFromMarkdown } from '../../../../lib/mdast-util/magic-block';
 import { mdxComponentFromMarkdown } from '../../../../lib/mdast-util/mdx-component';
 import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
+import { magicBlock } from '../../../../lib/micromark/magic-block';
 import { mdxComponent } from '../../../../lib/micromark/mdx-component';
 
 export type MdxAttributes = (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
@@ -20,8 +22,8 @@ export type MdxAttributes = (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
  * tokenizer chain as the top-level parse.
  */
 export const inlineMdProcessor = unified()
-  .data('micromarkExtensions', [mdxComponent(), legacyVariable()])
-  .data('fromMarkdownExtensions', [mdxComponentFromMarkdown(), legacyVariableFromMarkdown(), emptyTaskListItemFromMarkdown()])
+  .data('micromarkExtensions', [mdxComponent(), legacyVariable(), magicBlock()])
+  .data('fromMarkdownExtensions', [mdxComponentFromMarkdown(), legacyVariableFromMarkdown(), emptyTaskListItemFromMarkdown(), magicBlockFromMarkdown()])
   .use(remarkParse)
   .use(remarkGfm);
 


### PR DESCRIPTION
| [Slack thread](https://readmeio.slack.com/archives/C0AU1FRRC3A/p1777053878869219) |
| :-----------------: |


Magic block syntax (e.g. [block:image]...[/block]) was rendering as plain text when placed inside custom JSX components like <Tabs>/<Tab>.

The regression was introduced in #1429, which extracted a shared inlineMdProcessor into utils.ts for re-parsing JSX component children. That processor was initialized with mdxComponent and legacyVariable extensions but was missing magicBlock, so the micromark tokenizer inside component children didn't recognize the [block:...] syntax and passed it through as literal text.

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

- Include magic block tokenizer when parsing JSX component children by adding `magicBlock()` and `magicBlockFromMarkdown()` to `inlineMdProcessor`'s extension lists

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

This snippet should render fine:
```
<Tabs>
<Tab title="Foo">

[block:image]{"images":[{"image":["https://techdocs.akamai.com/linode/compute/img/pg-added-linode-v2.png","","A screenshot of the Placement Groups page."],"align":"center","sizing":"600px","border":true}]}[/block]

</Tab>
</Tabs>
```
You can verify by pulling locally and testing locally &/or linked with the React app

## 📸 Screenshot or Loom


| Before | After |
| --- | --- |
| <img width="3396" height="1716" alt="image" src="https://github.com/user-attachments/assets/e118ca05-7f96-45b3-a527-de52c4a4ce2a" /> |  <img width="3478" height="2004" alt="CleanShot 2026-04-24 at 13 33 45@2x" src="https://github.com/user-attachments/assets/24de5cf5-0c45-465c-978d-6e42accaaaf4" /> |


