### PR TITLE
fix(Callout): only apply callout title style to headings

### DIFF
--- a/components/Callout/style.scss
+++ b/components/Callout/style.scss
@@ -158,7 +158,7 @@
     }
   }
 
-  .callout-icon + * {
+  .callout-icon + .heading {
     color: var(--Callout-title);
   }
 


### PR DESCRIPTION
| 🎫 Resolve CX-3110 |
| :-----------------: |

`<Callout>` components without a header in their content were incorrectly styling the first body element as a callout title. This happened because the CSS selector `.callout-icon + *` matched any sibling  element after the callout icon including the first paragraph of body content when no title was present.                                                                             
                                                                                                             

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

- The fix tightens the selector to .callout-icon + .heading, so the --Callout-title CSS variable only applies when an actual heading element follows the icon. This was especially visible for customers using custom CSS themes (see ticket), where --title was set to a distinct color.

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

Content _should not_ have highlight color:
```
<Callout icon="📍" theme="info">
  Lorem ipsum dolor sit amet
</Callout>
```

Heading in content _should_ have highlight color:
```
<Callout icon="📍" theme="info">
  ### Heading
 
  Lorem ipsum dolor sit amet
</Callout>
```

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
