### PR TITLE
fix(mdxish): gemoji & expressions not rendering in components

### DIFF
--- a/__tests__/lib/mdxish/gemoji.test.ts
+++ b/__tests__/lib/mdxish/gemoji.test.ts
@@ -1,4 +1,8 @@
-import { mix } from '../../../lib';
+import type { Element } from 'hast';
+
+import { toHtml } from 'hast-util-to-html';
+
+import { mix, mdxish } from '../../../lib';
 
 describe('gemoji transformer', () => {
   it('should transform shortcodes back to emojis', () => {
@@ -393,6 +397,44 @@ describe('gemoji transformer', () => {
       expect(mix(md)).toMatchInlineSnapshot(
         '"<Callout icon="📘" theme="info"><h3 id="-">😁 <i class="fa-regular fa-rss-square"></i></h3><p>Hello <i class="fa-regular fa-rss-square"></i></p></Callout>"',
       );
+    });
+  });
+
+  describe('inside mdxish JSX components', () => {
+    it('should render emoji shortcodes inside a Tabs component child', () => {
+      const md = `
+<Tabs>
+<Tab title="Foo">
+
+Hello :grin::grin:
+
+</Tab>
+</Tabs>
+`;
+      const ast = mdxish(md);
+      const tabs = ast.children[0] as Element;
+      expect(tabs.tagName).toBe('Tabs');
+
+      const html = toHtml(tabs);
+      expect(html).toContain('😁😁');
+      expect(html).not.toContain(':grin:');
+    });
+
+    it('should render emoji shortcodes inside a Callout component', () => {
+      const md = `
+<Callout icon="📘">
+
+Hello :grin::grin:
+
+</Callout>
+`;
+      const ast = mdxish(md);
+      const callout = ast.children[0] as Element;
+      expect(callout.tagName).toBe('Callout');
+
+      const html = toHtml(callout);
+      expect(html).toContain('😁😁');
+      expect(html).not.toContain(':grin:');
     });
   });
 

--- a/__tests__/lib/mdxish/mdx-expressions.test.ts
+++ b/__tests__/lib/mdxish/mdx-expressions.test.ts
@@ -1,5 +1,7 @@
 import type { Element, Text } from 'hast';
 
+import { toHtml } from 'hast-util-to-html';
+
 import { describe, it, expect } from 'vitest';
 
 import { mdxish } from '../../../lib/mdxish';
@@ -640,6 +642,60 @@ Third {"3"} paragraph.`;
 
       const blockquote = ast.children.find(c => (c as Element).tagName === 'blockquote') as Element;
       expect(blockquote).toBeDefined();
+    });
+  });
+
+  describe('inside JSX components', () => {
+    it('should evaluate inline expressions inside a Tabs component child', () => {
+      const md = `
+<Tabs>
+<Tab title="Foo">
+
+The answer is {1 + 1}.
+
+</Tab>
+</Tabs>
+`;
+      const ast = mdxish(md);
+      const tabs = ast.children[0] as Element;
+      expect(tabs.tagName).toBe('Tabs');
+
+      const html = toHtml(tabs);
+      expect(html).toContain('The answer is 2');
+      expect(html).not.toContain('{1 + 1}');
+    });
+
+    it('should evaluate inline expressions inside a Callout component', () => {
+      const md = `
+<Callout icon="📘">
+
+The answer is {1 + 1}.
+
+</Callout>
+`;
+      const ast = mdxish(md);
+      const callout = ast.children[0] as Element;
+      expect(callout.tagName).toBe('Callout');
+
+      const html = toHtml(callout);
+      expect(html).toContain('The answer is 2');
+      expect(html).not.toContain('{1 + 1}');
+    });
+
+    it('should leave expressions as text inside components when safeMode is on', () => {
+      const md = `
+<Tabs>
+<Tab title="Foo">
+
+The answer is {1 + 1}.
+
+</Tab>
+</Tabs>
+`;
+      const ast = mdxish(md, { safeMode: true });
+      const tabs = ast.children[0] as Element;
+      const html = toHtml(tabs);
+      expect(html).toContain('{1 + 1}');
     });
   });
 });

--- a/processor/transform/mdxish/components/inline-html.ts
+++ b/processor/transform/mdxish/components/inline-html.ts
@@ -6,7 +6,7 @@ import { visit } from 'unist-util-visit';
 import { GENERIC_MDX_COMPONENT_EXCLUDED_TAGS } from '../../../../lib/constants';
 import { type ParseAttributesOptions, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
 
-import { hasExpressionAttr, inlineMdProcessor, isPascalCase, toMdxJsxTextElement } from './utils';
+import { getInlineMdProcessor, hasExpressionAttr, isPascalCase, toMdxJsxTextElement } from './utils';
 
 /**
  * Parse the body of an inline component as phrasing content. Remark always
@@ -17,10 +17,10 @@ import { hasExpressionAttr, inlineMdProcessor, isPascalCase, toMdxJsxTextElement
  * rejects line endings), so the paragraph-flatten path covers every case we
  * actually produce; other shapes fall back to empty children.
  */
-const parsePhrasingChildren = (value: string): PhrasingContent[] => {
+const parsePhrasingChildren = (value: string, safeMode: boolean): PhrasingContent[] => {
   const trimmed = value.trim();
   if (!trimmed) return [];
-  const [first] = inlineMdProcessor.parse(trimmed).children;
+  const [first] = getInlineMdProcessor({ safeMode }).parse(trimmed).children;
   return first?.type === 'paragraph' ? (first as Paragraph).children : [];
 };
 
@@ -34,7 +34,7 @@ const parsePhrasingChildren = (value: string): PhrasingContent[] => {
  *
  * Returns the original node unchanged when it doesn't qualify.
  */
-const promoteInlineHtml = (node: Html, parseOpts: ParseAttributesOptions): PhrasingContent => {
+const promoteInlineHtml = (node: Html, parseOpts: ParseAttributesOptions, safeMode: boolean): PhrasingContent => {
   const parsed = parseTag((node.value ?? '').trim(), parseOpts);
   if (!parsed) return node;
 
@@ -60,7 +60,7 @@ const promoteInlineHtml = (node: Html, parseOpts: ParseAttributesOptions): Phras
   if (closeIdx < 0) return node;
 
   const inner = contentAfterTag.slice(0, closeIdx);
-  return toMdxJsxTextElement(tag, attributes, parsePhrasingChildren(inner), node.position);
+  return toMdxJsxTextElement(tag, attributes, parsePhrasingChildren(inner, safeMode), node.position);
 };
 
 /**
@@ -80,11 +80,12 @@ const promoteInlineHtml = (node: Html, parseOpts: ParseAttributesOptions): Phras
  * `<a href="x">` stays as an html node for rehype-raw.
  */
 const mdxishInlineMdxHtmlBlocks: Plugin<[{ safeMode?: boolean }?], Root> = (opts = {}) => tree => {
-  const parseOpts: ParseAttributesOptions = { preserveExpressionsAsText: !!opts.safeMode };
+  const safeMode = !!opts.safeMode;
+  const parseOpts: ParseAttributesOptions = { preserveExpressionsAsText: safeMode };
 
   visit(tree, 'paragraph', (paragraph: Paragraph) => {
     paragraph.children = paragraph.children.map(child =>
-      child.type === 'html' ? promoteInlineHtml(child as Html, parseOpts) : child,
+      child.type === 'html' ? promoteInlineHtml(child as Html, parseOpts, safeMode) : child,
     );
   });
 };

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -5,7 +5,7 @@ import type { Plugin } from 'unified';
 import { GENERIC_MDX_COMPONENT_EXCLUDED_TAGS } from '../../../../lib/constants';
 import { type ParseAttributesOptions, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
 
-import { hasExpressionAttr, inlineMdProcessor, isPascalCase } from './utils';
+import { getInlineMdProcessor, hasExpressionAttr, isPascalCase } from './utils';
 
 export { parseAttributes, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
 
@@ -38,16 +38,16 @@ function safeDeindent(text: string): string {
  * Dedents the content first to prevent indented component content
  * (from nested components) from being treated as code blocks.
  */
-const parseMdChildren = (value: string): RootContent[] => {
-  const parsed = inlineMdProcessor.parse(safeDeindent(value).trim());
+const parseMdChildren = (value: string, safeMode: boolean): RootContent[] => {
+  const parsed = getInlineMdProcessor({ safeMode }).parse(safeDeindent(value).trim());
   return parsed.children || [];
 };
 
 /**
  * Parse substring content of a node and update the parent's children to include the new nodes.
  */
-const parseSibling = (stack: Parent[], parent: Parent, index: number, sibling: string) => {
-  const siblingNodes = parseMdChildren(sibling) as Node[];
+const parseSibling = (stack: Parent[], parent: Parent, index: number, sibling: string, safeMode: boolean) => {
+  const siblingNodes = parseMdChildren(sibling, safeMode) as Node[];
   // The new sibling nodes might contain new components to be processed
   if (siblingNodes.length > 0) {
     (parent.children as Node[]).splice(index + 1, 0, ...siblingNodes);
@@ -110,7 +110,8 @@ const substituteNodeWithMdxNode = (parent: Parent, index: number, mdxNode: MdxJs
  */
 const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opts = {}) => tree => {
   const stack: Parent[] = [tree];
-  const parseOpts: ParseAttributesOptions = { preserveExpressionsAsText: !!opts.safeMode };
+  const safeMode = !!opts.safeMode;
+  const parseOpts: ParseAttributesOptions = { preserveExpressionsAsText: safeMode };
 
   const processChildNode = (parent: Parent, index: number) => {
     const node = parent.children[index];
@@ -161,7 +162,7 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
       // Check and parse if there's relevant content after the current closing tag
       const remainingContent = contentAfterTag.trim();
       if (remainingContent) {
-        parseSibling(stack, parent, index, remainingContent);
+        parseSibling(stack, parent, index, remainingContent, safeMode);
       }
       return;
     }
@@ -175,7 +176,7 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
       const componentInnerContent = contentAfterTag.substring(0, closingTagIndex);
       const contentAfterClose = contentAfterTag.substring(closingTagIndex + closingTagStr.length).trim();
       let parsedChildren: MdxJsxFlowElement['children'] = componentInnerContent.trim()
-        ? (parseMdChildren(componentInnerContent) as MdxJsxFlowElement['children'])
+        ? (parseMdChildren(componentInnerContent, safeMode) as MdxJsxFlowElement['children'])
         : [];
       // Lowercase HTML tags are usually inline (e.g. <a>, <span>). Remark wraps
       // bare text in a paragraph; unwrap when there's exactly one paragraph so
@@ -193,7 +194,7 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
 
       // After the closing tag, there might be more content to be processed
       if (contentAfterClose) {
-        parseSibling(stack, parent, index, contentAfterClose);
+        parseSibling(stack, parent, index, contentAfterClose, safeMode);
       } else if (componentNode.children.length > 0) {
         // The content inside the component block might contain new components to be processed
         stack.push(componentNode as Parent);

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -19,13 +19,7 @@ import { mdxComponent } from '../../../../lib/micromark/mdx-component';
 
 export type MdxAttributes = (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
 
-/**
- * Shared unified processor for re-parsing the body of an MDX-ish component.
- * Used by both the block and inline-block transformers so a nested component
- * (e.g. `<Anchor>text with <b>bold</b></Anchor>`) goes through the same
- * tokenizer chain as the top-level parse.
- */
-export const getInlineMdProcessor = ({ safeMode = false }: { safeMode?: boolean } = {}) => {
+const buildInlineMdProcessor = (safeMode: boolean) => {
   const micromarkExts = [mdxComponent(), gemoji(), legacyVariable(), magicBlock()];
   const fromMarkdownExts = [
     mdxComponentFromMarkdown(),
@@ -35,12 +29,8 @@ export const getInlineMdProcessor = ({ safeMode = false }: { safeMode?: boolean 
     magicBlockFromMarkdown(),
   ];
 
+  // Since evaluating expressions can be dangerous, do so only when safeMode is off
   if (!safeMode) {
-    // Text-only mdx expression so `{1 + 1}` etc. inside a component body
-    // produce expression nodes that `evaluateExpressions` can later resolve,
-    // rather than falling through as literal text. Flow form is omitted on
-    // purpose to match the top-level parser, where `{...}` must not
-    // interrupt paragraphs (would break multiline magic blocks).
     const mdxExprExt = mdxExpression({ allowEmpty: true });
     micromarkExts.push({ text: mdxExprExt.text });
     fromMarkdownExts.push(mdxExpressionFromMarkdown());
@@ -51,6 +41,23 @@ export const getInlineMdProcessor = ({ safeMode = false }: { safeMode?: boolean 
     .data('fromMarkdownExtensions', fromMarkdownExts)
     .use(remarkParse)
     .use(remarkGfm);
+};
+
+const processorCache = new Map<boolean, ReturnType<typeof buildInlineMdProcessor>>();
+
+/**
+ * Unified processor for re-parsing the body of an MDX component
+ * Memoized based on the argument value so we don't pay the construction cost on every parse
+ * Currently the argument is only safeMode, but we could add more arguments in the future,
+ * in which case the key would need to be extend to include the new arguments.
+ */
+export const getInlineMdProcessor = ({ safeMode = false }: { safeMode?: boolean } = {}) => {
+  let processor = processorCache.get(safeMode);
+  if (!processor) {
+    processor = buildInlineMdProcessor(safeMode);
+    processorCache.set(safeMode, processor);
+  }
+  return processor;
 };
 
 /**

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -20,11 +20,10 @@ import { mdxComponent } from '../../../../lib/micromark/mdx-component';
 export type MdxAttributes = (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
 
 /**
- * Parse-only processor for re-parsing the body of an MDX-ish component.
- * Tokenizer extensions match the top-level parse so a nested component
+ * Shared unified processor for re-parsing the body of an MDX-ish component.
+ * Used by both the block and inline-block transformers so a nested component
  * (e.g. `<Anchor>text with <b>bold</b></Anchor>`) goes through the same
- * chain. `mdxExpression` is included only when not in safeMode, mirroring
- * the top-level parser's safeMode contract.
+ * tokenizer chain as the top-level parse.
  */
 export const getInlineMdProcessor = ({ safeMode = false }: { safeMode?: boolean } = {}) => {
   const micromarkExts = [mdxComponent(), gemoji(), legacyVariable(), magicBlock()];

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -1,14 +1,18 @@
 import type { Html, PhrasingContent } from 'mdast';
 import type { MdxJsxAttribute, MdxJsxExpressionAttribute, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 
+import { mdxExpressionFromMarkdown } from 'mdast-util-mdx-expression';
+import { mdxExpression } from 'micromark-extension-mdx-expression';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 
 import { emptyTaskListItemFromMarkdown } from '../../../../lib/mdast-util/empty-task-list-item';
+import { gemojiFromMarkdown } from '../../../../lib/mdast-util/gemoji';
 import { legacyVariableFromMarkdown } from '../../../../lib/mdast-util/legacy-variable';
 import { magicBlockFromMarkdown } from '../../../../lib/mdast-util/magic-block';
 import { mdxComponentFromMarkdown } from '../../../../lib/mdast-util/mdx-component';
+import { gemoji } from '../../../../lib/micromark/gemoji';
 import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
 import { magicBlock } from '../../../../lib/micromark/magic-block';
 import { mdxComponent } from '../../../../lib/micromark/mdx-component';
@@ -16,16 +20,39 @@ import { mdxComponent } from '../../../../lib/micromark/mdx-component';
 export type MdxAttributes = (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
 
 /**
- * Shared unified processor for re-parsing the body of an MDX-ish component.
- * Used by both the block and inline-block transformers so a nested component
+ * Parse-only processor for re-parsing the body of an MDX-ish component.
+ * Tokenizer extensions match the top-level parse so a nested component
  * (e.g. `<Anchor>text with <b>bold</b></Anchor>`) goes through the same
- * tokenizer chain as the top-level parse.
+ * chain. `mdxExpression` is included only when not in safeMode, mirroring
+ * the top-level parser's safeMode contract.
  */
-export const inlineMdProcessor = unified()
-  .data('micromarkExtensions', [mdxComponent(), legacyVariable(), magicBlock()])
-  .data('fromMarkdownExtensions', [mdxComponentFromMarkdown(), legacyVariableFromMarkdown(), emptyTaskListItemFromMarkdown(), magicBlockFromMarkdown()])
-  .use(remarkParse)
-  .use(remarkGfm);
+export const getInlineMdProcessor = ({ safeMode = false }: { safeMode?: boolean } = {}) => {
+  const micromarkExts = [mdxComponent(), gemoji(), legacyVariable(), magicBlock()];
+  const fromMarkdownExts = [
+    mdxComponentFromMarkdown(),
+    gemojiFromMarkdown(),
+    legacyVariableFromMarkdown(),
+    emptyTaskListItemFromMarkdown(),
+    magicBlockFromMarkdown(),
+  ];
+
+  if (!safeMode) {
+    // Text-only mdx expression so `{1 + 1}` etc. inside a component body
+    // produce expression nodes that `evaluateExpressions` can later resolve,
+    // rather than falling through as literal text. Flow form is omitted on
+    // purpose to match the top-level parser, where `{...}` must not
+    // interrupt paragraphs (would break multiline magic blocks).
+    const mdxExprExt = mdxExpression({ allowEmpty: true });
+    micromarkExts.push({ text: mdxExprExt.text });
+    fromMarkdownExts.push(mdxExpressionFromMarkdown());
+  }
+
+  return unified()
+    .data('micromarkExtensions', micromarkExts)
+    .data('fromMarkdownExtensions', fromMarkdownExts)
+    .use(remarkParse)
+    .use(remarkGfm);
+};
 
 /**
  * True when a tag name starts with an uppercase letter — ReadMe's marker for


### PR DESCRIPTION
## 🎯 What does this PR do?

After investigating the magic block regression fixed in #1447, I checked other syntaxes are also not rendering in components, and found that gemoji (`:smile:`) and MDX expressions (`{1 + 1}`) were also falling through.

The root cause of these regressions actually goes back to the MDX tokenizer addition itself in #1426: by capturing `<Component>...</Component>` as a single opaque html token, component inner content stopped passing through the top-level tokenizer chain and instead gets re-parsed by a separate inline subprocessor that was missing several extensions. This is only affecting the syntaxes that rely on a tokenizer.

Comparing the two extension lists, gemoji and mdx-expression are the only ones that meaningfully matter inside component bodies that needs to be added. I think one issue that lead to me not catching this is that we have several inline md processors that's we have to manually add the tokenisers, so I'm working to unify / clean them up & also understand better what tokenisers are actually needed where & potential gaps

## 🧪 QA tips

These should now render correctly:

```
<Tabs>
<Tab title="Foo">

Hello :grin::grin: — the answer is {1 + 1}.

</Tab>
</Tabs>

<Callout icon="📘">

Hello :grin::grin: — the answer is {1 + 1}.

</Callout>
```

In safeMode, \`{1 + 1}\` should remain literal text (covered by a new test).

| Before | After |
| --- | --- |
| <img width="502" height="202" alt="Screenshot 2026-04-27 at 6 12 40 pm" src="https://github.com/user-attachments/assets/213fa9c8-a984-40e8-b3cc-b7f0f446b73d" /> | <img width="493" height="214" alt="Screenshot 2026-04-27 at 6 11 55 pm" src="https://github.com/user-attachments/assets/4ead0464-a125-4572-9462-ce5bda0c29a8" /> |