### PR TITLE
fix(mdxish): multiple consecutive magic blocks under a list item not rendering & out of order

### DIFF
--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -1,9 +1,9 @@
-import type { Element, Text } from 'hast';
+import type { Element, Parent, RootContent, Text } from 'hast';
 
 import { toHtml } from 'hast-util-to-html';
 
 import { mdxish } from '../../../lib';
-import { findElementByTagName } from '../../helpers';
+import { findElementByTagName, parseMdxish } from '../../helpers';
 
 describe('mdxish magic blocks', () => {
   describe('image block', () => {
@@ -1387,6 +1387,165 @@ ${JSON.stringify(
 
       const nestedUl = secondLi.children.find((c): c is Element => c.type === 'element' && c.tagName === 'ul');
       expect(nestedUl).toBeDefined();
+    });
+
+    it('should lift two consecutive magic blocks under a list item out of the paragraph in source order', () => {
+      const md = `- Item two
+[block:callout]
+{"type":"info","title":"first","body":"one"}
+[/block]
+[block:callout]
+{"type":"info","title":"second","body":"two"}
+[/block]`;
+
+      const tree = parseMdxish(md);
+
+      expect(tree.children).toHaveLength(1);
+      const list = tree.children[0] as RootContent;
+      expect(list.type).toBe('list');
+      expect((list as Parent).children).toHaveLength(1);
+
+      const li = (list as Parent).children[0] as Parent;
+      // listItem holds the leading paragraph and the two lifted Callouts in source order.
+      expect(li.children).toHaveLength(3);
+      expect(li.children[0]).toMatchObject({
+        type: 'paragraph',
+        children: [{ type: 'text', value: 'Item two\n' }],
+      });
+      expect(li.children[1]).toMatchObject({
+        type: 'mdxJsxFlowElement',
+        name: 'Callout',
+        children: [
+          { type: 'heading', depth: 3, children: [{ type: 'text', value: 'first' }] },
+          { type: 'paragraph', children: [{ type: 'text', value: 'one' }] },
+        ],
+      });
+      expect(li.children[2]).toMatchObject({
+        type: 'mdxJsxFlowElement',
+        name: 'Callout',
+        children: [
+          { type: 'heading', depth: 3, children: [{ type: 'text', value: 'second' }] },
+          { type: 'paragraph', children: [{ type: 'text', value: 'two' }] },
+        ],
+      });
+    });
+
+    it('should place trailing text after a magic block (not before it) when both share a list-item paragraph', () => {
+      const md = `- Item two
+[block:callout]
+{"type":"info","title":"hi","body":"body"}
+[/block]
+trailing text`;
+
+      const tree = parseMdxish(md);
+      expect(tree.children[0]).toMatchObject({
+        type: 'list',
+        children: [
+          {
+            type: 'listItem',
+            children: [
+              {
+                type: 'paragraph',
+                children: [{ type: 'text', value: 'Item two\n' }],
+              },
+              {
+                type: 'mdxJsxFlowElement',
+                name: 'Callout',
+              },
+              {
+                type: 'paragraph',
+                children: [{ type: 'text', value: '\ntrailing text' }],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should lift mixed block types (callout + html-block) consecutively under a list item', () => {
+      const md = `- Item
+[block:callout]
+{"type":"info","title":"hi","body":"body"}
+[/block]
+[block:html]
+{"html":"<div>raw</div>"}
+[/block]`;
+
+      const tree = parseMdxish(md);
+      const li = (tree.children[0] as Parent).children[0] as Parent;
+
+      expect(li.children).toHaveLength(3);
+      expect(li.children[1]).toMatchObject({ type: 'mdxJsxFlowElement', name: 'Callout' });
+      expect(li.children[2]).toMatchObject({ type: 'html-block' });
+    });
+
+    it('should render mix of magic blocks and text interleaved under a list item', () => {
+      const md = `- first line
+[block:callout]
+{"type":"info","title":"first","body":"one"}
+[/block]
+second line
+[block:image]
+{"images":[{"image":["https://example.com/image.png",null,"Image"]}]}
+[/block]
+third line
+[block:image]
+{"images":[{"image":["https://example.com/image.png",null,"Image"]}]}
+[/block]
+fourth line
+`;
+
+      const ast = parseMdxish(md);
+      expect(ast.children[0]).toMatchObject({
+        type: 'list',
+        children: [
+          {
+            type: 'listItem',
+            children: [
+              {
+                type: 'paragraph',
+                children: [{ type: 'text', value: 'first line\n' }],
+              },
+              {
+                type: 'mdxJsxFlowElement',
+                name: 'Callout',
+              },
+              {
+                type: 'paragraph',
+                children: [
+                  { type: 'text', value: '\nsecond line\n' },
+                  { type: 'image', url: 'https://example.com/image.png' },
+                  { type: 'text', value: '\nthird line\n' },
+                  { type: 'image', url: 'https://example.com/image.png' },
+                  { type: 'text', value: '\nfourth line' },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('lifting magic blocks out of paragraphs at root', () => {
+    it('should split a paragraph around a lifted block, preserving leading and trailing text', () => {
+      const md = `before text
+[block:callout]
+{"type":"info","title":"hi","body":"body"}
+[/block]
+after text`;
+
+      const tree = parseMdxish(md);
+      expect(tree.children).toHaveLength(3);
+      expect(tree.children[0]).toMatchObject({
+        type: 'paragraph',
+        children: [{ type: 'text', value: 'before text' }],
+      });
+      expect(tree.children[1]).toMatchObject({ type: 'mdxJsxFlowElement', name: 'Callout' });
+      expect(tree.children[2]).toMatchObject({
+        type: 'paragraph',
+        children: [{ type: 'text', value: 'after text' }],
+      });
     });
   });
 

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -65,6 +65,17 @@ import {
 } from './placeholder';
 
 /**
+ * To be used when trying to lift a block node out of a paragraph
+ * since it can't be in a paragraph
+ */
+interface NodeLiftEvent {
+  childrenBlockNodes: RootContent[];
+  grandparent: Parent;
+  node: MagicBlockNode;
+  parent: Paragraph;
+}
+
+/**
  * Wraps a node in a "pinned" container if sidebar: true is set.
  */
 const wrapPinnedBlocks = (node: MdastNode, data: MagicBlockJson): MdastNode => {
@@ -652,12 +663,6 @@ const isWhitespacePhrasing = (node: PhrasingContent): boolean =>
 const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> =
   (options = {}) =>
   tree => {
-    interface NodeLiftEvent {
-      childrenBlockNodes: RootContent[];
-      grandparent: Parent;
-      node: MagicBlockNode;
-      parent: Paragraph;
-    }
     const lifts: NodeLiftEvent[] = [];
 
     visitParents(tree, 'magicBlock', (node: MagicBlockNode, ancestors: Parent[]) => {

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -20,7 +20,7 @@ import type {
 } from './types';
 import type { MagicBlockNode } from '../../../../lib/mdast-util/magic-block/types';
 import type { Root as HastRoot, Text as HastText, Element as HastElement, ElementContent } from 'hast';
-import type { Root as MdastRoot, RootContent, Parent } from 'mdast';
+import type { Root as MdastRoot, RootContent, Parent, Paragraph, PhrasingContent } from 'mdast';
 import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 import type { Plugin } from 'unified';
 
@@ -637,19 +637,29 @@ const blockTypes = [
  */
 const isBlockNode = (node: RootContent): boolean => blockTypes.includes(node.type);
 
+const isParagraph = (node: Parent): node is Paragraph => node.type === 'paragraph';
+
+/**
+ * True for phrasing content that contributes only whitespace at render time
+ * (a soft `break` node or a text node with no non-whitespace characters).
+ */
+const isWhitespacePhrasing = (node: PhrasingContent): boolean =>
+  node.type === 'break' || (node.type === 'text' && !node.value.trim());
+
 /**
  * Unified plugin that transforms magicBlock nodes into final MDAST nodes.
  */
 const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> =
   (options = {}) =>
   tree => {
-    const replacements: {
+    interface Lift {
       blockNodes: RootContent[];
       container: Parent;
-      inlineNodes: RootContent[];
+      inlineNodes: PhrasingContent[];
       node: MagicBlockNode;
-      parent: Parent;
-    }[] = [];
+      paragraph: Paragraph;
+    }
+    const lifts: Lift[] = [];
 
     visitParents(tree, 'magicBlock', (node: MagicBlockNode, ancestors: Parent[]) => {
       const parent = ancestors[ancestors.length - 1]; // direct parent of the current node
@@ -671,12 +681,18 @@ const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> 
       }
 
       // If parent is a paragraph and we're inserting block nodes (which must not be in paragraphs), lift them out
-      if (parent.type === 'paragraph' && children.some(child => isBlockNode(child))) {
+      if (isParagraph(parent) && children.some(isBlockNode)) {
         const blockNodes: RootContent[] = [];
-        const inlineNodes: RootContent[] = [];
+        const inlineNodes: PhrasingContent[] = [];
 
         children.forEach(child => {
-          (isBlockNode(child) ? blockNodes : inlineNodes).push(child);
+          if (isBlockNode(child)) {
+            blockNodes.push(child);
+          } else {
+            // Non-block children produced by transformMagicBlock are valid
+            // phrasing content and belong inside the paragraph.
+            inlineNodes.push(child as PhrasingContent);
+          }
         });
 
         // Defer the lift to a second pass — we don't precompute before/after
@@ -684,24 +700,24 @@ const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> 
         // and snapshots taken at visit-time would go stale once a sibling is
         // processed (see the regression where two magic blocks under a list
         // item caused the second one's raw text to leak back into the paragraph).
-        replacements.push({
-          container: ancestors[ancestors.length - 2] || tree, // grandparent of the current node
-          parent,
+        lifts.push({
           blockNodes,
+          container: ancestors[ancestors.length - 2] || tree, // grandparent of the current node
           inlineNodes,
           node,
+          paragraph: parent,
         });
       } else {
         parent.children.splice(index, 1, ...children);
       }
     });
 
-    // Second pass: apply replacements that require lifting block nodes out of paragraphs.
+    // Second pass: apply lifts that move block nodes out of paragraphs.
     // Operate on live state (find each node's current index now) and process in reverse so
     // that container insertions don't disturb earlier paragraphs' positions.
-    for (let i = replacements.length - 1; i >= 0; i -= 1) {
-      const { blockNodes, container, inlineNodes, node, parent } = replacements[i];
-      const liveIndex = parent.children.indexOf(node as unknown as RootContent);
+    for (let i = lifts.length - 1; i >= 0; i -= 1) {
+      const { blockNodes, container, inlineNodes, node, paragraph } = lifts[i];
+      const liveIndex = paragraph.children.indexOf(node);
       if (liveIndex === -1) {
         // eslint-disable-next-line no-continue
         continue;
@@ -709,28 +725,23 @@ const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> 
 
       // Snapshot live siblings — these are correct now (sibling magicBlocks for this
       // paragraph were already lifted by earlier reverse-order iterations).
-      const beforeChildren = parent.children.slice(0, liveIndex) as RootContent[];
-      const afterChildren = parent.children.slice(liveIndex + 1) as RootContent[];
+      const before = paragraph.children.slice(0, liveIndex);
+      const after = paragraph.children.slice(liveIndex + 1);
 
       // The newline that originally separated the magic block from its surrounding
-      // text now sits as a leading `break` (or whitespace-only text) on the trailing
+      // text now sits as a leading break (or whitespace-only text) on the trailing
       // siblings, and a trailing one on the leading siblings. Drop those so the
       // lifted block doesn't render with an extra blank line on either side.
-      const isWhitespaceOnly = (n: RootContent): boolean =>
-        n.type === 'break' || (n.type === 'text' && !/\S/.test((n as { value: string }).value));
-      while (beforeChildren.length > 0 && isWhitespaceOnly(beforeChildren[beforeChildren.length - 1])) {
-        beforeChildren.pop();
-      }
-      while (afterChildren.length > 0 && isWhitespaceOnly(afterChildren[0])) {
-        afterChildren.shift();
-      }
+      while (before.length > 0 && isWhitespacePhrasing(before[before.length - 1])) before.pop();
+      while (after.length > 0 && isWhitespacePhrasing(after[0])) after.shift();
 
-      const containerChildren = container.children as RootContent[];
-      const paraIndex = containerChildren.indexOf(parent as RootContent);
-
+      const paraIndex = container.children.indexOf(paragraph);
       if (paraIndex === -1) {
-        // Paragraph not found in container — splice block + inline nodes in place.
-        parent.children.splice(liveIndex, 1, ...blockNodes, ...inlineNodes);
+        // Defensive: paragraph isn't in the container we expected (tree was
+        // mutated between visit and apply). Drop just the magic block from the
+        // paragraph and place its inline portion in its slot — we can't safely
+        // lift block nodes out without a known container.
+        paragraph.children.splice(liveIndex, 1, ...inlineNodes);
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -739,18 +750,19 @@ const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> 
       // produced by the transform), then insert lifted blocks after the paragraph,
       // followed by a new paragraph for any trailing content. This preserves
       // source order: text-before, lifted block, text-after.
-      parent.children = [...beforeChildren, ...inlineNodes];
+      paragraph.children = [...before, ...inlineNodes];
 
       const insertions: RootContent[] = [...blockNodes];
-      if (afterChildren.length > 0) {
-        insertions.push({ type: 'paragraph', children: afterChildren } as unknown as RootContent);
+      if (after.length > 0) {
+        const trailing: Paragraph = { type: 'paragraph', children: after };
+        insertions.push(trailing);
       }
 
-      if (parent.children.length === 0) {
+      if (paragraph.children.length === 0) {
         // Original paragraph would be empty — drop it and put insertions in its place.
-        containerChildren.splice(paraIndex, 1, ...insertions);
+        container.children.splice(paraIndex, 1, ...insertions);
       } else {
-        containerChildren.splice(paraIndex + 1, 0, ...insertions);
+        container.children.splice(paraIndex + 1, 0, ...insertions);
       }
     }
   };

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -644,11 +644,10 @@ const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> 
   (options = {}) =>
   tree => {
     const replacements: {
-      after: RootContent[];
-      before: RootContent[];
       blockNodes: RootContent[];
       container: Parent;
       inlineNodes: RootContent[];
+      node: MagicBlockNode;
       parent: Parent;
     }[] = [];
 
@@ -680,44 +679,52 @@ const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> 
           (isBlockNode(child) ? blockNodes : inlineNodes).push(child);
         });
 
+        // Defer the lift to a second pass — we don't precompute before/after
+        // here because multiple magicBlocks may share the same paragraph parent,
+        // and snapshots taken at visit-time would go stale once a sibling is
+        // processed (see the regression where two magic blocks under a list
+        // item caused the second one's raw text to leak back into the paragraph).
         replacements.push({
           container: ancestors[ancestors.length - 2] || tree, // grandparent of the current node
           parent,
           blockNodes,
           inlineNodes,
-          before: parent.children.slice(0, index) as RootContent[],
-          after: parent.children.slice(index + 1) as RootContent[],
+          node,
         });
       } else {
         parent.children.splice(index, 1, ...children);
       }
     });
 
-    // Second pass: apply replacements that require lifting block nodes out of paragraphs
-    // Process in reverse order to maintain correct indices
+    // Second pass: apply replacements that require lifting block nodes out of paragraphs.
+    // Operate on live state (find each node's current index now) and process in reverse so
+    // that container insertions don't disturb earlier paragraphs' positions.
     for (let i = replacements.length - 1; i >= 0; i -= 1) {
-      const { after, before, blockNodes, container, inlineNodes, parent } = replacements[i];
-      const containerChildren = container.children as RootContent[];
-      const paraIndex = containerChildren.indexOf(parent as RootContent);
-
-      if (paraIndex === -1) {
-        parent.children.splice(before.length, 1, ...blockNodes, ...inlineNodes);
+      const { blockNodes, container, inlineNodes, node, parent } = replacements[i];
+      const liveIndex = parent.children.indexOf(node as unknown as RootContent);
+      if (liveIndex === -1) {
         // eslint-disable-next-line no-continue
         continue;
       }
 
-      if (inlineNodes.length > 0) {
-        parent.children = [...before, ...inlineNodes, ...after];
-        if (blockNodes.length > 0) {
-          containerChildren.splice(paraIndex + 1, 0, ...blockNodes);
-        }
-      } else if (before.length === 0 && after.length === 0) {
+      // Replace the magicBlock node in the paragraph with its inline portion (if any).
+      parent.children.splice(liveIndex, 1, ...inlineNodes);
+
+      const containerChildren = container.children as RootContent[];
+      const paraIndex = containerChildren.indexOf(parent as RootContent);
+
+      if (paraIndex === -1) {
+        // Paragraph not found in container - leave block nodes alongside inline ones in place.
+        parent.children.splice(liveIndex + inlineNodes.length, 0, ...blockNodes);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+
+      if (parent.children.length === 0) {
+        // Paragraph is now empty — replace it with the block nodes directly.
         containerChildren.splice(paraIndex, 1, ...blockNodes);
-      } else {
-        parent.children = [...before, ...after];
-        if (blockNodes.length > 0) {
-          containerChildren.splice(paraIndex + 1, 0, ...blockNodes);
-        }
+      } else if (blockNodes.length > 0) {
+        containerChildren.splice(paraIndex + 1, 0, ...blockNodes);
       }
     }
   };

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -652,14 +652,13 @@ const isWhitespacePhrasing = (node: PhrasingContent): boolean =>
 const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> =
   (options = {}) =>
   tree => {
-    interface Lift {
-      blockNodes: RootContent[];
-      container: Parent;
-      inlineNodes: PhrasingContent[];
+    interface NodeLiftEvent {
+      childrenBlockNodes: RootContent[];
+      grandparent: Parent;
       node: MagicBlockNode;
-      paragraph: Paragraph;
+      parent: Paragraph;
     }
-    const lifts: Lift[] = [];
+    const lifts: NodeLiftEvent[] = [];
 
     visitParents(tree, 'magicBlock', (node: MagicBlockNode, ancestors: Parent[]) => {
       const parent = ancestors[ancestors.length - 1]; // direct parent of the current node
@@ -680,89 +679,62 @@ const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> 
         return;
       }
 
-      // If parent is a paragraph and we're inserting block nodes (which must not be in paragraphs), lift them out
+      // If parent is a paragraph and we're inserting block nodes (which must not be in paragraphs)
+      // it means we need to lift them out
       if (isParagraph(parent) && children.some(isBlockNode)) {
         const blockNodes: RootContent[] = [];
-        const inlineNodes: PhrasingContent[] = [];
-
         children.forEach(child => {
           if (isBlockNode(child)) {
             blockNodes.push(child);
-          } else {
-            // Non-block children produced by transformMagicBlock are valid
-            // phrasing content and belong inside the paragraph.
-            inlineNodes.push(child as PhrasingContent);
           }
         });
 
-        // Defer the lift to a second pass — we don't precompute before/after
-        // here because multiple magicBlocks may share the same paragraph parent,
-        // and snapshots taken at visit-time would go stale once a sibling is
-        // processed (see the regression where two magic blocks under a list
-        // item caused the second one's raw text to leak back into the paragraph).
         lifts.push({
-          blockNodes,
-          container: ancestors[ancestors.length - 2] || tree, // grandparent of the current node
-          inlineNodes,
+          childrenBlockNodes: blockNodes,
+          grandparent: ancestors[ancestors.length - 2] || tree, // grandparent of the current node
           node,
-          paragraph: parent,
+          parent,
         });
       } else {
         parent.children.splice(index, 1, ...children);
       }
     });
 
-    // Second pass: apply lifts that move block nodes out of paragraphs.
+    // Second pass: apply lifts that move block nodes, and the content after them, out of paragraphs.
     // Operate on live state (find each node's current index now) and process in reverse so
     // that container insertions don't disturb earlier paragraphs' positions.
     for (let i = lifts.length - 1; i >= 0; i -= 1) {
-      const { blockNodes, container, inlineNodes, node, paragraph } = lifts[i];
-      const liveIndex = paragraph.children.indexOf(node);
-      if (liveIndex === -1) {
+      const { childrenBlockNodes: blockNodes, grandparent, node, parent: parentParagraph } = lifts[i];
+      const nodePosition = parentParagraph.children.indexOf(node);
+      const parentPosition = grandparent.children.indexOf(parentParagraph);
+      if (nodePosition === -1 || parentPosition === -1) {
         // eslint-disable-next-line no-continue
         continue;
       }
 
-      // Snapshot live siblings — these are correct now (sibling magicBlocks for this
-      // paragraph were already lifted by earlier reverse-order iterations).
-      const before = paragraph.children.slice(0, liveIndex);
-      const after = paragraph.children.slice(liveIndex + 1);
+      // Snapshot live siblings to reconstruct the parent paragraph around the lifted node.
+      const parentSiblingsBefore = parentParagraph.children.slice(0, nodePosition);
+      const parentSiblingsAfter = parentParagraph.children.slice(nodePosition + 1);
 
-      // The newline that originally separated the magic block from its surrounding
-      // text now sits as a leading break (or whitespace-only text) on the trailing
-      // siblings, and a trailing one on the leading siblings. Drop those so the
-      // lifted block doesn't render with an extra blank line on either side.
-      while (before.length > 0 && isWhitespacePhrasing(before[before.length - 1])) before.pop();
-      while (after.length > 0 && isWhitespacePhrasing(after[0])) after.shift();
+      // Remove split-edge whitespace so lifted blocks do not render with extra blank lines.
+      while (parentSiblingsBefore.length > 0 && isWhitespacePhrasing(parentSiblingsBefore[parentSiblingsBefore.length - 1])) parentSiblingsBefore.pop();
+      while (parentSiblingsAfter.length > 0 && isWhitespacePhrasing(parentSiblingsAfter[0])) parentSiblingsAfter.shift();
 
-      const paraIndex = container.children.indexOf(paragraph);
-      if (paraIndex === -1) {
-        // Defensive: paragraph isn't in the container we expected (tree was
-        // mutated between visit and apply). Drop just the magic block from the
-        // paragraph and place its inline portion in its slot — we can't safely
-        // lift block nodes out without a known container.
-        paragraph.children.splice(liveIndex, 1, ...inlineNodes);
-        // eslint-disable-next-line no-continue
-        continue;
+      const splitOffContentFromParent: RootContent[] = [...blockNodes];
+      if (parentSiblingsAfter.length > 0) {
+        // Keep trailing inline content grouped under a paragraph sibling as it might be an inline node
+        // Even if it contains a block node, it will be hoisted out during its turn in the loop
+        const trailingParagraph: Paragraph = { type: 'paragraph', children: parentSiblingsAfter };
+        splitOffContentFromParent.push(trailingParagraph);
       }
 
-      // Reshape the paragraph to hold only the leading content (plus inline nodes
-      // produced by the transform), then insert lifted blocks after the paragraph,
-      // followed by a new paragraph for any trailing content. This preserves
-      // source order: text-before, lifted block, text-after.
-      paragraph.children = [...before, ...inlineNodes];
-
-      const insertions: RootContent[] = [...blockNodes];
-      if (after.length > 0) {
-        const trailing: Paragraph = { type: 'paragraph', children: after };
-        insertions.push(trailing);
-      }
-
-      if (paragraph.children.length === 0) {
-        // Original paragraph would be empty — drop it and put insertions in its place.
-        container.children.splice(paraIndex, 1, ...insertions);
+      parentParagraph.children = [...parentSiblingsBefore];
+      // If the parent paragraph is empty, just replace it with the lifted block nodes
+      const shouldReplaceParent = parentParagraph.children.length === 0;
+      if (shouldReplaceParent) {
+        grandparent.children.splice(parentPosition, 1, ...splitOffContentFromParent);
       } else {
-        container.children.splice(paraIndex + 1, 0, ...insertions);
+        grandparent.children.splice(parentPosition + 1, 0, ...splitOffContentFromParent);
       }
     }
   };

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -707,24 +707,50 @@ const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> 
         continue;
       }
 
-      // Replace the magicBlock node in the paragraph with its inline portion (if any).
-      parent.children.splice(liveIndex, 1, ...inlineNodes);
+      // Snapshot live siblings — these are correct now (sibling magicBlocks for this
+      // paragraph were already lifted by earlier reverse-order iterations).
+      const beforeChildren = parent.children.slice(0, liveIndex) as RootContent[];
+      const afterChildren = parent.children.slice(liveIndex + 1) as RootContent[];
+
+      // The newline that originally separated the magic block from its surrounding
+      // text now sits as a leading `break` (or whitespace-only text) on the trailing
+      // siblings, and a trailing one on the leading siblings. Drop those so the
+      // lifted block doesn't render with an extra blank line on either side.
+      const isWhitespaceOnly = (n: RootContent): boolean =>
+        n.type === 'break' || (n.type === 'text' && !/\S/.test((n as { value: string }).value));
+      while (beforeChildren.length > 0 && isWhitespaceOnly(beforeChildren[beforeChildren.length - 1])) {
+        beforeChildren.pop();
+      }
+      while (afterChildren.length > 0 && isWhitespaceOnly(afterChildren[0])) {
+        afterChildren.shift();
+      }
 
       const containerChildren = container.children as RootContent[];
       const paraIndex = containerChildren.indexOf(parent as RootContent);
 
       if (paraIndex === -1) {
-        // Paragraph not found in container - leave block nodes alongside inline ones in place.
-        parent.children.splice(liveIndex + inlineNodes.length, 0, ...blockNodes);
+        // Paragraph not found in container — splice block + inline nodes in place.
+        parent.children.splice(liveIndex, 1, ...blockNodes, ...inlineNodes);
         // eslint-disable-next-line no-continue
         continue;
       }
 
+      // Reshape the paragraph to hold only the leading content (plus inline nodes
+      // produced by the transform), then insert lifted blocks after the paragraph,
+      // followed by a new paragraph for any trailing content. This preserves
+      // source order: text-before, lifted block, text-after.
+      parent.children = [...beforeChildren, ...inlineNodes];
+
+      const insertions: RootContent[] = [...blockNodes];
+      if (afterChildren.length > 0) {
+        insertions.push({ type: 'paragraph', children: afterChildren } as unknown as RootContent);
+      }
+
       if (parent.children.length === 0) {
-        // Paragraph is now empty — replace it with the block nodes directly.
-        containerChildren.splice(paraIndex, 1, ...blockNodes);
-      } else if (blockNodes.length > 0) {
-        containerChildren.splice(paraIndex + 1, 0, ...blockNodes);
+        // Original paragraph would be empty — drop it and put insertions in its place.
+        containerChildren.splice(paraIndex, 1, ...insertions);
+      } else {
+        containerChildren.splice(paraIndex + 1, 0, ...insertions);
       }
     }
   };


### PR DESCRIPTION
| 🎫 Resolve RM-16280 |
| :-----------------: |

## 🎯 What does this PR do?

Fixes issue 2 from the linear ticket, where bunched-up magic blocks under a list item were not rendering and trailing text leaked above the lifted block.

### Root cause

The lift logic in `magic-block-transformer.ts` precomputed `before`/`after` snapshots of `parent.children` at visit time. When two magic blocks share one paragraph parent (e.g. two block-level blocks right after a list item with no blank line between them), processing the second replacement in reverse order uses a stale snapshot and can reattach the first replacement's sibling (and the reverse), so the second magic block's raw token ends up back in the paragraph above the lifted blocks. Additionally, the previous lift collapsed `before` and `after` content into a single residual paragraph rendered _before_ the lifted block, so any trailing text appeared above the block instead of after it.

### Fixes

- The lift pass no longer precomputes `before`/`after`, and we get that info & the index of the node in the loop itself so that it reflects changes from the previous loop which might be their sibling. This prevents stale tree editing
- Reshape the original paragraph to `[...before, ...inlineNodes]`, splice `blockNodes` into the container after the paragraph, and append a fresh `paragraph` for `after` content preserving source order. This ensure the sequence of items are correct
- Removing some dead code such as tracking the `inlineNodes` (already handled by a previous code), skipping when positions are not found, and some variable renaming to make the code more understandable 

## 🧪 QA tips

Paste each example into the editor and confirm both magic blocks render in source order and neither stays trapped inside a `<p>`.

**1. Two consecutive callouts under a list item (the original bug)**

```md
- Item two
[block:callout]
{"type":"info","title":"first","body":"one"}
[/block]
[block:callout]
{"type":"info","title":"second","body":"two"}
[/block]
```

Expected: both callouts render inside the `<li>`, `first` above `second`.

**2. Magic block followed by trailing text in a list item**

```md
- Item two
[block:callout]
{"type":"info","title":"hi","body":"body"}
[/block]
trailing text
```

Expected: callout renders, then `trailing text` renders **after** it (not above).

**3. Three consecutive blocks sharing one paragraph parent**

```md
- Item
[block:callout]
{"type":"info","title":"a","body":"A"}
[/block]
[block:callout]
{"type":"info","title":"b","body":"B"}
[/block]
[block:callout]
{"type":"info","title":"c","body":"C"}
[/block]
```

Expected: callouts render in order a → b → c, all inside the `<li>`.

**4. Mixed block types under a list item**

```md
- Item
[block:callout]
{"type":"info","title":"hi","body":"body"}
[/block]
[block:html]
{"html":"<div>raw html</div>"}
[/block]
```

Expected: callout above the html block, both inside the `<li>`.

**5. Leading + block + trailing text at root level**

```md
before text
[block:callout]
{"type":"info","title":"hi","body":"body"}
[/block]
after text
```

Expected: `before text` paragraph, callout, `after text` paragraph — three siblings in that order.
