### PR TITLE
fix(mdxish): render markdown after unclosed block-level HTML in table cells

### DIFF
--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -758,6 +758,71 @@ ${JSON.stringify(
       expect(underscoreEm).toBeDefined();
       expect(underscoreEm.tagName).toBe('em');
     });
+
+    it('should render markdown in a cell if it is under an unclosed HTML tag', () => {
+      const md = `[block:parameters]
+${JSON.stringify(
+  {
+    data: {
+      'h-0': 'Header',
+      '0-0': '<div>**strong**',
+    },
+    cols: 1,
+    rows: 1,
+  },
+  null,
+  2,
+)}
+[/block]`;
+
+      const ast = mdxish(md);
+      const body = findElementByTagName(ast, 'strong');
+      expect(body).not.toBeNull();
+    });
+
+    it('should render markdown after an unclosed block-level HTML tag with multiple inline marks', () => {
+      const md = `[block:parameters]
+${JSON.stringify(
+  {
+    data: {
+      'h-0': 'Header',
+      '0-0': '<section>**bold** and _em_ and `code`',
+    },
+    cols: 1,
+    rows: 1,
+  },
+  null,
+  2,
+)}
+[/block]`;
+
+      const ast = mdxish(md);
+      expect(findElementByTagName(ast, 'strong')).not.toBeNull();
+      expect(findElementByTagName(ast, 'em')).not.toBeNull();
+      expect(findElementByTagName(ast, 'code')).not.toBeNull();
+    });
+
+    it('should leave bare inline HTML tags untouched (no mangling to <i></i>)', () => {
+      const md = `[block:parameters]
+${JSON.stringify(
+  {
+    data: {
+      'h-0': 'Header',
+      '0-0': '<i>italic text</i>',
+    },
+    cols: 1,
+    rows: 1,
+  },
+  null,
+  2,
+)}
+[/block]`;
+
+      const ast = mdxish(md);
+      const i = findElementByTagName(ast, 'i');
+      expect(i).not.toBeNull();
+      expect(i!.children.length).toBeGreaterThan(0);
+    });
   });
 
   describe('recipe block', () => {

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -50,9 +50,9 @@ import normalizeEmphasisAST from '../normalize-malformed-md-syntax';
 
 import {
   CLOSE_BLOCK_TAG_BOUNDARY_RE,
-  COMPLETE_HTML_ELEMENT_RE,
   HTML_ELEMENT_BLOCK_RE,
   HTML_TAG_RE,
+  HTML_TAG_STRIP_RE,
   NEWLINE_WITH_WHITESPACE_RE,
 } from './patterns';
 import {
@@ -270,10 +270,12 @@ const parseTableCell = (text: string): MdastNode[] => {
   const processed = trimmedLines.join('\n');
   const tree = contentParser.runSync(contentParser.parse(processed)) as MdastRoot;
 
-  // Process markdown inside complete HTML elements (e.g. _emphasis_ within <li>).
-  // Bare tags like "<i>" are left for rehypeRaw since rehype-parse would mangle them.
+  // Process markdown inside HTML blocks that have non-tag inner text (e.g. `<div>**x**`
+  // or `<ul><li>_x_</li></ul>`). Pure bare tags like "<i>" or "<br>" are left for rehypeRaw
+  // since rehype-parse would mangle them (auto-closing void/inline elements).
   visit(tree, 'html', (node: { type: 'html'; value: string }) => {
-    if (COMPLETE_HTML_ELEMENT_RE.test(node.value)) {
+    const hasInnerText = node.value.replace(HTML_TAG_STRIP_RE, '').trim().length > 0;
+    if (hasInnerText) {
       node.value = processMarkdownInHtmlString(node.value);
     } else {
       node.value = escapeInvalidTags(node.value);

--- a/processor/transform/mdxish/magic-blocks/patterns.ts
+++ b/processor/transform/mdxish/magic-blocks/patterns.ts
@@ -10,5 +10,5 @@ export const NEWLINE_WITH_WHITESPACE_RE = /[^\S\n]*\n[^\S\n]*/g;
 /** Matches a closing block-level tag followed by non-tag text or by a newline then non-blank content. */
 export const CLOSE_BLOCK_TAG_BOUNDARY_RE = /<\/([a-zA-Z][a-zA-Z0-9-]*)>\s*(?:(?!<)(\S)|\n([^\n]))/g;
 
-/** Tests whether a string contains a complete HTML element (open + close tag). */
-export const COMPLETE_HTML_ELEMENT_RE = /<[a-zA-Z][^>]*>[\s\S]*<\/[a-zA-Z]/;
+/** Strips HTML open/close tags. Used to detect non-tag inner text content. */
+export const HTML_TAG_STRIP_RE = /<\/?[a-zA-Z][^>]*>/g;


### PR DESCRIPTION
## 🎯 What does this PR do?

Allow markdown after an unclosed block-level HTML tag inside a table magic block cell to actually render instead of being as raw text (e.g. `<div>**strong**` keeps `**strong**` literal).

Akamai reported an issue where some bolded text inside a table wasn't rendering the boldness. The root issue was that those text were under an unclosed HTML tag, in this case `<li>`, and our table magic block transformer logic only targeted content inside fully closed HTML tags to be markdown parsed. 

Honestly I think this isn't necessarily a bug but more of a rendering quirk that was present in legacy and akamai uses. We shouldn't really need to render markdown inside HTML, since legacy does that we had to create some rather verbose special logic just to deal with them in table cells.

So the fix is updating that parsing in HTML markdown logic to check for inner text after the opening tag instead of only looking for fully closed ones, so this also covers the unclosed case while still bypassing bare-tag cases like `<i>` / `<br>` that rehype-parse would mangle.

## 🧪 QA tips

1. Cell with unclosed block tag — `**strong**` should render as bold:

```
[block:parameters]
{ "data": { "h-0": "Header", "0-0": "<div>**strong**" }, "cols": 1, "rows": 1 }
[/block]
```

2. Multiple inline marks under an unclosed block tag should all render:

```
[block:parameters]
{ "data": { "h-0": "Header", "0-0": "<section>**bold** and _em_ and `code`" }, "cols": 1, "rows": 1 }
[/block]
```

3. Regression — bare inline tags should still pass through untouched:

```
[block:parameters]
{ "data": { "h-0": "Header", "0-0": "<i>italic text</i>" }, "cols": 1, "rows": 1 }
[/block]
```