### PR TITLE
fix(mdxish): move node-level transformers after MDX component re-parse

### DIFF
--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -1970,5 +1970,125 @@ asdasdasd
       expect(img).toContain('example.com/image.png');
       expect(img).not.toContain('[block:image]');
     });
+
+    it('should parse image block indented under a list item (column 3) inside a Tabs component', () => {
+      const md = `<Tabs>
+<Tab title="Foo">
+3. Baz
+   [block:image]{"images":[{"image":["https://example.com/image.png","","Alt text"]}]}[/block]
+</Tab>
+</Tabs>`;
+      const ast = mdxish(md);
+
+      expect(ast.children[0]).toMatchObject({
+        type: 'element',
+        tagName: 'Tabs',
+        children: [
+          {
+            type: 'element',
+            tagName: 'Tab',
+            properties: { title: 'Foo' },
+            children: [
+              {
+                type: 'element',
+                tagName: 'ol',
+                properties: { start: 3 },
+                children: [
+                  {
+                    type: 'text',
+                    value: '\n',
+                  },
+                  {
+                    type: 'element',
+                    tagName: 'li',
+                    children: [
+                      {
+                        type: 'text',
+                        value: 'Baz\n',
+                      },
+                      {
+                        type: 'element',
+                        tagName: 'img',
+                        properties: { src: 'https://example.com/image.png', alt: 'Alt text', title: '' },
+                      },
+                      {
+                        type: 'text',
+                        value: '\n',
+                      },
+                    ],
+                  },
+                  {
+                    type: 'text',
+                    value: '\n',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should parse image block inside a blockquote inside a Tabs component', () => {
+      const md = `<Tabs>
+<Tab title="Foo">
+
+> [block:image]{"images":[{"image":["https://example.com/image.png","","Alt text"]}]}[/block]
+
+</Tab>
+</Tabs>`;
+      const ast = mdxish(md);
+
+      expect(ast.children[0]).toMatchObject({
+        type: 'element',
+        tagName: 'Tabs',
+        children: [
+          {
+            type: 'element',
+            tagName: 'Tab',
+            properties: { title: 'Foo' },
+            children: [
+              {
+                type: 'element',
+                tagName: 'blockquote',
+                children: [
+                  {
+                    type: 'text',
+                    value: '\n',
+                  },
+                  {
+                    type: 'element',
+                    tagName: 'img',
+                    properties: { src: 'https://example.com/image.png', alt: 'Alt text', title: '' },
+                  },
+                  {
+                    type: 'text',
+                    value: '\n',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should parse image block indented under a list item inside a Callout component', () => {
+      const md = `<Callout icon="📘">
+
+3. Baz
+
+   [block:image]{"images":[{"image":["https://example.com/image.png","","Alt text"]}]}[/block]
+
+</Callout>`;
+      const ast = mdxish(md);
+      const callout = ast.children[0] as Element;
+      expect(callout.tagName).toBe('Callout');
+
+      const html = toHtml(callout);
+      expect(html).toContain('<img');
+      expect(html).toContain('example.com/image.png');
+      expect(html).not.toContain('[block:image]');
+    });
   });
 });

--- a/__tests__/lib/mdxish/mermaid.test.ts
+++ b/__tests__/lib/mdxish/mermaid.test.ts
@@ -1,0 +1,76 @@
+import type { Element } from 'hast';
+
+import { describe, it, expect } from 'vitest';
+
+import { mdxish } from '../../../lib/mdxish';
+import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
+
+/**
+ * `mdxishMermaidTransformer` adds a `mermaid-render` className to <pre>
+ * wrappers whose <code> child has `lang === 'mermaid'`. The `lang` property
+ * is populated by `codeTabsTransformer` on every `code` mdast node, so the
+ * mermaid class only lands when codeTabs has visited the node first.
+ *
+ * Both transformers now run *after* `mdxishMdxComponentBlocks` re-parses
+ * component bodies, so mermaid blocks should also work inside `<Tabs>`,
+ * `<Callout>`, lists, etc.
+ */
+describe('mermaid diagrams', () => {
+  it('adds mermaid-render class to a top-level mermaid fenced block', () => {
+    const tree = mdxish('```mermaid\ngraph TD\nA-->B\n```');
+
+    const pre = findElementByTagName(tree, 'pre');
+    expect(pre).toMatchObject({
+      type: 'element',
+      tagName: 'pre',
+      properties: { className: ['mermaid-render'] },
+    });
+  });
+
+  describe('nested inside components', () => {
+    it('adds mermaid-render class when nested inside <Tabs><Tab>', () => {
+      const tree = mdxish('<Tabs>\n<Tab title="x">\n\n```mermaid\ngraph TD\nA-->B\n```\n\n</Tab>\n</Tabs>');
+
+      const pre = findElementByTagName(tree, 'pre');
+      expect(pre).toMatchObject({
+        type: 'element',
+        tagName: 'pre',
+        properties: { className: ['mermaid-render'] },
+      });
+
+      const code = findElementByTagName(pre as Element, 'code');
+      expect(code).toMatchObject({
+        properties: { className: ['language-mermaid'], lang: 'mermaid' },
+      });
+    });
+
+    it('adds mermaid-render class when nested inside <Callout>', () => {
+      const tree = mdxish('<Callout icon="📘">\n\n```mermaid\ngraph TD\nA-->B\n```\n\n</Callout>');
+
+      const pre = findElementByTagName(tree, 'pre');
+      expect(pre).toMatchObject({
+        type: 'element',
+        tagName: 'pre',
+        properties: { className: ['mermaid-render'] },
+      });
+    });
+
+    it('adds mermaid-render class to a mermaid block nested inside a list inside <Tabs>', () => {
+      const tree = mdxish(
+        '<Tabs>\n<Tab title="x">\n\n1. Step\n\n   ```mermaid\n   graph TD\n   A-->B\n   ```\n\n</Tab>\n</Tabs>',
+      );
+
+      const pres = findAllElementsByTagName(tree, 'pre');
+      const mermaidPre = pres.find(p => Array.isArray(p.properties?.className) && p.properties.className.includes('mermaid-render'));
+      expect(mermaidPre).toBeDefined();
+    });
+
+    it('does NOT add mermaid-render class to non-mermaid fenced blocks inside components', () => {
+      const tree = mdxish('<Tabs>\n<Tab title="x">\n\n```js\nconst x = 1;\n```\n\n</Tab>\n</Tabs>');
+
+      const pre = findElementByTagName(tree, 'pre');
+      const className = pre?.properties?.className;
+      expect(Array.isArray(className) ? className : []).not.toContain('mermaid-render');
+    });
+  });
+});

--- a/__tests__/transformers/callouts.test.ts
+++ b/__tests__/transformers/callouts.test.ts
@@ -1,4 +1,5 @@
 import type { Callout } from '../../types';
+import type { Element } from 'hast';
 import type { Blockquote, Heading, List, Paragraph } from 'mdast';
 
 import remarkGfm from 'remark-gfm';
@@ -7,7 +8,9 @@ import { unified } from 'unified';
 import { removePosition } from 'unist-util-remove-position';
 
 import { mdast } from '../../index';
+import { mdxish } from '../../lib/mdxish';
 import calloutTransformer from '../../processor/transform/callouts';
+import { findAllElementsByTagName, findElementByTagName } from '../helpers';
 
 const mdxishMdast = (md: string) => {
   const processor = unified().use(remarkParse).use(remarkGfm).use(calloutTransformer, { isMdxish: true });
@@ -763,6 +766,51 @@ describe('callouts transformer', () => {
           child.children?.some(c => c.type === 'image' && c.url === 'https://example.com/image.png'),
       );
       expect(hasImage).toBe(true);
+    });
+  });
+
+  describe('in mdxish', () => {
+    describe('inside MDX/JSX components', () => {
+      it('converts a blockquote callout inside <Tabs><Tab> to a <Callout> element', () => {
+        const tree = mdxish('<Tabs>\n<Tab title="x">\n\n> 📘 Note\n>\n> body text\n\n</Tab>\n</Tabs>');
+
+        const callout = findElementByTagName(tree, 'Callout');
+        expect(callout).toMatchObject({
+          type: 'element',
+          tagName: 'Callout',
+          properties: { icon: '📘', theme: 'info' },
+        });
+
+        // Title becomes <h3> inside the Callout
+        const heading = findElementByTagName(callout as Element, 'h3');
+        expect(heading).toMatchObject({
+          type: 'element',
+          tagName: 'h3',
+          children: [{ type: 'text', value: 'Note' }],
+        });
+      });
+
+      it('converts a blockquote callout inside a list item inside <Tabs>', () => {
+        const tree = mdxish(
+          '<Tabs>\n<Tab title="x">\n\n1. Step\n\n   > ❗️ Warning\n   >\n   > careful\n\n</Tab>\n</Tabs>',
+        );
+
+        const callout = findElementByTagName(tree, 'Callout');
+        expect(callout).toMatchObject({
+          type: 'element',
+          tagName: 'Callout',
+          properties: { icon: '❗️', theme: 'error' },
+        });
+      });
+
+      it('converts a blockquote callout inside another <Callout> wrapper', () => {
+        const tree = mdxish('<Callout icon="📘">\n\n> ❗️ Inner\n>\n> body\n\n</Callout>');
+
+        const callouts = findAllElementsByTagName(tree, 'Callout');
+        expect(callouts).toHaveLength(2);
+        expect(callouts[0].properties).toMatchObject({ icon: '📘' });
+        expect(callouts[1].properties).toMatchObject({ icon: '❗️', theme: 'error' });
+      });
     });
   });
 });

--- a/__tests__/transformers/code-tabs.test.ts
+++ b/__tests__/transformers/code-tabs.test.ts
@@ -1,4 +1,8 @@
+import type { Element } from 'hast';
+
 import { mdast, hast } from '../../index';
+import { mdxish } from '../../lib/mdxish';
+import { findAllElementsByTagName, findElementByTagName } from '../helpers';
 
 describe('Code Tabs Transformer', () => {
   it('can parse code tabs', () => {
@@ -107,5 +111,90 @@ Second code block
 
     expect(tree.children[0].children[0].children[0].type).toBe('code-tabs');
     expect(tree.children[0].children[0].children).toHaveLength(1);
+  });
+
+  describe('in mdxish', () => {
+    describe('inside MDX/JSX components', () => {
+      it('wraps a fenced code block inside <Tabs><Tab> in <CodeTabs>', () => {
+        const tree = mdxish('<Tabs>\n<Tab title="x">\n\n```js\nconst x = 1;\n```\n\n</Tab>\n</Tabs>');
+
+        const codeTabs = findElementByTagName(tree, 'CodeTabs');
+        expect(codeTabs).toMatchObject({
+          type: 'element',
+          tagName: 'CodeTabs',
+          children: [
+            {
+              type: 'element',
+              tagName: 'pre',
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'code',
+                  properties: {
+                    className: ['language-js'],
+                    lang: 'js',
+                    value: 'const x = 1;',
+                  },
+                },
+              ],
+            },
+          ],
+        });
+      });
+
+      it('wraps a fenced code block inside <Callout> in <CodeTabs>', () => {
+        const tree = mdxish('<Callout icon="📘">\n\n```python\nprint("hi")\n```\n\n</Callout>');
+
+        const codeTabs = findElementByTagName(tree, 'CodeTabs');
+        expect(codeTabs).not.toBeNull();
+        const code = findElementByTagName(codeTabs as Element, 'code');
+        expect(code).toMatchObject({
+          type: 'element',
+          tagName: 'code',
+          properties: {
+            className: ['language-python'],
+            lang: 'python',
+            value: 'print("hi")',
+          },
+        });
+      });
+
+      it('merges adjacent code blocks of different languages into a single <CodeTabs> inside <Tabs>', () => {
+        const tree = mdxish(
+          '<Tabs>\n<Tab title="x">\n\n```js\nconst x = 1;\n```\n```py\nx = 1\n```\n\n</Tab>\n</Tabs>',
+        );
+
+        const allCodeTabs = findAllElementsByTagName(tree, 'CodeTabs');
+        expect(allCodeTabs).toHaveLength(1);
+
+        const pres = findAllElementsByTagName(allCodeTabs[0], 'pre');
+        expect(pres).toHaveLength(2);
+        expect((pres[0].children[0] as Element).properties).toMatchObject({ lang: 'js' });
+        expect((pres[1].children[0] as Element).properties).toMatchObject({ lang: 'py' });
+      });
+
+      it('does NOT wrap a single code block with no language inside <Tabs>', () => {
+        // Mirrors the top-level rule at code-tabs.ts:52: a single code block
+        // with neither lang nor meta stays as plain <pre><code>.
+        const tree = mdxish('<Tabs>\n<Tab title="x">\n\n```\nplain text\n```\n\n</Tab>\n</Tabs>');
+
+        expect(findElementByTagName(tree, 'CodeTabs')).toBeNull();
+        const code = findElementByTagName(tree, 'code');
+        expect(code).toMatchObject({ type: 'element', tagName: 'code' });
+      });
+
+      it('wraps a fenced code block nested inside a list item inside <Tabs>', () => {
+        const tree = mdxish(
+          '<Tabs>\n<Tab title="x">\n\n1. Step\n\n   ```js\n   const x = 1;\n   ```\n\n</Tab>\n</Tabs>',
+        );
+
+        const codeTabs = findElementByTagName(tree, 'CodeTabs');
+        expect(codeTabs).not.toBeNull();
+        const code = findElementByTagName(codeTabs as Element, 'code');
+        expect(code).toMatchObject({
+          properties: { className: ['language-js'], lang: 'js' },
+        });
+      });
+    });
   });
 });

--- a/__tests__/transformers/embeds.test.ts
+++ b/__tests__/transformers/embeds.test.ts
@@ -1,4 +1,6 @@
 import { mdast } from '../../index';
+import { mdxish } from '../../lib/mdxish';
+import { findElementByTagName } from '../helpers';
 
 describe('embeds transformer', () => {
   it('converts a link with a title of "@embed" to an embed-block', () => {
@@ -9,5 +11,50 @@ describe('embeds transformer', () => {
 
     expect(tree.children[0].type).toBe('embed-block');
     expect(tree.children[0].data.hProperties.title).toBe('alt');
+  });
+
+  describe('in mdxish', () => {
+    describe('inside MDX/JSX components', () => {
+      it('converts an @embed link inside <Tabs><Tab> to an <embed> element', () => {
+        const tree = mdxish(
+          '<Tabs>\n<Tab title="x">\n\n[doc](https://example.com/cool.pdf "@embed")\n\n</Tab>\n</Tabs>',
+        );
+
+        const embed = findElementByTagName(tree, 'embed');
+        expect(embed).toMatchObject({
+          type: 'element',
+          tagName: 'embed',
+          properties: { url: 'https://example.com/cool.pdf', title: 'doc' },
+          children: [],
+        });
+      });
+
+      it('converts an @embed link inside <Callout> to an <embed> element', () => {
+        const tree = mdxish(
+          '<Callout icon="📘">\n\n[doc](https://example.com/cool.pdf "@embed")\n\n</Callout>',
+        );
+
+        const embed = findElementByTagName(tree, 'embed');
+        expect(embed).toMatchObject({
+          type: 'element',
+          tagName: 'embed',
+          properties: { url: 'https://example.com/cool.pdf', title: 'doc' },
+        });
+      });
+
+      it('does NOT convert a regular link (no @embed title) inside <Tabs>', () => {
+        const tree = mdxish(
+          '<Tabs>\n<Tab title="x">\n\n[doc](https://example.com/cool.pdf)\n\n</Tab>\n</Tabs>',
+        );
+
+        expect(findElementByTagName(tree, 'embed')).toBeNull();
+        const link = findElementByTagName(tree, 'a');
+        expect(link).toMatchObject({
+          type: 'element',
+          tagName: 'a',
+          properties: { href: 'https://example.com/cool.pdf' },
+        });
+      });
+    });
   });
 });

--- a/__tests__/transformers/images.test.ts
+++ b/__tests__/transformers/images.test.ts
@@ -1,4 +1,6 @@
 import { mdast } from '../../index';
+import { mdxish } from '../../lib/mdxish';
+import { findElementByTagName } from '../helpers';
 
 describe('images transformer', () => {
   it('converts single children images of paragraphs to an image-block', () => {
@@ -39,5 +41,46 @@ describe('images transformer', () => {
     expect(tree.children[0].border).toBe(true);
     expect(tree.children[0].title).toBe('Testing');
     expect(tree.children[0].width).toBe('100px');
+  });
+
+  describe('in mdxish', () => {
+    describe('inside MDX components (mdxish pipeline)', () => {
+      it('renders a markdown image inside <Tabs><Tab> as <img> with src and alt', () => {
+        const tree = mdxish('<Tabs>\n<Tab title="x">\n\n![my alt](https://example.com/img.png)\n\n</Tab>\n</Tabs>');
+
+        const img = findElementByTagName(tree, 'img');
+        expect(img).toMatchObject({
+          type: 'element',
+          tagName: 'img',
+          properties: {
+            src: 'https://example.com/img.png',
+            alt: 'my alt',
+          },
+          children: [],
+        });
+      });
+
+      it('renders a markdown image inside <Callout> as <img>', () => {
+        const tree = mdxish('<Callout icon="📘">\n\n![alt](https://example.com/img.png)\n\n</Callout>');
+
+        const img = findElementByTagName(tree, 'img');
+        expect(img).toMatchObject({
+          type: 'element',
+          tagName: 'img',
+          properties: { src: 'https://example.com/img.png', alt: 'alt' },
+        });
+      });
+
+      it('renders an image nested inside a list item inside <Tabs>', () => {
+        const tree = mdxish(
+          '<Tabs>\n<Tab title="x">\n\n1. Step\n\n   ![alt](https://example.com/img.png)\n\n</Tab>\n</Tabs>',
+        );
+
+        const img = findElementByTagName(tree, 'img');
+        expect(img).toMatchObject({
+          properties: { src: 'https://example.com/img.png', alt: 'alt' },
+        });
+      });
+    });
   });
 });

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -188,7 +188,6 @@ export function mdxishAstProcessor(mdContent: string, opts: MdxishOpts = {}) {
     .use(remarkParse)
     .use(remarkFrontmatter)
     .use(normalizeEmphasisAST)
-    .use(magicBlockTransformer)
     .use(imageTransformer, { isMdxish: true })
     .use(defaultTransformers)
     .use(mdxishSelfClosingBlocks)
@@ -197,6 +196,7 @@ export function mdxishAstProcessor(mdContent: string, opts: MdxishOpts = {}) {
     .use(restoreSnakeCaseComponentNames, { mapping: snakeCaseMapping })
     .use(mdxishTables)
     .use(mdxishHtmlBlocks)
+    .use(magicBlockTransformer)
     .use(newEditorTypes ? mdxishInlineMdxComponents : undefined) // Merge inline html components (e.g. <Anchor>) into MDAST nodes
     .use(newEditorTypes ? mdxishJsxToMdast : undefined) // Convert block JSX elements to MDAST types
     .use(variablesTextTransformer) // Parse {user.*} patterns from text nodes

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -188,8 +188,6 @@ export function mdxishAstProcessor(mdContent: string, opts: MdxishOpts = {}) {
     .use(remarkParse)
     .use(remarkFrontmatter)
     .use(normalizeEmphasisAST)
-    .use(imageTransformer, { isMdxish: true })
-    .use(defaultTransformers)
     .use(mdxishSelfClosingBlocks)
     .use(mdxishMdxComponentBlocks, { safeMode })
     .use(mdxishInlineMdxHtmlBlocks, { safeMode })
@@ -197,6 +195,8 @@ export function mdxishAstProcessor(mdContent: string, opts: MdxishOpts = {}) {
     .use(mdxishTables)
     .use(mdxishHtmlBlocks)
     .use(magicBlockTransformer)
+    .use(imageTransformer, { isMdxish: true })
+    .use(defaultTransformers)
     .use(newEditorTypes ? mdxishInlineMdxComponents : undefined) // Merge inline html components (e.g. <Anchor>) into MDAST nodes
     .use(newEditorTypes ? mdxishJsxToMdast : undefined) // Convert block JSX elements to MDAST types
     .use(variablesTextTransformer) // Parse {user.*} patterns from text nodes

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -194,6 +194,9 @@ export function mdxishAstProcessor(mdContent: string, opts: MdxishOpts = {}) {
     .use(restoreSnakeCaseComponentNames, { mapping: snakeCaseMapping })
     .use(mdxishTables)
     .use(mdxishHtmlBlocks)
+    // The next few transformers must appear after mdxishMdxComponentBlocks
+    // so nodes produced by the inline re-parse of component bodies
+    // (e.g. code/image/embed inside <Tabs>) get visited too
     .use(magicBlockTransformer)
     .use(imageTransformer, { isMdxish: true })
     .use(defaultTransformers)


### PR DESCRIPTION
| 🎫 Resolve [RM-16252](https://linear.app/readme-io/issue/RM-16252/mdxish-does-not-properly-parse-magic-blocks-within-lists-within-jsx) | 
| :--------------------------------------------------------------------------------------------------------------------------------------------: | 

## 🎯 What does this PR do?

Sibling fix to #1447 and #1449 based on more regressions uncovered from the MDX tokenizer integration in #1426, specifically to resolve the issues where content inside MDX components such as magic blocks in a list item not rendering (what happened in this ticket), and some default transformers not working in them. I also found some related pre-existing issues such as code tabs not tabbed and mermaid diagrams not rendering that has the same fix with this.

Tracing back to #1426: by capturing `<Component>...</Component>` as a single opaque html token, component inner content is now re-parsed by the inline subprocessor in `mdxishMdxComponentBlocks`. But `magicBlockTransformer`, `imageTransformer`, and `defaultTransformers` (callouts, codeTabs, embeds) ran *before* this re-parse, so the fresh mdast nodes produced from component bodies were never visited — they survived into the rehype phase as raw text or unstyled HTML.

The fix moves these transformers to run *after* `mdxishMdxComponentBlocks` and `mdxishInlineMdxHtmlBlocks`, so they see nodes from both the top-level parse and the component-body re-parse in a single pass. Their relative order to each other is preserved (`magicBlockTransformer` → `imageTransformer` → callouts/codeTabs/embeds), and moving them back in the pipeline didn't cause any noticeable regressions and only made them more useful.

This also automatically fixes the mermaid case: `mdxishMermaidTransformer` keys on `code.properties.lang === 'mermaid'`, which is set by `codeTabsTransformer`. Since codeTabs now visits component-body code nodes, mermaid's check works there too.

## 🧪 QA tips

These should now render correctly inside MDX components, we're using `<Tabs>` and `<Callout>` as examples:

1. Consecutive code blocks should be tabbed:
````
<Tabs>
<Tab title="x">
```js
const x = 1;
```
```python
print('hello')
```
</Tab>
</Tabs>
````

2. Mermaid diagrams should get rendered:
````
<Tabs>
<Tab title="x">
```mermaid                                                                                  
graph TD                                                       
A-->B                                                                                       
```
</Tab>
</Tabs>
````

3. Blockquote callouts become `<Callout>` elements with its styling:
```
<Tabs>
<Tab title="x">

> 📘 Note
>
> body text

</Tab>
</Tabs>
```

4. Markdown images and `@embed` links render properly:
```
<Callout icon="📘">

![alt](https://as1.ftcdn.net/v2/jpg/03/75/41/52/1000_F_375415241_OeJZkvxvj11YfhrwVWunsA14LU8FnbL1.jpg)

[doc](https://example.com/cool.pdf "@embed")

</Callout>
```

5. Magic blocks nested inside lists inside components render (the main regression in the relevant ticket):
```
<Tabs>
<Tab title="x">

## Bar

3. Baz

   [block:image]{"images":[{"image":["https://as1.ftcdn.net/v2/jpg/03/75/41/52/1000_F_375415241_OeJZkvxvj11YfhrwVWunsA14LU8FnbL1.jpg","","alt"]}]}[/block]

</Tab>
</Tabs>
```

| Before | After |
| --- | --- |
| <img width="1243" height="787" alt="Screenshot 2026-04-28 at 3 50 06 pm" src="https://github.com/user-attachments/assets/6d125c92-d53d-4173-b6d3-35befda6ae26" /> | <img width="1252" height="787" alt="Screenshot 2026-04-28 at 3 50 16 pm" src="https://github.com/user-attachments/assets/c2cd000d-e53a-47b7-8f12-99b455a7505b" /> |