### PR TITLE
fix(mdxish): consecutive magic blocks not rendering if they have html tags in their content

### DIFF
--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -2094,7 +2094,7 @@ asdasdasd
   });
 
   describe('multiple magic blocks', () => {
-    it('should parse 2 magic blocks that have html content in the same line', () => {
+    it('should parse consecutive magic blocks whose JSON bodies contain HTML tags', () => {
       const md = `
 [block:parameters]
 {

--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -1,9 +1,9 @@
-import type { Element, Text } from 'hast';
+import type { Element, Parent, RootContent, Text } from 'hast';
 
 import { toHtml } from 'hast-util-to-html';
 
 import { mdxish } from '../../../lib';
-import { findElementByTagName } from '../../helpers';
+import { findElementByTagName, parseMdxish } from '../../helpers';
 
 describe('mdxish magic blocks', () => {
   describe('image block', () => {
@@ -1387,6 +1387,165 @@ ${JSON.stringify(
 
       const nestedUl = secondLi.children.find((c): c is Element => c.type === 'element' && c.tagName === 'ul');
       expect(nestedUl).toBeDefined();
+    });
+
+    it('should lift two consecutive magic blocks under a list item out of the paragraph in source order', () => {
+      const md = `- Item two
+[block:callout]
+{"type":"info","title":"first","body":"one"}
+[/block]
+[block:callout]
+{"type":"info","title":"second","body":"two"}
+[/block]`;
+
+      const tree = parseMdxish(md);
+
+      expect(tree.children).toHaveLength(1);
+      const list = tree.children[0] as RootContent;
+      expect(list.type).toBe('list');
+      expect((list as Parent).children).toHaveLength(1);
+
+      const li = (list as Parent).children[0] as Parent;
+      // listItem holds the leading paragraph and the two lifted Callouts in source order.
+      expect(li.children).toHaveLength(3);
+      expect(li.children[0]).toMatchObject({
+        type: 'paragraph',
+        children: [{ type: 'text', value: 'Item two\n' }],
+      });
+      expect(li.children[1]).toMatchObject({
+        type: 'mdxJsxFlowElement',
+        name: 'Callout',
+        children: [
+          { type: 'heading', depth: 3, children: [{ type: 'text', value: 'first' }] },
+          { type: 'paragraph', children: [{ type: 'text', value: 'one' }] },
+        ],
+      });
+      expect(li.children[2]).toMatchObject({
+        type: 'mdxJsxFlowElement',
+        name: 'Callout',
+        children: [
+          { type: 'heading', depth: 3, children: [{ type: 'text', value: 'second' }] },
+          { type: 'paragraph', children: [{ type: 'text', value: 'two' }] },
+        ],
+      });
+    });
+
+    it('should place trailing text after a magic block (not before it) when both share a list-item paragraph', () => {
+      const md = `- Item two
+[block:callout]
+{"type":"info","title":"hi","body":"body"}
+[/block]
+trailing text`;
+
+      const tree = parseMdxish(md);
+      expect(tree.children[0]).toMatchObject({
+        type: 'list',
+        children: [
+          {
+            type: 'listItem',
+            children: [
+              {
+                type: 'paragraph',
+                children: [{ type: 'text', value: 'Item two\n' }],
+              },
+              {
+                type: 'mdxJsxFlowElement',
+                name: 'Callout',
+              },
+              {
+                type: 'paragraph',
+                children: [{ type: 'text', value: '\ntrailing text' }],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('should lift mixed block types (callout + html-block) consecutively under a list item', () => {
+      const md = `- Item
+[block:callout]
+{"type":"info","title":"hi","body":"body"}
+[/block]
+[block:html]
+{"html":"<div>raw</div>"}
+[/block]`;
+
+      const tree = parseMdxish(md);
+      const li = (tree.children[0] as Parent).children[0] as Parent;
+
+      expect(li.children).toHaveLength(3);
+      expect(li.children[1]).toMatchObject({ type: 'mdxJsxFlowElement', name: 'Callout' });
+      expect(li.children[2]).toMatchObject({ type: 'html-block' });
+    });
+
+    it('should render mix of magic blocks and text interleaved under a list item', () => {
+      const md = `- first line
+[block:callout]
+{"type":"info","title":"first","body":"one"}
+[/block]
+second line
+[block:image]
+{"images":[{"image":["https://example.com/image.png",null,"Image"]}]}
+[/block]
+third line
+[block:image]
+{"images":[{"image":["https://example.com/image.png",null,"Image"]}]}
+[/block]
+fourth line
+`;
+
+      const ast = parseMdxish(md);
+      expect(ast.children[0]).toMatchObject({
+        type: 'list',
+        children: [
+          {
+            type: 'listItem',
+            children: [
+              {
+                type: 'paragraph',
+                children: [{ type: 'text', value: 'first line\n' }],
+              },
+              {
+                type: 'mdxJsxFlowElement',
+                name: 'Callout',
+              },
+              {
+                type: 'paragraph',
+                children: [
+                  { type: 'text', value: '\nsecond line\n' },
+                  { type: 'image', url: 'https://example.com/image.png' },
+                  { type: 'text', value: '\nthird line\n' },
+                  { type: 'image', url: 'https://example.com/image.png' },
+                  { type: 'text', value: '\nfourth line' },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  describe('lifting magic blocks out of paragraphs at root', () => {
+    it('should split a paragraph around a lifted block, preserving leading and trailing text', () => {
+      const md = `before text
+[block:callout]
+{"type":"info","title":"hi","body":"body"}
+[/block]
+after text`;
+
+      const tree = parseMdxish(md);
+      expect(tree.children).toHaveLength(3);
+      expect(tree.children[0]).toMatchObject({
+        type: 'paragraph',
+        children: [{ type: 'text', value: 'before text' }],
+      });
+      expect(tree.children[1]).toMatchObject({ type: 'mdxJsxFlowElement', name: 'Callout' });
+      expect(tree.children[2]).toMatchObject({
+        type: 'paragraph',
+        children: [{ type: 'text', value: 'after text' }],
+      });
     });
   });
 

--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -3,6 +3,7 @@ import type { Element, Text } from 'hast';
 import { toHtml } from 'hast-util-to-html';
 
 import { mdxish } from '../../../lib';
+import { findElementByTagName } from '../../helpers';
 
 describe('mdxish magic blocks', () => {
   describe('image block', () => {
@@ -2089,6 +2090,37 @@ asdasdasd
       expect(html).toContain('<img');
       expect(html).toContain('example.com/image.png');
       expect(html).not.toContain('[block:image]');
+    });
+  });
+
+  describe('multiple magic blocks', () => {
+    it('should parse 2 magic blocks that have html content in the same line', () => {
+      const md = `
+[block:parameters]
+{
+  "data": {
+    "h-0": "Heading",
+    "0-0": "<li>List item<li>"
+  },
+  "cols": 1,
+  "rows": 1
+}
+[/block]
+
+
+[block:html]
+{
+  "html": "<table><tbody><tr><td><ul><li>a</li><li>b</li></ul></td></tr></tbody></table>"
+}
+[/block]
+`;
+      const ast = mdxish(md);
+
+      const tableNode = findElementByTagName(ast, 'table');
+      expect(tableNode).not.toBeNull();
+
+      const htmlBlockNode = findElementByTagName(ast, 'html-block');
+      expect(htmlBlockNode).not.toBeNull();
     });
   });
 });

--- a/__tests__/transformers/preprocess-jsx-expressions.test.ts
+++ b/__tests__/transformers/preprocess-jsx-expressions.test.ts
@@ -761,6 +761,31 @@ hello
         expect(() => mdxish(result)).not.toThrow();
         expect(result).toBe(content);
       });
+
+      it('should not escape unclosed curly braces if it is next to an unclosed HTML tag', () => {
+        const content = '<strong> hello {';
+        const result = preprocessJSXExpressions(content);
+        expect(() => mdxish(result)).not.toThrow();
+        expect(result).toBe('<strong> hello \\{');
+      });
+
+      it.skip('should not escape unclosed curly braces if it is next to an unclosed list tag', () => {
+        const content = '<li> hello {';
+        const result = preprocessJSXExpressions(content);
+        expect(() => mdxish(result)).not.toThrow();
+        expect(result).toBe(content);
+      });
+
+      it.skip('should not escape unclosed curly braces if it is next to an unclosed HTML tag inside a component', () => {
+        const content = `
+<Callout>
+<li> hello {
+</Callout>
+        `;
+        const result = preprocessJSXExpressions(content);
+        expect(() => mdxish(result)).not.toThrow();
+        expect(result).toBe(content);
+      });
     });
 
     describe('stress tests - regression prevention', () => {

--- a/__tests__/transformers/preprocess-jsx-expressions.test.ts
+++ b/__tests__/transformers/preprocess-jsx-expressions.test.ts
@@ -762,6 +762,21 @@ hello
         expect(result).toBe(content);
       });
 
+      it('should escape both braces in an empty expression that spans multiple lines inside an HTML tag, that has an empty line inside the expression', () => {
+        const content = `<div>
+{
+
+}
+</div>`;
+        const result = preprocessJSXExpressions(content);
+        expect(() => mdxish(result)).not.toThrow();
+        expect(result).toBe(`<div>
+\\{
+
+\\}
+</div>`);
+      });
+
       it('should escape an unclosed brace next to an inline HTML tag (mdxish would otherwise throw)', () => {
         const content = '<strong> hello {';
         const result = preprocessJSXExpressions(content);

--- a/__tests__/transformers/preprocess-jsx-expressions.test.ts
+++ b/__tests__/transformers/preprocess-jsx-expressions.test.ts
@@ -741,7 +741,7 @@ hi \\{ unclosed
         `);
       });
 
-      it('should not escape multilne balanced braces inside HTML tags that starts right after the opening tag', () => {
+      it('should not escape multi-line balanced braces inside HTML tags that start right after the opening tag', () => {
         const content = `<div>{
 hello
 
@@ -762,21 +762,21 @@ hello
         expect(result).toBe(content);
       });
 
-      it('should not escape unclosed curly braces if it is next to an unclosed HTML tag', () => {
+      it('should escape an unclosed brace next to an inline HTML tag (mdxish would otherwise throw)', () => {
         const content = '<strong> hello {';
         const result = preprocessJSXExpressions(content);
         expect(() => mdxish(result)).not.toThrow();
         expect(result).toBe('<strong> hello \\{');
       });
 
-      it.skip('should not escape unclosed curly braces if it is next to an unclosed list tag', () => {
+      it.skip('should not escape an unclosed brace next to a block-level HTML tag', () => {
         const content = '<li> hello {';
         const result = preprocessJSXExpressions(content);
         expect(() => mdxish(result)).not.toThrow();
         expect(result).toBe(content);
       });
 
-      it.skip('should not escape unclosed curly braces if it is next to an unclosed HTML tag inside a component', () => {
+      it.skip('should not escape an unclosed brace next to a block-level HTML tag nested inside a component', () => {
         const content = `
 <Callout>
 <li> hello {

--- a/__tests__/transformers/preprocess-jsx-expressions.test.ts
+++ b/__tests__/transformers/preprocess-jsx-expressions.test.ts
@@ -604,26 +604,6 @@ Another valid: {name}`;
         expect(result).toBe(content);
       });
 
-      it('should handle HTML with curly braces in text spanning blank line', () => {
-        // CX-2978: backslashes from preprocessor escaping must not surface as
-        // literal text in the rendered output. For a multi-line block like
-        // this, mdxish parses the interior as MDX, so escaping is harmless
-        // — the `\` is consumed by the MDX text parser, not rendered.
-        const content = `<div>
-{
-
-}
-</div>`;
-        const tree = mdxish(preprocessJSXExpressions(content));
-        const texts: string[] = [];
-        const collect = (n: { children?: unknown[]; type: string; value?: string }): void => {
-          if (n.type === 'text' && typeof n.value === 'string') texts.push(n.value);
-          n.children?.forEach(c => collect(c as Parameters<typeof collect>[0]));
-        };
-        collect(tree as Parameters<typeof collect>[0]);
-        expect(texts.join('')).not.toContain('\\');
-      });
-
       it('should handle very long content between braces with blank line', () => {
         const longContent = 'a'.repeat(1000);
         const content = `{${longContent}\n\n${longContent}}`;
@@ -748,7 +728,7 @@ const obj = {key: value};
       it('should deal with unclosed { inside multi-line HTML tags', () => {
         const content = `
 <li>
-{ unclosed
+hi { unclosed
 </li>
         `;
         const result = preprocessJSXExpressions(content);
@@ -756,9 +736,30 @@ const obj = {key: value};
         expect(() => mdxish(result)).not.toThrow();
         expect(result).toBe(`
 <li>
-\\{ unclosed
+hi \\{ unclosed
 </li>
         `);
+      });
+
+      it('should not escape multilne balanced braces inside HTML tags that starts right after the opening tag', () => {
+        const content = `<div>{
+hello
+
+}
+</div>`;
+        const result = preprocessJSXExpressions(content);
+
+        expect(result).toBe(content);
+      });
+
+      it('should not escape empty curly braces inside HTML tags', () => {
+        const content = `<div>
+{
+}
+</div>`;
+        const result = preprocessJSXExpressions(content);
+        expect(() => mdxish(result)).not.toThrow();
+        expect(result).toBe(content);
       });
     });
 

--- a/__tests__/transformers/preprocess-jsx-expressions.test.ts
+++ b/__tests__/transformers/preprocess-jsx-expressions.test.ts
@@ -102,6 +102,13 @@ describe('preprocessJSXExpressions', () => {
         expect(result).toBe(content);
       });
 
+      it('table magic blocks', () => {
+        const content = '[block:parameters]\n{"data":{"h-0":"Header","0-0":"{ unclosed "},"cols":1,"rows":1}\n[/block]';
+        const result = preprocessJSXExpressions(content);
+
+        expect(result).toBe(content);
+      });
+
       it('html blocks', () => {
         const content = '<HTMLBlock>{`unclosed } { unclosed `}</HTMLBlock>';
         const tree = mdxish(content);
@@ -598,18 +605,23 @@ Another valid: {name}`;
       });
 
       it('should handle HTML with curly braces in text spanning blank line', () => {
-        // HTML elements are protected and their content is NOT escaped,
-        // because rehypeRaw parses them into hast elements and backslashes
-        // would appear as literal text in the output (CX-2978)
+        // CX-2978: backslashes from preprocessor escaping must not surface as
+        // literal text in the rendered output. For a multi-line block like
+        // this, mdxish parses the interior as MDX, so escaping is harmless
+        // — the `\` is consumed by the MDX text parser, not rendered.
         const content = `<div>
 {
 
 }
 </div>`;
-        const result = preprocessJSXExpressions(content);
-
-        // Braces inside HTML elements should NOT be escaped
-        expect(result).toBe(content);
+        const tree = mdxish(preprocessJSXExpressions(content));
+        const texts: string[] = [];
+        const collect = (n: { children?: unknown[]; type: string; value?: string }): void => {
+          if (n.type === 'text' && typeof n.value === 'string') texts.push(n.value);
+          n.children?.forEach(c => collect(c as Parameters<typeof collect>[0]));
+        };
+        collect(tree as Parameters<typeof collect>[0]);
+        expect(texts.join('')).not.toContain('\\');
       });
 
       it('should handle very long content between braces with blank line', () => {
@@ -723,6 +735,30 @@ const obj = {key: value};
 
         expect(result).toContain('\\{');
         expect(() => mdxish(result)).not.toThrow();
+      });
+
+      it('should deal with unclosed { inside HTML tags that has surrounding text', () => {
+        const content = 'hi <div>{unclosed</div>';
+        const result = preprocessJSXExpressions(content);
+
+        expect(() => mdxish(result)).not.toThrow();
+        expect(result).toBe('hi <div>\\{unclosed</div>');
+      });
+
+      it('should deal with unclosed { inside multi-line HTML tags', () => {
+        const content = `
+<li>
+{ unclosed
+</li>
+        `;
+        const result = preprocessJSXExpressions(content);
+
+        expect(() => mdxish(result)).not.toThrow();
+        expect(result).toBe(`
+<li>
+\\{ unclosed
+</li>
+        `);
       });
     });
 

--- a/lib/utils/extractMagicBlocks.ts
+++ b/lib/utils/extractMagicBlocks.ts
@@ -4,6 +4,11 @@ export interface BlockHit {
   token: string;
 }
 
+export interface ExtractMagicBlocksOptions {
+  /** Skip the padding-newline around the magic blocks */
+  lossless?: boolean;
+}
+
 /**
  * The content matching in this regex captures everything between `[block:TYPE]`
  * and `[/block]`, including new lines. Negative lookahead for the closing
@@ -48,7 +53,10 @@ export function extractMagicBlocks(markdown: string) {
 /**
  * Restore extracted magic blocks back into a markdown string.
  */
-export function restoreMagicBlocks(replaced: string, blocks: BlockHit[]) {
+export function restoreMagicBlocks(replaced: string, blocks: BlockHit[], options: ExtractMagicBlocksOptions = {}) {
+  if (blocks.length === 0) return replaced;
+
+  const { lossless = false } = options;
   // If a magic block is at the start or end of the document, the extraction
   // token's newlines will have been trimmed during processing. We need to
   // account for that here to ensure the token is found and replaced correctly.
@@ -56,8 +64,8 @@ export function restoreMagicBlocks(replaced: string, blocks: BlockHit[]) {
   const content = `\n${replaced}\n`;
 
   const restoredContent = blocks.reduce((acc, { token, raw }) => {
-    // Ensure each magic block is separated by newlines when restored.
-    return acc.split(token).join(`\n${raw}\n`);
+    const restoredBlock = lossless ? raw : `\n${raw}\n`;
+    return acc.split(token).join(restoredBlock);
   }, content);
 
   return restoredContent.trim();

--- a/lib/utils/extractMagicBlocks.ts
+++ b/lib/utils/extractMagicBlocks.ts
@@ -4,11 +4,6 @@ export interface BlockHit {
   token: string;
 }
 
-export interface ExtractMagicBlocksOptions {
-  /** Skip the padding-newline around the magic blocks */
-  lossless?: boolean;
-}
-
 /**
  * The content matching in this regex captures everything between `[block:TYPE]`
  * and `[/block]`, including new lines. Negative lookahead for the closing
@@ -53,10 +48,7 @@ export function extractMagicBlocks(markdown: string) {
 /**
  * Restore extracted magic blocks back into a markdown string.
  */
-export function restoreMagicBlocks(replaced: string, blocks: BlockHit[], options: ExtractMagicBlocksOptions = {}) {
-  if (blocks.length === 0) return replaced;
-
-  const { lossless = false } = options;
+export function restoreMagicBlocks(replaced: string, blocks: BlockHit[]) {
   // If a magic block is at the start or end of the document, the extraction
   // token's newlines will have been trimmed during processing. We need to
   // account for that here to ensure the token is found and replaced correctly.
@@ -64,8 +56,8 @@ export function restoreMagicBlocks(replaced: string, blocks: BlockHit[], options
   const content = `\n${replaced}\n`;
 
   const restoredContent = blocks.reduce((acc, { token, raw }) => {
-    const restoredBlock = lossless ? raw : `\n${raw}\n`;
-    return acc.split(token).join(restoredBlock);
+    // Ensure each magic block is separated by newlines when restored.
+    return acc.split(token).join(`\n${raw}\n`);
   }, content);
 
   return restoredContent.trim();

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -20,7 +20,7 @@ import type {
 } from './types';
 import type { MagicBlockNode } from '../../../../lib/mdast-util/magic-block/types';
 import type { Root as HastRoot, Text as HastText, Element as HastElement, ElementContent } from 'hast';
-import type { Root as MdastRoot, RootContent, Parent } from 'mdast';
+import type { Root as MdastRoot, RootContent, Parent, Paragraph, PhrasingContent } from 'mdast';
 import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 import type { Plugin } from 'unified';
 
@@ -63,6 +63,17 @@ import {
   EMPTY_TABLE_PLACEHOLDER,
   EMPTY_RECIPE_PLACEHOLDER,
 } from './placeholder';
+
+/**
+ * To be used when trying to lift a block node out of a paragraph
+ * since it can't be in a paragraph
+ */
+interface NodeLiftEvent {
+  childrenBlockNodes: RootContent[];
+  grandparent: Parent;
+  node: MagicBlockNode;
+  parent: Paragraph;
+}
 
 /**
  * Wraps a node in a "pinned" container if sidebar: true is set.
@@ -637,20 +648,22 @@ const blockTypes = [
  */
 const isBlockNode = (node: RootContent): boolean => blockTypes.includes(node.type);
 
+const isParagraph = (node: Parent): node is Paragraph => node.type === 'paragraph';
+
+/**
+ * True for phrasing content that contributes only whitespace at render time
+ * (a soft `break` node or a text node with no non-whitespace characters).
+ */
+const isWhitespacePhrasing = (node: PhrasingContent): boolean =>
+  node.type === 'break' || (node.type === 'text' && !node.value.trim());
+
 /**
  * Unified plugin that transforms magicBlock nodes into final MDAST nodes.
  */
 const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> =
   (options = {}) =>
   tree => {
-    const replacements: {
-      after: RootContent[];
-      before: RootContent[];
-      blockNodes: RootContent[];
-      container: Parent;
-      inlineNodes: RootContent[];
-      parent: Parent;
-    }[] = [];
+    const lifts: NodeLiftEvent[] = [];
 
     visitParents(tree, 'magicBlock', (node: MagicBlockNode, ancestors: Parent[]) => {
       const parent = ancestors[ancestors.length - 1]; // direct parent of the current node
@@ -671,53 +684,62 @@ const magicBlockTransformer: Plugin<[MagicBlockTransformerOptions?], MdastRoot> 
         return;
       }
 
-      // If parent is a paragraph and we're inserting block nodes (which must not be in paragraphs), lift them out
-      if (parent.type === 'paragraph' && children.some(child => isBlockNode(child))) {
+      // If parent is a paragraph and we're inserting block nodes (which must not be in paragraphs)
+      // it means we need to lift them out
+      if (isParagraph(parent) && children.some(isBlockNode)) {
         const blockNodes: RootContent[] = [];
-        const inlineNodes: RootContent[] = [];
-
         children.forEach(child => {
-          (isBlockNode(child) ? blockNodes : inlineNodes).push(child);
+          if (isBlockNode(child)) {
+            blockNodes.push(child);
+          }
         });
 
-        replacements.push({
-          container: ancestors[ancestors.length - 2] || tree, // grandparent of the current node
+        lifts.push({
+          childrenBlockNodes: blockNodes,
+          grandparent: ancestors[ancestors.length - 2] || tree, // grandparent of the current node
+          node,
           parent,
-          blockNodes,
-          inlineNodes,
-          before: parent.children.slice(0, index) as RootContent[],
-          after: parent.children.slice(index + 1) as RootContent[],
         });
       } else {
         parent.children.splice(index, 1, ...children);
       }
     });
 
-    // Second pass: apply replacements that require lifting block nodes out of paragraphs
-    // Process in reverse order to maintain correct indices
-    for (let i = replacements.length - 1; i >= 0; i -= 1) {
-      const { after, before, blockNodes, container, inlineNodes, parent } = replacements[i];
-      const containerChildren = container.children as RootContent[];
-      const paraIndex = containerChildren.indexOf(parent as RootContent);
-
-      if (paraIndex === -1) {
-        parent.children.splice(before.length, 1, ...blockNodes, ...inlineNodes);
+    // Second pass: apply lifts that move block nodes, and the content after them, out of paragraphs.
+    // Operate on live state (find each node's current index now) and process in reverse so
+    // that container insertions don't disturb earlier paragraphs' positions.
+    for (let i = lifts.length - 1; i >= 0; i -= 1) {
+      const { childrenBlockNodes: blockNodes, grandparent, node, parent: parentParagraph } = lifts[i];
+      const nodePosition = parentParagraph.children.indexOf(node);
+      const parentPosition = grandparent.children.indexOf(parentParagraph);
+      if (nodePosition === -1 || parentPosition === -1) {
         // eslint-disable-next-line no-continue
         continue;
       }
 
-      if (inlineNodes.length > 0) {
-        parent.children = [...before, ...inlineNodes, ...after];
-        if (blockNodes.length > 0) {
-          containerChildren.splice(paraIndex + 1, 0, ...blockNodes);
-        }
-      } else if (before.length === 0 && after.length === 0) {
-        containerChildren.splice(paraIndex, 1, ...blockNodes);
+      // Snapshot live siblings to reconstruct the parent paragraph around the lifted node.
+      const parentSiblingsBefore = parentParagraph.children.slice(0, nodePosition);
+      const parentSiblingsAfter = parentParagraph.children.slice(nodePosition + 1);
+
+      // Remove split-edge whitespace so lifted blocks do not render with extra blank lines.
+      while (parentSiblingsBefore.length > 0 && isWhitespacePhrasing(parentSiblingsBefore[parentSiblingsBefore.length - 1])) parentSiblingsBefore.pop();
+      while (parentSiblingsAfter.length > 0 && isWhitespacePhrasing(parentSiblingsAfter[0])) parentSiblingsAfter.shift();
+
+      const splitOffContentFromParent: RootContent[] = [...blockNodes];
+      if (parentSiblingsAfter.length > 0) {
+        // Keep trailing inline content grouped under a paragraph sibling as it might be an inline node
+        // Even if it contains a block node, it will be hoisted out during its turn in the loop
+        const trailingParagraph: Paragraph = { type: 'paragraph', children: parentSiblingsAfter };
+        splitOffContentFromParent.push(trailingParagraph);
+      }
+
+      parentParagraph.children = [...parentSiblingsBefore];
+      // If the parent paragraph is empty, just replace it with the lifted block nodes
+      const shouldReplaceParent = parentParagraph.children.length === 0;
+      if (shouldReplaceParent) {
+        grandparent.children.splice(parentPosition, 1, ...splitOffContentFromParent);
       } else {
-        parent.children = [...before, ...after];
-        if (blockNodes.length > 0) {
-          containerChildren.splice(paraIndex + 1, 0, ...blockNodes);
-        }
+        grandparent.children.splice(parentPosition + 1, 0, ...splitOffContentFromParent);
       }
     }
   };

--- a/processor/transform/mdxish/preprocess-jsx-expressions.ts
+++ b/processor/transform/mdxish/preprocess-jsx-expressions.ts
@@ -1,5 +1,4 @@
 import { JSX_COMMENT_REGEX } from '../../../lib/micromark/jsx-comment/pattern';
-import { MAGIC_BLOCK_REGEX } from '../../../lib/utils/extractMagicBlocks';
 import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
 
 // Base64 encode (Node.js + browser compatible)
@@ -65,14 +64,27 @@ export function removeJSXComments(content: string): string {
  * so backslashes don't leak into rendered output via rehypeRaw.
  */
 function escapeProblematicBraces(content: string): string {
-  // Skip HTML elements — their content should never be escaped because
-  // rehypeRaw parses them into hast elements, making `\` literal text in output
+  // Skip HTML elements that mdxish will parse as raw HTML — escaping their
+  // braces would surface backslashes as literal text via rehypeRaw. We only
+  // match what mdxish actually treats as raw: (1) a block element on a single
+  // line, or (2) a block element whose interior lines are themselves only
+  // tags. A bare-text line at column 0 inside a block makes mdxish split a
+  // paragraph out and parse `{` as MDX, so we must NOT skip those.
   const htmlElements: string[] = [];
-  const safe = content.replace(/<([a-z][a-zA-Z0-9]*)(?:\s[^>]*)?>[\s\S]*?<\/\1>/g, match => {
+  const TAG = '[a-z][a-zA-Z0-9]*';
+  const SAME_LINE = new RegExp(`(?<=^|\\n)[ \\t]*<(${TAG})(?:\\s[^>]*)?>[^\\n]*?</\\1>[ \\t]*(?=\\n|$)`, 'g');
+  // Multi-line: opening tag alone on its line, interior lines each start with
+  // whitespace + `<` (i.e., tags only), closing tag alone on its line.
+  const MULTI_LINE = new RegExp(
+    `(?<=^|\\n)[ \\t]*<(${TAG})(?:\\s[^>]*)?>[ \\t]*\\n(?:[ \\t]*<[^\\n]*\\n)+?[ \\t]*</\\1>[ \\t]*(?=\\n|$)`,
+    'g',
+  );
+  const stash = (match: string): string => {
     const idx = htmlElements.length;
     htmlElements.push(match);
     return `___HTML_ELEM_${idx}___`;
-  });
+  };
+  const safe = content.replace(MULTI_LINE, stash).replace(SAME_LINE, stash);
 
   const toEscape = new Set<number>();
   // Convert to array of Unicode code points to handle emojis and multi-byte characters correctly
@@ -206,24 +218,11 @@ function escapeProblematicBraces(content: string): string {
 export function preprocessJSXExpressions(content: string): string {
   let processed = protectHTMLBlockContent(content);
 
-  // We don't want to touch magic block content as well as they're flaky
-  // and need to be exact as it is in the original markdown.
-  const magicBlocks: string[] = [];
-  processed = processed.replace(MAGIC_BLOCK_REGEX, match => {
-    const idx = magicBlocks.length;
-    magicBlocks.push(match);
-    return `___MAGIC_BLOCK_${idx}___`;
-  });
-
   const { protectedCode, protectedContent } = protectCodeBlocks(processed);
 
   processed = escapeProblematicBraces(protectedContent);
 
   processed = restoreCodeBlocks(processed, protectedCode);
-
-  if (magicBlocks.length > 0) {
-    processed = processed.replace(/___MAGIC_BLOCK_(\d+)___/g, (_m, idx) => magicBlocks[parseInt(idx, 10)]);
-  }
 
   return processed;
 }

--- a/processor/transform/mdxish/preprocess-jsx-expressions.ts
+++ b/processor/transform/mdxish/preprocess-jsx-expressions.ts
@@ -58,52 +58,61 @@ export function removeJSXComments(content: string): string {
   return content.replace(JSX_COMMENT_REGEX, '');
 }
 
+const HTML_ELEM_PLACEHOLDER_PREFIX = '___MDXISH_HTML_ELEM_';
+const HTML_ELEM_PLACEHOLDER = new RegExp(`${HTML_ELEM_PLACEHOLDER_PREFIX}(\\d+)___`, 'g');
+// Matches an HTML element that starts at a line boundary and ends at a line boundary.
+// Allows optional leading indentation and lazily matches until the same closing tag.
+const BLOCK_HTML_RE = /(?<=^|\n)[ \t]*<([a-z][a-zA-Z0-9]*)(?:\s[^>]*)?>[\s\S]*?<\/\1>[ \t]*(?=\n|$)/g;
+
 /**
- * Escapes problematic braces in content to prevent MDX expression parsing errors.
- * Handles unbalanced braces and paragraph-spanning expressions. Skips HTML elements
- * so backslashes don't leak into rendered output via rehypeRaw.
+ * Extracts and replaces raw HTML element sequences so they don't get affected by the brace escaping
+ * and surface literal `\{` before an unclosed brace inside the HTML.
+ *
+ * In most cases, we still need to escape unclosed braces  under HTML elements,
+ * especially if they span multiple lines because the sequence might get split in the pipeline and
+ * the opening braces might cause an error with the mdxExpression step.
+ *
+ * E.g. `<div>{foo</div>` should be rendered as raw HTML, so escaping the `{` would surface `\{` literally.
+ */
+function protectHTMLElements(content: string): { htmlElements: string[]; protectedContent: string } {
+  const htmlElements: string[] = [];
+  const protectedContent = content.replace(BLOCK_HTML_RE, match => {
+    // Look at the lines between the open and close tags. If any of them starts
+    // at column 0 with bare text (not whitespace, not another tag) and contains
+    // `{`, mdxish will parse that line as a paragraph and the brace as an MDX
+    // expression, which would throw an error. So we let the brace balancer escape it.
+    const interior = match.split('\n').slice(1, -1);
+    const hazard = interior.some(line => line.length > 0 && line[0] !== ' ' && line[0] !== '\t' && line[0] !== '<' && line.includes('{'));
+    if (hazard) return match;
+
+    htmlElements.push(match);
+    return `${HTML_ELEM_PLACEHOLDER_PREFIX}${htmlElements.length - 1}___`;
+  });
+  return { htmlElements, protectedContent };
+}
+
+function restoreHTMLElements(content: string, htmlElements: string[]): string {
+  if (htmlElements.length === 0) return content;
+  return content.replace(HTML_ELEM_PLACEHOLDER, (_m, idx) => htmlElements[parseInt(idx, 10)]);
+}
+
+/**
+ * Escapes unbalanced and paragraph-spanning braces so MDX doesn't trip on them.
  */
 function escapeProblematicBraces(content: string): string {
-  // Skip HTML elements that mdxish parses as raw HTML — escaping their braces
-  // would leak `\` as literal text via rehypeRaw. The hazard signal is an
-  // interior line that starts with `{` at column 0: mdxish tokenizes that as
-  // an MDX expression, and a following blank line breaks parsing. Indented
-  // `{` is fine — mdxish doesn't promote it to an expression. So skip any
-  // line-anchored block element whose interior has no column-0 `{`.
-  const htmlElements: string[] = [];
-  const TAG = '[a-z][a-zA-Z0-9]*';
-  const BLOCK_HTML = new RegExp(
-    `(?<=^|\\n)[ \\t]*<(${TAG})(?:\\s[^>]*)?>[\\s\\S]*?</\\1>[ \\t]*(?=\\n|$)`,
-    'g',
-  );
+  const { htmlElements, protectedContent } = protectHTMLElements(content);
 
-  const hasColumnZeroOpenBrace = (match: string): boolean => {
-    // Hazard: an interior line that begins at column 0 with bare text (not a
-    // tag, not whitespace) and contains `{`. mdxish promotes it to an MDX
-    // expression and the surrounding block then breaks parsing. Indented
-    // text and tag-only lines are safe — mdxish keeps treating them as raw
-    // HTML, so we can leave the braces alone there.
-    const lines = match.split('\n');
-    return lines.slice(1, -1).some(line => line.length > 0 && line[0] !== ' ' && line[0] !== '\t' && line[0] !== '<' && line.includes('{'));
-  };
-
-  const stashIfRaw = (match: string): string => {
-    if (hasColumnZeroOpenBrace(match)) return match;
-    const idx = htmlElements.length;
-    htmlElements.push(match);
-    return `___HTML_ELEM_${idx}___`;
-  };
-  const safe = content.replace(BLOCK_HTML, stashIfRaw);
-
-  const toEscape = new Set<number>();
-  // Convert to array of Unicode code points to handle emojis and multi-byte characters correctly
-  const chars = Array.from(safe);
   let strDelim: string | null = null;
   let strEscaped = false;
-  // Stack of open braces with their state
-  const openStack: { hasBlankLine: boolean; isAttrExpr: boolean; pos: number }[] = [];
   // Track position of last newline (outside strings) to detect blank lines
-  let lastNewlinePos = -2; // -2 means no recent newline
+  // -2 means no recent newline
+  let lastNewlinePos = -2;
+
+  // Character state machine trackers
+  const toEscape = new Set<number>();
+  // Convert to array of Unicode code points so that emojis and multi-byte characters are correctly tracked
+  const chars = Array.from(protectedContent);
+  const openStack: { hasBlankLine: boolean; isAttrExpr: boolean; pos: number }[] = [];
 
   for (let i = 0; i < chars.length; i += 1) {
     const ch = chars[i];
@@ -122,24 +131,18 @@ function escapeProblematicBraces(content: string): string {
         // eslint-disable-next-line no-continue
         continue;
       }
-
-      // Track newlines to detect blank lines (paragraph boundaries)
       if (ch === '\n') {
-        // Check if this newline creates a blank line (only whitespace since last newline)
         if (lastNewlinePos >= 0) {
           const between = chars.slice(lastNewlinePos + 1, i).join('');
           if (/^[ \t]*$/.test(between)) {
-            // This is a blank line - mark all open expressions as paragraph-spanning
-            openStack.forEach(entry => {
-              entry.hasBlankLine = true;
-            });
+            openStack.forEach(entry => { entry.hasBlankLine = true; });
           }
         }
         lastNewlinePos = i;
       }
     }
 
-    // Skip already-escaped braces (count preceding backslashes)
+    // Skip already-escaped braces (odd run of preceding backslashes).
     if (ch === '{' || ch === '}') {
       let bs = 0;
       for (let j = i - 1; j >= 0 && chars[j] === '\\'; j -= 1) bs += 1;
@@ -150,10 +153,9 @@ function escapeProblematicBraces(content: string): string {
     }
 
     if (ch === '{') {
-      // If preceded by `=` (ignoring whitespace), this is a JSX attribute
-      // expression (e.g. `data={[...]}`). The mdxComponent tokenizer captures
-      // the entire component block, so blank lines inside attribute values
-      // won't split paragraphs — skip the blank-line check for these.
+      // `=` (after whitespace) before `{` ⇒ JSX attribute expression. The
+      // mdxComponent tokenizer captures the whole component, so blank lines
+      // inside attribute values are harmless. Nested `{` inherits the flag.
       let isAttrExpr = false;
       for (let j = i - 1; j >= 0; j -= 1) {
         const pc = chars[j];
@@ -163,26 +165,17 @@ function escapeProblematicBraces(content: string): string {
       // Nested `{ ... }` inside an attribute value (e.g. `data={[{ ... }]}` or
       // `data={{ a: { b: 1 } }}`) must inherit the same exemption; only the
       // outer `{` is directly after `=`.
-      if (!isAttrExpr && openStack.length > 0) {
-        const parent = openStack[openStack.length - 1];
-        if (parent.isAttrExpr) {
-          isAttrExpr = true;
-        }
+      if (!isAttrExpr && openStack.length > 0 && openStack[openStack.length - 1].isAttrExpr) {
+        isAttrExpr = true;
       }
       openStack.push({ pos: i, hasBlankLine: false, isAttrExpr });
-      lastNewlinePos = -2; // Reset newline tracking for new expression
+      lastNewlinePos = -2;
+
     } else if (ch === '}') {
       if (openStack.length > 0) {
         const entry = openStack.pop()!;
-        // Don't escape pure JSX comments, the `jsxComment` tokenizer downstream
-        // already knows how to swallow a whole `{/* ... */}` block in one go,
-        // even if the body has blank lines in it. If we escape the braces here
-        // the tokenizer never gets a shot at it.
-        //
-        // "Pure" means the braces open with `{/*` and close with `*/}` right
-        // next to each other. Something like `{/* c */ expr\n\nmore}` is just
-        // a regular expression that happens to start with a comment, so it
-        // still needs the normal blank-line protection.
+        // Pure `{/* ... */}` comments are handled downstream by the jsxComment
+        // tokenizer — escaping their braces would prevent it from running.
         const isPureJsxComment =
           chars[entry.pos + 1] === '/' &&
           chars[entry.pos + 2] === '*' &&
@@ -193,25 +186,19 @@ function escapeProblematicBraces(content: string): string {
           toEscape.add(i);
         }
       } else {
-        // Unbalanced closing brace (no matching open)
         toEscape.add(i);
       }
     }
   }
 
-  // Any remaining open braces are unbalanced
+  // Anything still open is unbalanced.
   openStack.forEach(entry => toEscape.add(entry.pos));
 
-  // If there are no problematic braces, return safe content as-is;
-  // otherwise, escape each problematic `{` or `}` so MDX doesn't treat them as expressions.
-  let result = toEscape.size === 0 ? safe : chars.map((ch, i) => (toEscape.has(i) ? `\\${ch}` : ch)).join('');
+  // Reconstruct the content with the escaped braces.
+  const escapedContent = toEscape.size === 0 ? protectedContent : chars.map((ch, i) => (toEscape.has(i) ? `\\${ch}` : ch)).join('');
 
-  // Restore HTML elements
-  if (htmlElements.length > 0) {
-    result = result.replace(/___HTML_ELEM_(\d+)___/g, (_m, idx) => htmlElements[parseInt(idx, 10)]);
-  }
-
-  return result;
+  const restoredContent = restoreHTMLElements(escapedContent, htmlElements);
+  return restoredContent;
 }
 
 /**
@@ -226,12 +213,10 @@ function escapeProblematicBraces(content: string): string {
  */
 export function preprocessJSXExpressions(content: string): string {
   let processed = protectHTMLBlockContent(content);
-
   const { protectedCode, protectedContent } = protectCodeBlocks(processed);
 
   processed = escapeProblematicBraces(protectedContent);
 
   processed = restoreCodeBlocks(processed, protectedCode);
-
   return processed;
 }

--- a/processor/transform/mdxish/preprocess-jsx-expressions.ts
+++ b/processor/transform/mdxish/preprocess-jsx-expressions.ts
@@ -65,14 +65,12 @@ const HTML_ELEM_PLACEHOLDER = new RegExp(`${HTML_ELEM_PLACEHOLDER_PREFIX}(\\d+)_
 const BLOCK_HTML_RE = /(?<=^|\n)[ \t]*<([a-z][a-zA-Z0-9]*)(?:\s[^>]*)?>[\s\S]*?<\/\1>[ \t]*(?=\n|$)/g;
 
 /**
- * Extracts and replaces raw HTML element sequences so they don't get affected by the brace escaping
- * and surface literal `\{` before an unclosed brace inside the HTML.
+ * Hides line-anchored HTML elements from the brace-escaping pass so we don't leak `\{`
+ * into rendered output (rehypeRaw renders the `\` literally, e.g. `<div>{foo</div>`).
  *
- * In most cases, we still need to escape unclosed braces  under HTML elements,
- * especially if they span multiple lines because the sequence might get split in the pipeline and
- * the opening braces might cause an error with the mdxExpression step.
- *
- * E.g. `<div>{foo</div>` should be rendered as raw HTML, so escaping the `{` would surface `\{` literally.
+ * One carve-out: if an interior line at column 0 has bare text containing `{`, mdxish
+ * parses that line as a paragraph and the mdxExpression step would throw without an
+ * escape — so we leave that case to the brace balancer.
  */
 function protectHTMLElements(content: string): { htmlElements: string[]; protectedContent: string } {
   const htmlElements: string[] = [];
@@ -81,6 +79,7 @@ function protectHTMLElements(content: string): { htmlElements: string[]; protect
     // at column 0 with bare text (not whitespace, not another tag) and contains
     // `{`, mdxish will parse that line as a paragraph and the brace as an MDX
     // expression, which would throw an error. So we let the brace balancer escape it.
+    // Otherwise, we need to extract the sequence to protect it from the brace escaping.
     const interior = match.split('\n').slice(1, -1);
     const hazard = interior.some(line => line.length > 0 && line[0] !== ' ' && line[0] !== '\t' && line[0] !== '<' && line.includes('{'));
     if (hazard) return match;
@@ -170,7 +169,6 @@ function escapeProblematicBraces(content: string): string {
       }
       openStack.push({ pos: i, hasBlankLine: false, isAttrExpr });
       lastNewlinePos = -2;
-
     } else if (ch === '}') {
       if (openStack.length > 0) {
         const entry = openStack.pop()!;
@@ -196,9 +194,7 @@ function escapeProblematicBraces(content: string): string {
 
   // Reconstruct the content with the escaped braces.
   const escapedContent = toEscape.size === 0 ? protectedContent : chars.map((ch, i) => (toEscape.has(i) ? `\\${ch}` : ch)).join('');
-
-  const restoredContent = restoreHTMLElements(escapedContent, htmlElements);
-  return restoredContent;
+  return restoreHTMLElements(escapedContent, htmlElements);
 }
 
 /**

--- a/processor/transform/mdxish/preprocess-jsx-expressions.ts
+++ b/processor/transform/mdxish/preprocess-jsx-expressions.ts
@@ -1,4 +1,5 @@
 import { JSX_COMMENT_REGEX } from '../../../lib/micromark/jsx-comment/pattern';
+import { MAGIC_BLOCK_REGEX } from '../../../lib/utils/extractMagicBlocks';
 import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
 
 // Base64 encode (Node.js + browser compatible)
@@ -204,10 +205,25 @@ function escapeProblematicBraces(content: string): string {
  */
 export function preprocessJSXExpressions(content: string): string {
   let processed = protectHTMLBlockContent(content);
+
+  // We don't want to touch magic block content as well as they're flaky
+  // and need to be exact as it is in the original markdown.
+  const magicBlocks: string[] = [];
+  processed = processed.replace(MAGIC_BLOCK_REGEX, match => {
+    const idx = magicBlocks.length;
+    magicBlocks.push(match);
+    return `___MAGIC_BLOCK_${idx}___`;
+  });
+
   const { protectedCode, protectedContent } = protectCodeBlocks(processed);
 
   processed = escapeProblematicBraces(protectedContent);
 
   processed = restoreCodeBlocks(processed, protectedCode);
+
+  if (magicBlocks.length > 0) {
+    processed = processed.replace(/___MAGIC_BLOCK_(\d+)___/g, (_m, idx) => magicBlocks[parseInt(idx, 10)]);
+  }
+
   return processed;
 }

--- a/processor/transform/mdxish/preprocess-jsx-expressions.ts
+++ b/processor/transform/mdxish/preprocess-jsx-expressions.ts
@@ -64,27 +64,36 @@ export function removeJSXComments(content: string): string {
  * so backslashes don't leak into rendered output via rehypeRaw.
  */
 function escapeProblematicBraces(content: string): string {
-  // Skip HTML elements that mdxish will parse as raw HTML — escaping their
-  // braces would surface backslashes as literal text via rehypeRaw. We only
-  // match what mdxish actually treats as raw: (1) a block element on a single
-  // line, or (2) a block element whose interior lines are themselves only
-  // tags. A bare-text line at column 0 inside a block makes mdxish split a
-  // paragraph out and parse `{` as MDX, so we must NOT skip those.
+  // Skip HTML elements that mdxish parses as raw HTML — escaping their braces
+  // would leak `\` as literal text via rehypeRaw. The hazard signal is an
+  // interior line that starts with `{` at column 0: mdxish tokenizes that as
+  // an MDX expression, and a following blank line breaks parsing. Indented
+  // `{` is fine — mdxish doesn't promote it to an expression. So skip any
+  // line-anchored block element whose interior has no column-0 `{`.
   const htmlElements: string[] = [];
   const TAG = '[a-z][a-zA-Z0-9]*';
-  const SAME_LINE = new RegExp(`(?<=^|\\n)[ \\t]*<(${TAG})(?:\\s[^>]*)?>[^\\n]*?</\\1>[ \\t]*(?=\\n|$)`, 'g');
-  // Multi-line: opening tag alone on its line, interior lines each start with
-  // whitespace + `<` (i.e., tags only), closing tag alone on its line.
-  const MULTI_LINE = new RegExp(
-    `(?<=^|\\n)[ \\t]*<(${TAG})(?:\\s[^>]*)?>[ \\t]*\\n(?:[ \\t]*<[^\\n]*\\n)+?[ \\t]*</\\1>[ \\t]*(?=\\n|$)`,
+  const BLOCK_HTML = new RegExp(
+    `(?<=^|\\n)[ \\t]*<(${TAG})(?:\\s[^>]*)?>[\\s\\S]*?</\\1>[ \\t]*(?=\\n|$)`,
     'g',
   );
-  const stash = (match: string): string => {
+
+  const hasColumnZeroOpenBrace = (match: string): boolean => {
+    // Hazard: an interior line that begins at column 0 with bare text (not a
+    // tag, not whitespace) and contains `{`. mdxish promotes it to an MDX
+    // expression and the surrounding block then breaks parsing. Indented
+    // text and tag-only lines are safe — mdxish keeps treating them as raw
+    // HTML, so we can leave the braces alone there.
+    const lines = match.split('\n');
+    return lines.slice(1, -1).some(line => line.length > 0 && line[0] !== ' ' && line[0] !== '\t' && line[0] !== '<' && line.includes('{'));
+  };
+
+  const stashIfRaw = (match: string): string => {
+    if (hasColumnZeroOpenBrace(match)) return match;
     const idx = htmlElements.length;
     htmlElements.push(match);
     return `___HTML_ELEM_${idx}___`;
   };
-  const safe = content.replace(MULTI_LINE, stash).replace(SAME_LINE, stash);
+  const safe = content.replace(BLOCK_HTML, stashIfRaw);
 
   const toEscape = new Set<number>();
   // Convert to array of Unicode code points to handle emojis and multi-byte characters correctly


### PR DESCRIPTION
| 🎫 Resolve RM-16280 |
| :-----------------: |

## 🎯 What does this PR do?

Fixes first regression reported in the ticket, where a magic block wasn't rendering.

### Issue
The issue was quite specific to the content of the first magic block. The first magic block contained an unclosed `<li>` tag in its JSON body, and the magic block right after it happened to contain a matching `</li>`. The `escapeProblematicBraces` step in the JSX preprocessor uses a regex to extract `<tag>...</tag>` sequences and stash them away from brace escaping. That regex spanned across the magic-block boundary and pulled the closing `</li>` out together with the opening `<li>`. Once the closing tag was removed from the second block, the brace balancer saw the second block's opening `{` as unbalanced and escaped it to `\{`, which broke the magic-block parser and caused the block to fall through as plain text.

This regression has been live for about 2 months, it landed with the HTML skipping introduced in #1358.

### Fix
Tighten the HTML-extraction regex so it only matches what we actually need to protect: a line-anchored, single-element block where escaping `\{` would leak literally via rehypeRaw. Otherwise, every other HTML spans, especially the multi-line ones, and specifically the interior lines start at column 0 with bare text + `{`, might potentially contain problematic unclosed braces and need to go through the escape pipeline.

While I was in there, I also more related edge cases that were silently broken (see the new tests in `__tests__/transformers/preprocess-jsx-expressions.test.ts`). There are still some I found that are failing but it looks like edge case and were more difficult to fix.

### Some considerations
I also considered extract & replacing magic blocks in the preprocess step which would solve the akamai issue, and technically would be correct as well, but it looks more flaky given the urgency, and I also my fix tries to solve a bigger issue that's actually not really magic blocks related.

## 🧪 QA tips

This magic block should now render:
```
[block:parameters]
{
  "data": {
    "h-0": "Setting",
    "h-1": "Description",
    "0-0": "**Index name**",
    "0-1": "A file specified here will be served if the request does not end in a specific file name and extension. Use single white-spaces to include multiple entries, the system will use the first entry found.  \n  \nThe file(s) named here is served for HTTP download requests that end with a trailing slash (“/”), as well as those that actually end in the value input here. NetStorage doesn't automatically apply the Force Case setting to Index requests. If using the Force Case option, you must manually name your index.htm file accordingly. For example, if the Force case setting is set to Convert all requests to uppercase, then you must set the filename to **INDEX.HTM** instead of **index.htm**.",
    "1-0": "**Directory listing**",
    "1-1": "If desired, you can truncate or hide the file path displayed in the HTML directory listing for the Index name file.  \nDon’t serve - do not serve directory listings, but continue to search for the requested Index Name file.  \nServe limited number of objects -  limit directory listings in the path to the number specified in Index limit.  \nServe unlimited number of objects - unlimited objects in directory displayed.",
    "2-0": "**Index limit**",
    "2-1": "Input an integer value here that represents the number of directories in a path that should be revealed:  \n  \nLimit directory listings in the path to this number. Directories will be listed based on root first, up to the number specified here, with sub-directories in excess of this quantity omitted and revealed as `...` in the path.",
    "3-0": "**Search on 404**",
    "3-1": "Select the action that should be taken in the event of a 404 error. (The client was able to access NetStorage, but the requested content or directory could not be found.)  \n  \n<li>**Do not look for a directory**. Select this to stop additional searches, and return an “Error 404.”\n<li>**Look for an explicit directory entry**. Select this to have the system look for an explicit directory matching the path specified in the request. (For example, any superfluous “/” are stripped out in the path that might have been inadvertently included in an attempt to access an implicit directory).\n<li>**Always look for an implicit or explicit directory, before serving a 404**. Select this to have the system look for both an explicit directory (as discussed in the point above), as well as an implicit one that may match a path defined in the request."
  },
  "cols": 2,
  "rows": 4,
  "align": [
    "left",
    "left"
  ]
}
[/block]


[block:html]
{
  "html": "<table>\n<thead>\n<tr>\n<th style=\"text-align:left\">Option</th>\n<th style=\"text-align:left\">Description</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>\n<strong>Upload directory</strong>\n</td>\n<td>This is the upload directory that contains the directory that you want to purge.</td>\n</tr>\n<tr>\n<td>\n<strong>Purged directory path</strong>\n</td>\n<td>The directory path where the automatic purge routine will be applied. Any directory path specified here must already exist in the selected upload directory.\n</tr>\n<tr>\n<td>\n<strong>Size threshold</strong>\n</td>\n<td>Input a non-zero, positive decimal and select the appropriate file size type from the drop-down (Bytes, KB, MB or GB). When the specified value is reached, the purge will be initiated.<br>\n<blockquote class=\"callout callout_info\" theme=\"📘\"><h3 class=\"callout-heading true\"></h3><p>This functionality uses sub-directories and their content when determining overall directory size. However, only contents within the <strong>Upload Directory</strong> field is targeted by the purge unless the <strong>Recursive Purge</strong> option is enabled.</p></blockquote>\n</td>\n</tr>\n<tr>\n<td>\n<strong>Age threshold (in days)</strong>\n</td>\n<td>Input a non-zero, positive integer to represent the desired number of days. (For example, insert “10” to represent files 10 days older than the current date.) Once the value set in the \"Size threshold\" field is reached, files older than this date will be purged.<br>\n<blockquote class=\"callout callout_info\" theme=\"📘\"><h3 class=\"callout-heading true\"></h3>If no content is older than what you’ve specified here, nothing is purged--even if the directory size exceeds what is defined in the <strong>Purge When The Directory Reaches</strong> field.</blockquote>\n</tr>\n<tr>\n<td>\n<strong>Recursive purge</strong>\n</td>\n<td>With this option enabled, subdirectories within the specified upload directory will also be targeted, and their contents will be purged. If left disabled, only files within the actual Upload Directory will be purged. Purge routines don't delete empty, explicit directories and must be deleted manually.</td>\n</tr>\n<tr>\n<td>\n<strong>File exclusion regular expression</strong>\n</td>\n<td>Using POSIX Extended Regular Expression syntax, input file names/types that should be excluded from the purge. Some basic examples of use include the following:<br>\n<ul id=\"\">\n<li dir=\"ltr\" id=\"\"><strong id=\"\">.html$</strong> - To exclude all “.html” files.</li>\n<li dir=\"ltr\" id=\"\"><strong id=\"\">/index.html$</strong> - To exclude all instances of the file named “index.html”.</li>\n<li dir=\"ltr\" id=\"\"><strong id=\"\">b</strong> - To exclude any file with the character “b” anywhere in its pathname.</li>\n<li dir=\"ltr\" id=\"\"><strong id=\"\">/[0-9]+$</strong> - To exclude all files whose filenames consist of numbers.</li>\n<li dir=\"ltr\" id=\"\"><strong id=\"\">/trash/</strong> - To exclude all files in any directory named “trash” (i.e., throughout the path).</li>\n<li dir=\"ltr\" id=\"\"><strong id=\"\">^/files/test/only.new.foo/5.bat$</strong> - To explicitly exclude the file, “5.bat” which exists in the path, “/files/test/only.new.foo/”.</li>\n</ul>\n<blockquote class=\"callout callout_info\" theme=\"📘\"><h3 class=\"callout-heading true\"></h3><p>File Exclusion Regular Expression takes precedence over File Selection Regular Expression, below (i.e., if a file/path match a regular expression input set for both options, the EXCLUSION will occur).</p></blockquote>\n</td>\n</tr>\n<tr>\n<td>\n<strong>File inclusion regular expression</strong>\n</td>\n<td>Using POSIX Extended Regular Expression syntax, input file names/types that should explicitly be included in the purge. These file types/names will be targeted first in the list of applicable files for the purge. The same examples cited above apply with this option as well, except those files would be included.<br>\n<blockquote class=\"callout callout_info\" theme=\"📘\"><h3 class=\"callout-heading true\"></h3><p>Basic wildcard-type patterns are not supported, only POSIX Extended Regular Expressions. For example, while “foo<em>” matches any filename beginning with “foo”, it also matches filenames containing \"fo\" (e.g., \"file.fo_g\", \"c_fo\" and \"ox_fo_rd.txt\".) And “test.</em>” doesn't just match \"test\" with any filename extension. It also matches \"cu<em>test</em>.mp4\" and \"data.la<em>test</em>\".</p></blockquote>\n</td>\n</tr>\n</tbody>\n</table>\n\n"
}
[/block]
```

These should no longer error out:
```
hi <div>{unclosed</div>

<li>
{ unclosed
</li>
```
