### PR TITLE
fix(mdxish): decode html entities in jsx attribute values

### DIFF
--- a/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
+++ b/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
@@ -96,10 +96,10 @@ describe('mdxish-jsx-to-mdast transformer', () => {
         const ast = processWithNewTypes(md);
 
         const imageNode = ast.children[0] as ImageBlock;
-        expect(imageNode.caption).toBe('With **Default Handling** enabled, the `default` value &#x22;Buster&#x22; is used.');
+        expect(imageNode.caption).toBe('With **Default Handling** enabled, the `default` value "Buster" is used.');
         expect(imageNode.children).toHaveLength(1);
 
-        const paragraph = imageNode.children[0] as Paragraph;
+        const paragraph = imageNode.children![0] as Paragraph;
         expect(paragraph.type).toBe('paragraph');
         expect(paragraph.children[0]).toMatchObject({ type: 'text', value: 'With ' });
         expect(paragraph.children[1]).toMatchObject({ type: 'strong' });
@@ -132,6 +132,36 @@ This is a warning message.
         const calloutNode = ast.children[0] as Callout;
         expect(calloutNode.children).toBeDefined();
         expect(calloutNode.children.length).toBeGreaterThan(0);
+      });
+
+      it('should decode HTML numeric entities in Callout icon attribute', () => {
+        const md = `<Callout icon="&#128679;" theme="warn">
+   text
+</Callout>`;
+        const ast = processWithNewTypes(md);
+
+        const calloutNode = ast.children[0] as Callout;
+        expect(calloutNode.data?.hProperties?.icon).toBe('\u{1F6A7}');
+      });
+
+      it('should decode HTML hex entities in Callout icon attribute', () => {
+        const md = `<Callout icon="&#x1F4D8;" theme="info">
+   text
+</Callout>`;
+        const ast = processWithNewTypes(md);
+
+        const calloutNode = ast.children[0] as Callout;
+        expect(calloutNode.data?.hProperties?.icon).toBe('\u{1F4D8}');
+      });
+
+      it('should decode named HTML entities in JSX attributes', () => {
+        const md = `<Callout icon="&amp;" theme="info">
+   text
+</Callout>`;
+        const ast = processWithNewTypes(md);
+
+        const calloutNode = ast.children[0] as Callout;
+        expect(calloutNode.data?.hProperties?.icon).toBe('&');
       });
     });
 

--- a/processor/plugin/mdxish-handlers.ts
+++ b/processor/plugin/mdxish-handlers.ts
@@ -3,6 +3,8 @@ import type { Properties } from 'hast';
 import type { MdxJsxAttribute, MdxJsxAttributeValueExpression } from 'mdast-util-mdx-jsx';
 import type { Handler, Handlers } from 'mdast-util-to-hast';
 
+import { decodeHTMLStrict } from 'entities';
+
 import { NodeTypes } from '../../enums';
 import { evaluate } from '../utils';
 
@@ -11,16 +13,6 @@ const mdxExpressionHandler: Handler = (_state, node) => ({
   type: 'text',
   value: (node as { value?: string }).value || '',
 });
-
-// Since we serialize component / html tag attributes
-function decodeHtmlEntities(value: string) {
-  return value
-    .replace(/&quot;/g, '"')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&#10;/g, '\n')
-    .replace(/&amp;/g, '&');
-}
 
 function isStructuredCloneable(value: unknown): boolean {
   try {
@@ -43,7 +35,7 @@ const mdxJsxElementHandler: Handler = (state, node) => {
     if (attribute.value === null) {
       properties[attribute.name] = true;
     } else if (typeof attribute.value === 'string') {
-      properties[attribute.name] = decodeHtmlEntities(attribute.value);
+      properties[attribute.name] = decodeHTMLStrict(attribute.value);
     } else {
       const expressionSource = (attribute.value as MdxJsxAttributeValueExpression).value;
       let evaluated: ReturnType<typeof evaluate>;

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -8,6 +8,7 @@ import type {
   MdxJsxAttributeValueExpressionData,
 } from 'mdast-util-mdx-jsx';
 
+import { decodeHTMLStrict } from 'entities';
 import { CONTINUE, EXIT, visit } from 'unist-util-visit';
 
 import mdast from '../lib/mdast';
@@ -92,7 +93,7 @@ export const getAttrs = <T>(jsx: MdxJsxFlowElement | MdxJsxTextElement): T =>
       if (attr.value === null) {
         memo[attr.name] = true;
       } else if (typeof attr.value === 'string') {
-        memo[attr.name] = attr.value;
+        memo[attr.name] = decodeHTMLStrict(attr.value);
       } else if (attr.value?.value !== undefined) {
         try {
           memo[attr.name] = evaluate(attr.value.value);


### PR DESCRIPTION
| 🎫 Resolve CX-3377 |
| :-----------------: |

## 🎯 What does this PR do?

When `mdxish` encounters a JSX attribute with HTML character references (e.g. `<Callout icon="&#128679;" theme="warn">`), the underlying tokenizer stores the attribute value as the raw substring with entities intact and doesnt decode them

This caused `<Callout>` icons written as numeric/hex entities to render as the literal entity text rather than the emoji, and made the `rmdx` and `mdxish` pipelines diverge for the same source. 

The fix decodes JSX attribute string values via `decodeHTMLStrict` from the already-vendored `entities` package at the two boundaries where mdxish reads JSX attributes:

- `getAttrs` in `processor/utils.ts` 
- and `mdxJsxElementHandler` in `processor/plugin/mdxish-handlers.ts`

## 🧪 QA tips

Type something like this:
```
<Callout icon="&#128679;" theme="warn">
   text
</Callout>
```

## 📸 Screenshot or Loom

Before | After
-- | --
<img width="1752" height="1602" alt="Screenshot 2026-05-12 at 15 38 18" src="https://github.com/user-attachments/assets/1b5d8d64-8f30-4efb-bffc-3ea361b23cae" /> | <img width="1753" height="1600" alt="Screenshot 2026-05-12 at 15 37 56" src="https://github.com/user-attachments/assets/24e9d652-3cb4-4f4c-9e56-1984f7fecf67" />

Monorepo showcase
View Mode | Editor
-- | --
<img width="1551" height="656" alt="Screenshot 2026-05-12 at 15 39 05" src="https://github.com/user-attachments/assets/f01b7306-8c85-4644-8b9d-caabcf7a08c5" /> | <img width="2169" height="1246" alt="Screenshot 2026-05-12 at 15 38 54" src="https://github.com/user-attachments/assets/5e590116-72dd-4e6d-98d7-42699275cd35" />


