### PR TITLE
fix(mdxish): skip variable resolution in Mermaid code blocks

### DIFF
--- a/__tests__/lib/mdxish/variables-code.test.ts
+++ b/__tests__/lib/mdxish/variables-code.test.ts
@@ -118,4 +118,15 @@ const name = 'Bearer ${variable}';
 
     expect(getCodeText(tree)).toBe('{user.secret}');
   });
+
+  it('does not resolve Mermaid sequence arrows as legacy variables', () => {
+    const tree = mdxish(`\`\`\`mermaid
+sequenceDiagram
+  Client <<-->> Server: Bidirectional dotted
+  Client <<->> Server: Bidirectional solid
+\`\`\``);
+
+    expect(getCodeText(tree)).toContain('Client <<-->> Server: Bidirectional dotted');
+    expect(getCodeText(tree)).toContain('Client <<->> Server: Bidirectional solid');
+  });
 });

--- a/processor/transform/mdxish/variables-code.ts
+++ b/processor/transform/mdxish/variables-code.ts
@@ -62,6 +62,8 @@ const variablesCodeResolver: Plugin<[Options?]> = ({ variables }: Options = {}) 
 
   visit(tree, 'code', (node: Code) => {
     if (!node.value) return;
+    if (node.lang === 'mermaid') return;
+
     const nextValue = resolveCodeVariables(node.value, resolvedVariables);
     node.value = nextValue;
 


### PR DESCRIPTION
| 🎫 Resolve CX-3361 |
| :-----------------: |

## 🎯 What does this PR do?

 - Skips MDXish variable resolution inside Mermaid code blocks so Mermaid sequence arrows like `<<-->>` and `<<->>` are preserved.
 - Adds a regression test covering bidirectional Mermaid sequence arrows that were previously parsed as legacy `<<...>>` variables.

  ## 🧪 QA tips

 - [ ] Add this Mermaid block to a docs page and verify it renders without a syntax error:

mermaid: 
  sequenceDiagram
    Client <<-->> Server: Bidirectional dotted
    Client <<->> Server: Bidirectional solid

 - [ ] Run npm test -- __tests__/lib/mdxish/variables-code.test.ts __tests__/lib/mdxish/mermaid.test.ts.

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->

As shown - graphs with previously erroring syntax is now working

https://github.com/user-attachments/assets/34b2d2da-b499-4f35-b814-a4cc665680d5


https://github.com/user-attachments/assets/2d7cf5d9-f7d4-48af-8996-9b875070a7d4