### PR TITLE
fix(mdxish): scope \n unescaping in HTMLBlock content

### DIFF
--- a/__tests__/compilers/html-block.test.ts
+++ b/__tests__/compilers/html-block.test.ts
@@ -185,4 +185,32 @@ const foo = () => {
     // The expected content should have triple backticks
     expect(htmlProp).toBe('<pre>```javascript\nconst x = 1;\n```</pre>');
   });
+
+  it('preserves \\n escape sequences inside <script> string literals', () => {
+    const markdown = [
+      '<HTMLBlock runScripts={true}>{`',
+      '<div id="repro">before</div>',
+      '<script>alert(1);</script>',
+      '<script>',
+      '  var x = "hello\\nworld";',
+      '  document.getElementById("repro").textContent = "script ran: " + x;',
+      '</script>',
+      '`}</HTMLBlock>',
+    ].join('\n');
+
+    const hast = mdxish(markdown);
+    const paragraph = hast.children[0] as Element;
+
+    expect(paragraph.type).toBe('element');
+    const htmlBlock = findHTMLBlock(paragraph);
+    expect(htmlBlock).toBeDefined();
+
+    const htmlProp = htmlBlock?.properties?.html as string;
+    expect(htmlProp).toBeDefined();
+
+    // The `\n` inside the JS string literal must survive as the two-byte escape
+    // sequence so eval() sees a well-formed JS string. A real LF here would break it.
+    expect(htmlProp).toContain('var x = "hello\\nworld";');
+    expect(htmlProp).not.toContain('var x = "hello\nworld";');
+  });
 });

--- a/__tests__/compilers/html-block.test.ts
+++ b/__tests__/compilers/html-block.test.ts
@@ -186,6 +186,34 @@ const foo = () => {
     expect(htmlProp).toBe('<pre>```javascript\nconst x = 1;\n```</pre>');
   });
 
+  it('expands \\n only inside <pre>/<code>, not in plain text after tags', () => {
+    const markdown = [
+      '<HTMLBlock>{`',
+      '<pre>qerq3er \\n qerreqqe</pre>',
+      '<code>qerq3er \\n qerreqqe</code>',
+      'hello \\n world',
+      '`}</HTMLBlock>',
+    ].join('\n');
+
+    const hast = mdxish(markdown);
+    const paragraph = hast.children[0] as Element;
+
+    expect(paragraph.type).toBe('element');
+    const htmlBlock = findHTMLBlock(paragraph);
+    expect(htmlBlock).toBeDefined();
+
+    const htmlProp = htmlBlock?.properties?.html as string;
+    expect(htmlProp).toBeDefined();
+
+    // Literal `\n` expands to real newlines only inside <pre> / <code>.
+    expect(htmlProp).toBe(
+      '<pre>qerq3er \n qerreqqe</pre>\n<code>qerq3er \n qerreqqe</code>\n\nhello \\n world',
+    );
+    // Must not turn the plain-text `hello \n world` into a line break between words.
+    expect(htmlProp).toContain('hello \\n world');
+    expect(htmlProp).not.toMatch(/hello \n world/); // space + LF + space (wrong)
+  });
+
   it('preserves \\n escape sequences inside <script> string literals', () => {
     const markdown = [
       '<HTMLBlock runScripts={true}>{`',

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -163,7 +163,7 @@ export function formatHtmlForMdxish(html: string): string {
 
   // Convert literal \n sequences to actual newlines only inside <pre> and <code>.
   // Because <pre> needs to respect the newline visual and
-  // escape characters shoudl be processed in the <code> tag.
+  // escape characters should be processed in the <code> tag.
   //
   // We don't want to unescape every \n because it might break the HTML & cause errors
   // Example: <script>console.log("\n");</script>

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -161,8 +161,23 @@ export function formatHtmlForMdxish(html: string): string {
   // Removes the leading/trailing newlines
   let cleaned = processed.replace(/^\s*\n|\n\s*$/g, '');
 
-  // Unescape backticks: \` -> ` (users escape backticks in template literals
-  // because backticks would otherwise terminate the JSX template literal child).
+  // Convert literal \n sequences to actual newlines only inside <pre> and <code>.
+  // Because <pre> needs to respect the newline visual and
+  // escape characters shoudl be processed in the <code> tag.
+  //
+  // We don't want to unescape every \n because it might break the HTML & cause errors
+  // Example: <script>console.log("\n");</script>
+  // Would get turned into: <script>console.log("
+  // ");</script>
+  // which is invalid javascript and will cause error
+  cleaned = cleaned.replace(
+    /(<(pre|code)\b[^>]*>)([\s\S]*?)(<\/\2>)/gi,
+    (_m, open: string, _tag: string, inner: string, close: string) =>
+      open + inner.replace(/\\n/g, '\n') + close,
+  );
+
+  // Unescape backticks: \` -> ` (users escape backticks in template literals)
+  // Handle both cases: \` (adjacent) and \ followed by ` (split by markdown parser)
   cleaned = cleaned.replace(/\\`/g, '`');
 
   // Also handle case where backslash and backtick got separated by markdown parsing

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -161,12 +161,8 @@ export function formatHtmlForMdxish(html: string): string {
   // Removes the leading/trailing newlines
   let cleaned = processed.replace(/^\s*\n|\n\s*$/g, '');
 
-  // Convert literal \n sequences to actual newlines BEFORE processing backticks
-  // This prevents the backtick unescaping regex from incorrectly matching \n sequences
-  cleaned = cleaned.replace(/\\n/g, '\n');
-
-  // Unescape backticks: \` -> ` (users escape backticks in template literals)
-  // Handle both cases: \` (adjacent) and \ followed by ` (split by markdown parser)
+  // Unescape backticks: \` -> ` (users escape backticks in template literals
+  // because backticks would otherwise terminate the JSX template literal child).
   cleaned = cleaned.replace(/\\`/g, '`');
 
   // Also handle case where backslash and backtick got separated by markdown parsing


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

Fixes a `SyntaxError: Invalid or unexpected token` crash thrown from `<HTMLBlock>`, when runScripts is enabled, when the embedded script contains a `\n` escape inside a JS string literal.

### Repro

````mdx
<HTMLBlock runScripts=true>{`
<script>
console.log('\n');
</script>
`}</HTMLBlock>
````

What happened was the \n actually made that code
```
console.log('
');
```
which is invalid javascript & throws an error

### Root cause

We had regex logic in `formatHtmlForMdxish` in `processor/utils.ts` that runs `cleaned.replace(/\\n/g, '\n')` over the whole HTML. That substitution exists to mimic JS template-literal semantics from MDX's HTMLBlocks. But when it applies the regex for `\n` inside `<script>` body, `'\n'` becomes `'` + literal LF + `'`, which is not a valid JS string literal and the execution fails.

### Fix

Scope the `\n → newline` rewrite to the inner text of `<pre>` and `<code>` elements only. Everything outside those tags (including `<script>` bodies) keeps `\n` as the two-char escape, so the script code doesn't error out. We keep evaluating them for `<pre>` because it needs to respect the newline visual and escape sequences should be processed in the `<code>` tag.

### Limitations & Notes

- mdxish output will diverge slightly from strict MDX for `\n` sequences outside `<pre>`/`<code>`, since real MDX evaluates the template literal and always turns `\n` into a newline. In practice this should be fine, the only place authors rely on the newline behaviour is inside code blocks, which we still handle. So this would render differently in MDX, but I think it should be fine since even in MDX the \n don't get rendered anyway
```
  <HTMLBlock>{`
  hello \n there
  `}</HTMLBlock>
```
- This only fixes the JSX `<HTMLBlock>{`...`}</HTMLBlock>` path. Magic-block HTML (`[block:html]...[/block]`) does not reach `formatHtmlForMdxish`, so there is no visual diff with legacy magic-block content.

## 🧪 QA tips

Paste each into a doc and confirm it renders without errors. The first three exercise the JSX `<HTMLBlock>` path; the last two confirm magic-block HTML is unaffected. Test in the markdown playground so you can compare the output in the 3 different engines, very useful to catch differences

- [ ] **Script with `\n` escape (the repro)** — should render without a console SyntaxError; clicking "Run" logs a newline char.

  ````md
  <HTMLBlock runScripts=true>{`
  <script>
  console.log('\n');
  </script>
  `}</HTMLBlock>
  ````

- [ ] **`<pre>` with `\n`** — `\n` should still render as a real line break inside the `<pre>`.

  ````md
  <HTMLBlock>{`
  <pre>line one\nline two\nline three</pre>
  `}</HTMLBlock>
  ````

- [ ] **`<code>` block with `\n`** — `\n` should still produce real newlines between lines of code.

  ````md
  <HTMLBlock>{`
  <pre><code>const a = 1;\nconst b = 2;\nconsole.log(a + b);</code></pre>
  `}</HTMLBlock>
  ````

- [ ] **Mixed: `<script>` + `<pre>` in same block** — `<pre>` newlines render; the script evals cleanly.

  ````md
  <HTMLBlock runScripts=true>{`
  <pre>before\nafter</pre>
  <script>
  document.title = 'ok\n';
  </script>
  `}</HTMLBlock>
  ````

- [ ] **HTML magic block (legacy)** — should look identical to `next`; this PR does not touch the magic-block code path.

  ````md
  [block:html]
  {
    "html": "<pre>line one\nline two</pre><script>console.log('hi');</script>"
  }
  [/block]
  ````

- [ ] Existing suite passes, especially `__tests__/compilers/html-block.test.ts` (nested template literals / code-fence cases).
