### PR TITLE
fix(mdxish): render Image captions containing entity-encoded JSX

### DIFF
--- a/__tests__/transformers/images.test.ts
+++ b/__tests__/transformers/images.test.ts
@@ -1,3 +1,5 @@
+import type { Element, Nodes as HastNode, Root as HastRoot } from 'hast';
+
 import { mdast } from '../../index';
 import { mdxish } from '../../lib/mdxish';
 import { findElementByTagName } from '../helpers';
@@ -21,6 +23,28 @@ describe('images transformer', () => {
 
     expect(tree.children[0].children[0].children[0].type).toBe('strong');
     expect(tree.children[0].children[0].children[2].type).toBe('emphasis');
+  });
+
+  it('parses an Image inside a caption attribute via mdxish (RM-16428)', () => {
+    const md = `
+<Image align="center" caption="<Image align=&#x22;center&#x22; caption=&#x22;Light & Dark&#x22; src=&#x22;https://example.com/a.png&#x22; />" src="https://example.com/b.png" width="700px" />
+`;
+    expect(() => mdxish(md)).not.toThrow();
+
+    const hast = mdxish(md);
+    const imgs: Element[] = [];
+    const walk = (n: HastNode | HastRoot) => {
+      if ('tagName' in n && n.tagName === 'img') imgs.push(n);
+      if ('children' in n && Array.isArray(n.children)) n.children.forEach(walk);
+    };
+    walk(hast);
+    expect(imgs.length).toBeGreaterThanOrEqual(2);
+
+    const srcs = imgs.map(i => i.properties?.src ?? '');
+    expect(srcs).toStrictEqual(expect.arrayContaining([
+      'https://example.com/b.png',
+      'https://example.com/a.png',
+    ]));
   });
 
   it('can parse attributes', () => {

--- a/processor/plugin/mdxish-components.ts
+++ b/processor/plugin/mdxish-components.ts
@@ -3,6 +3,7 @@ import type { Root, Element, ElementContent } from 'hast';
 import type { Transformer } from 'unified';
 import type { VFile } from 'vfile';
 
+import { decodeHTML } from 'entities';
 import { visit } from 'unist-util-visit';
 
 import { INLINE_COMPONENT_TAGS_LOWER } from '../../lib/constants';
@@ -181,7 +182,10 @@ export const rehypeMdxishComponents = ({ components, processMarkdown }: Options)
       // rehypeRaw strips children from <img> (void element), so we must
       // re-process the caption here, after rehypeRaw.
       if (node.tagName === 'img' && typeof node.properties?.caption === 'string' && !node.children?.length) {
-        const captionHast = processMarkdown(node.properties.caption as string);
+        // Decode HTML character references before re-parsing so any JSX the author embedded with entity-encoded
+        // quotes (e.g. `caption="<Image align=&#x22;center&#x22; />"`) becomes valid JSX that the inner
+        // pipeline can parse
+        const captionHast = processMarkdown(decodeHTML(node.properties.caption as string));
         node.children = (captionHast.children ?? []).filter(isElementContentNode);
       }
 

--- a/processor/plugin/mdxish-components.ts
+++ b/processor/plugin/mdxish-components.ts
@@ -3,7 +3,6 @@ import type { Root, Element, ElementContent } from 'hast';
 import type { Transformer } from 'unified';
 import type { VFile } from 'vfile';
 
-import { decodeHTML } from 'entities';
 import { visit } from 'unist-util-visit';
 
 import { INLINE_COMPONENT_TAGS_LOWER } from '../../lib/constants';
@@ -182,10 +181,7 @@ export const rehypeMdxishComponents = ({ components, processMarkdown }: Options)
       // rehypeRaw strips children from <img> (void element), so we must
       // re-process the caption here, after rehypeRaw.
       if (node.tagName === 'img' && typeof node.properties?.caption === 'string' && !node.children?.length) {
-        // Decode HTML character references before re-parsing so any JSX the author embedded with entity-encoded
-        // quotes (e.g. `caption="<Image align=&#x22;center&#x22; />"`) becomes valid JSX that the inner
-        // pipeline can parse
-        const captionHast = processMarkdown(decodeHTML(node.properties.caption as string));
+        const captionHast = processMarkdown(node.properties.caption as string);
         node.children = (captionHast.children ?? []).filter(isElementContentNode);
       }
 

--- a/processor/transform/images.ts
+++ b/processor/transform/images.ts
@@ -53,7 +53,8 @@ const imageTransformer = ({ isMdxish }: { isMdxish?: boolean } = {}) => (tree: N
   visit(tree, isImageBlock, (node: MdxJsxFlowElement) => {
     const attrs = getAttrs<ImageBlock>(node);
 
-    if (attrs.caption) {
+    // Mdxish handles caption parsing at the HAST stage via `rehypeMdxishComponents`
+    if (attrs.caption && !isMdxish) {
       // @ts-expect-error - @todo: figure out how to coerce RootContent[] to
       // the correct type
       node.children = mdast(attrs.caption).children;


### PR DESCRIPTION
| 🎫 Resolve RM-16428 |
| :-----------------: |

## 🎯 What does this PR do?

When an `<Image> caption=""` attribute contained a nested JSX tag with entity-encoded quotes (e.g. `caption="<Image align=&#x22;center&#x22; src=&#x22;...&#x22; />"`), mdxish's permissive tokenizer stores attribute values as opaque strings (no entity decoding), so when `imageTransformer` recursively re-parsed `attrs.caption` via `mdast()` which uses the strict `mdx-jsx` parser it throws the moment it sees this invalid syntax


Two-part fix: 

(1) skip the MDAST-stage caption parse in `imageTransformer` when `isMdxish` is set, since `rehypeRaw` strips children from `<img>` (void element) downstream and `rehypeMdxishComponents` re-parses the caption at the HAST stage regardless

(2) decode HTML character references with `decodeHTML` from entities before handing the caption to `processMarkdown` in `rehypeMdxishComponents`

## 🧪 QA tips

In the demo app, try to render something like:
```
<Image 
align="center" 
caption="<Image align=&#x22;center&#x22; caption=&#x22;Pizza Man is Part of the Caption&#x22; 
src=&#x22;https://files.readme.io/6f52e22-man-eating-pizza-and-making-an-ok-gesture.jpg&#x22; width=&#x22;600px&#x22; />" 
src="https://joyrideharness.com/cdn/shop/articles/AdobeStock_274099078.jpg?v=1620400547" width="700px" />
```

both images should be seen!

## 📸 Screenshot or Loom

<img width="3004" height="1604" alt="Screenshot 2026-05-12 at 13 20 46" src="https://github.com/user-attachments/assets/218c727f-8511-4df7-8fc9-13fff7cee714" />

