### PR TITLE
fix(mdxish): preserve attributes on raw <table> rows/cells

### DIFF
--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -86,21 +86,37 @@ describe('mdxish tables transformation', () => {
         type: 'root',
         children: [
           {
-            type: 'table',
+            type: 'mdxJsxFlowElement',
+            name: 'Table',
             children: [
               {
-                type: 'tableRow',
-                children: [{ type: 'tableCell', children: [] }],
-              },
-              {
-                type: 'tableRow',
+                type: 'mdxJsxFlowElement',
+                name: 'thead',
                 children: [
                   {
-                    type: 'tableCell',
+                    type: 'mdxJsxFlowElement',
+                    name: 'tr',
+                    children: [{ type: 'mdxJsxFlowElement', name: 'th', children: [] }],
+                  },
+                ],
+              },
+              {
+                type: 'mdxJsxFlowElement',
+                name: 'tbody',
+                children: [
+                  {
+                    type: 'mdxJsxFlowElement',
+                    name: 'tr',
                     children: [
-                      { type: 'paragraph', children: [{ type: 'text', value: 'Line 1' }] },
-                      { type: 'paragraph', children: [{ type: 'text', value: 'Line 3' }] },
-                      { type: 'paragraph', children: [{ type: 'text', value: 'Line 5' }] },
+                      {
+                        type: 'mdxJsxFlowElement',
+                        name: 'td',
+                        children: [
+                          { type: 'text', value: 'Line 1' },
+                          { type: 'text', value: 'Line 3' },
+                          { type: 'text', value: 'Line 5' },
+                        ],
+                      },
                     ],
                   },
                 ],
@@ -159,7 +175,141 @@ describe('mdxish tables transformation', () => {
     });
   });
 
-  it('should unwrap a sole paragraph in a table cell', () => {
+  describe('given HTML attributes on rows/cells', () => {
+    describe('in raw HTML tables', () => {
+      // Regression test: lowercase `<table>` paths previously dropped
+      // class/style/colspan/rowspan because the table was converted to a
+      // markdown table node, which can't carry HTML attributes
+      it('preserves class attribute', () => {
+        const html = toHtml(
+          mdxish(`<table>
+  <thead>
+  <tr><th class="head">A</th></tr>
+  </thead>
+  <tbody>
+  <tr><td>x</td></tr>
+  </tbody>
+  </table>`),
+        );
+
+        expect(html).toContain('<th class="head">A</th>');
+      });
+
+      it('preserves colspan attribute', () => {
+        const html = toHtml(
+          mdxish(`<table>
+  <thead>
+  <tr><th>A</th><th>B</th></tr>
+  </thead>
+  <tbody>
+  <tr><td colspan="2">merged</td></tr>
+  </tbody>
+  </table>`),
+        );
+
+        expect(html).toContain('<td colspan="2">merged</td>');
+      });
+
+      it('preserves inline style', () => {
+        const html = toHtml(
+          mdxish(`<table>
+  <thead>
+  <tr><th>A</th></tr>
+  </thead>
+  <tbody>
+  <tr><td style="color:red">x</td></tr>
+  </tbody>
+  </table>`),
+        );
+
+        expect(html).toContain('<td style="color:red">x</td>');
+      });
+
+      it('preserves attributes when only some cells carry them', () => {
+        const html = toHtml(
+          mdxish(`<table>
+  <thead>
+  <tr><th>A</th><th>B</th></tr>
+  </thead>
+  <tbody>
+  <tr><td class="hi">x</td><td>y</td></tr>
+  </tbody>
+  </table>`),
+        );
+
+        expect(html).toContain('<td class="hi">x</td>');
+        expect(html).toContain('<td>y</td>');
+      });
+    });
+
+    describe('in JSX <Table> tables', () => {
+      it('preserves class attributes', () => {
+        const md = `<Table>
+<thead>
+<tr>
+<th class="head">A</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">merged</td>
+</tr>
+</tbody>
+</Table>`;
+        const ast = astProcessor(md);
+
+        expect(ast).toMatchObject({
+          type: 'root',
+          children: [
+            {
+              type: 'mdxJsxFlowElement',
+              name: 'Table',
+              children: [
+                {
+                  type: 'mdxJsxFlowElement',
+                  name: 'thead',
+                  children: [
+                    {
+                      type: 'mdxJsxFlowElement',
+                      name: 'tr',
+                      children: [
+                        {
+                          type: 'mdxJsxTextElement',
+                          name: 'th',
+                          attributes: [{ type: 'mdxJsxAttribute', name: 'class', value: 'head' }],
+                          children: [{ type: 'text', value: 'A' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: 'mdxJsxFlowElement',
+                  name: 'tbody',
+                  children: [
+                    {
+                      type: 'mdxJsxFlowElement',
+                      name: 'tr',
+                      children: [
+                        {
+                          type: 'mdxJsxTextElement',
+                          name: 'td',
+                          attributes: [{ type: 'mdxJsxAttribute', name: 'colspan', value: '2' }],
+                          children: [{ type: 'text', value: 'merged' }],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+      });
+    });
+  });
+
+  it('should unwrap a sole paragraph in a Table cell', () => {
     const md = `<Table align={["left"]}>
   <thead>
     <tr>
@@ -183,23 +333,40 @@ describe('mdxish tables transformation', () => {
       type: 'root',
       children: [
         {
-          type: 'table',
+          type: 'mdxJsxFlowElement',
+          name: 'Table',
           children: [
             {
-              type: 'tableRow',
+              type: 'mdxJsxFlowElement',
+              name: 'thead',
               children: [
                 {
-                  type: 'tableCell',
-                  children: [{ type: 'text', value: 'Header' }],
+                  type: 'mdxJsxFlowElement',
+                  name: 'tr',
+                  children: [
+                    {
+                      type: 'mdxJsxFlowElement',
+                      name: 'th',
+                      children: [{ type: 'text', value: 'Header' }],
+                    },
+                  ],
                 },
               ],
             },
             {
-              type: 'tableRow',
+              type: 'mdxJsxFlowElement',
+              name: 'tbody',
               children: [
                 {
-                  type: 'tableCell',
-                  children: [{ type: 'text', value: 'Just one line' }],
+                  type: 'mdxJsxFlowElement',
+                  name: 'tr',
+                  children: [
+                    {
+                      type: 'mdxJsxFlowElement',
+                      name: 'td',
+                      children: [{ type: 'text', value: 'Just one line' }],
+                    },
+                  ],
                 },
               ],
             },

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -175,8 +175,8 @@ describe('mdxish tables transformation', () => {
     });
   });
 
-  describe('given HTML attributes on rows/cells', () => {
-    describe('in raw HTML tables', () => {
+  describe('given HTML attributes on structural table HTML children', () => {
+    describe('with raw HTML tables', () => {
       // Regression test: lowercase `<table>` paths previously dropped
       // class/style/colspan/rowspan because the table was converted to a
       // markdown table node, which can't carry HTML attributes
@@ -225,36 +225,50 @@ describe('mdxish tables transformation', () => {
         expect(html).toContain('<td style="color:red">x</td>');
       });
 
-      it('preserves attributes when only some cells carry them', () => {
+      it('preserves attributes on thead and tbody', () => {
         const html = toHtml(
           mdxish(`<table>
-  <thead>
-  <tr><th>A</th><th>B</th></tr>
+  <thead class="head-group">
+  <tr><th>A</th></tr>
   </thead>
-  <tbody>
-  <tr><td class="hi">x</td><td>y</td></tr>
+  <tbody align="left">
+  <tr><td>x</td></tr>
   </tbody>
   </table>`),
         );
 
-        expect(html).toContain('<td class="hi">x</td>');
-        expect(html).toContain('<td>y</td>');
+        expect(html).toContain('<thead class="head-group">');
+        expect(html).toContain('<tbody align="left">');
+      });
+
+      it('preserves attributes on columns (colgroup/col)', () => {
+        const html = toHtml(
+          mdxish(`<table>
+          <colgroup class="head-group">
+          <col style="width:100px" />
+          </colgroup>
+          </table>`),
+        );
+        expect(html).toContain('<colgroup class="head-group">');
+        expect(html).toContain('<col style="width:100px">');
       });
     });
 
-    describe('in JSX <Table> tables', () => {
-      it('preserves class attributes', () => {
+    describe('with JSX tables', () => {
+      it('preserves class attributes, outputs table in JSX, and denotes table nodes as mdxElements', () => {
         const md = `<Table>
-<thead>
+<thead style="color:blue">
 <tr>
 <th class="head">A</th>
 </tr>
 </thead>
-<tbody>
+
+<tbody style="color:red">
 <tr>
 <td colspan="2">merged</td>
 </tr>
 </tbody>
+
 </Table>`;
         const ast = astProcessor(md);
 
@@ -268,6 +282,7 @@ describe('mdxish tables transformation', () => {
                 {
                   type: 'mdxJsxFlowElement',
                   name: 'thead',
+                  attributes: [{ type: 'mdxJsxAttribute', name: 'style', value: 'color:blue' }],
                   children: [
                     {
                       type: 'mdxJsxFlowElement',
@@ -286,6 +301,7 @@ describe('mdxish tables transformation', () => {
                 {
                   type: 'mdxJsxFlowElement',
                   name: 'tbody',
+                  attributes: [{ type: 'mdxJsxAttribute', name: 'style', value: 'color:red' }],
                   children: [
                     {
                       type: 'mdxJsxFlowElement',

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -163,11 +163,22 @@ const processTableNode = (
   // represent a header-less table in mdast without the first body row getting
   // promoted. Keep as JSX instead so remarkRehype renders it correctly
   let hasThead = false;
+  // mdast table/tableRow/tableCell can't represent HTML attributes (colspan,
+  // rowspan, class, style, etc). If any row/cell carries attributes, keep the
+  // table as JSX so they're preserved through to the rendered output.
+  let hasRowOrCellAttributes = false;
   visit(node as Node, isMDXElement, (child: MdxJsxFlowElement | MdxJsxTextElement) => {
     if (child.name === 'thead') hasThead = true;
+    if (
+      (child.name === 'tr' || child.name === 'th' || child.name === 'td') &&
+      Array.isArray(child.attributes) &&
+      child.attributes.length > 0
+    ) {
+      hasRowOrCellAttributes = true;
+    }
   });
 
-  if (tableHasFlowContent || !hasThead) {
+  if (tableHasFlowContent || !hasThead || hasRowOrCellAttributes) {
     // remarkMdx wraps inline elements in paragraph nodes (e.g. <td> on the
     // same line as content becomes mdxJsxTextElement inside a paragraph).
     // Unwrap these so <td>/<th> sit directly under <tr>, and strip

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -20,7 +20,7 @@ import codeTabsTransformer from '../../code-tabs';
 import { extractText } from '../../extract-text';
 import normalizeEmphasisAST from '../normalize-malformed-md-syntax';
 
-import { unwrapSoleParagraph } from './utils';
+import { tableTags, unwrapSoleParagraph } from './utils';
 
 interface MdxJsxTableCell extends Omit<MdxJsxFlowElement, 'name'> {
   name: 'td' | 'th';
@@ -163,22 +163,22 @@ const processTableNode = (
   // represent a header-less table in mdast without the first body row getting
   // promoted. Keep as JSX instead so remarkRehype renders it correctly
   let hasThead = false;
-  // mdast table/tableRow/tableCell can't represent HTML attributes (colspan,
-  // rowspan, class, style, etc). If any row/cell carries attributes, keep the
-  // table as JSX so they're preserved through to the rendered output.
-  let hasRowOrCellAttributes = false;
+  // mdast table/tableRow/tableCell does not represent HTML attributes (class, style, etc).
+  // If any structural table HTML child carries attributes, keep the table as JSX so their attributes
+  // are preserved through to the rendered output.
+  let hasStructuralAttributes = false;
   visit(node as Node, isMDXElement, (child: MdxJsxFlowElement | MdxJsxTextElement) => {
     if (child.name === 'thead') hasThead = true;
     if (
-      (child.name === 'tr' || child.name === 'th' || child.name === 'td') &&
+      tableTags.has(child.name) &&
       Array.isArray(child.attributes) &&
       child.attributes.length > 0
     ) {
-      hasRowOrCellAttributes = true;
+      hasStructuralAttributes = true;
     }
   });
 
-  if (tableHasFlowContent || !hasThead || hasRowOrCellAttributes) {
+  if (tableHasFlowContent || !hasThead || hasStructuralAttributes) {
     // remarkMdx wraps inline elements in paragraph nodes (e.g. <td> on the
     // same line as content becomes mdxJsxTextElement inside a paragraph).
     // Unwrap these so <td>/<th> sit directly under <tr>, and strip

--- a/processor/transform/mdxish/tables/utils.ts
+++ b/processor/transform/mdxish/tables/utils.ts
@@ -1,5 +1,17 @@
 import type { Node } from 'mdast';
 
+export const tableTags = new Set([
+  'thead',
+  'tbody',
+  'tfoot',
+  'caption',
+  'colgroup',
+  'col',
+  'tr',
+  'th',
+  'td',
+]);
+
 /**
  * If the cell has exactly one paragraph child, unwrap it so its inline children sit
  * directly under the cell (matches GFM table cell shape and avoids stray `<p>` wrappers).


### PR DESCRIPTION
| 🎫 Resolve [CX-3381](https://linear.app/readme-io/issue/CX-3381) |
| :-----------------: |

## 🎯 What does this PR do?

Raw HTML `<table>` cells were silently losing attributes like `class`, `colspan`, `rowspan`, and inline `style` in the mdxish editor. The same was true for attributes on the structural wrappers (`<thead>`, `<tbody>`, `<tfoot>`, `<caption>`, `<colgroup>`, `<col>`) — those wrappers get collapsed entirely on the conversion path, so any attributes on them were dropped too.

This is another regression from #1403, which started treating lowercase `<table>` the same as JSX `<Table>` and routing it through the markdown-table conversion path instead of passing it through until the end. mdast's `table`/`tableRow`/`tableCell` nodes can't carry HTML attributes, and the conversion drops the structural wrappers, so any attributes on HTML table tags like `<tr>`/`<th>`/`<td>`/`<thead>`/`<tbody>`/`<tfoot>`/`<caption>`/`<colgroup>`/`<col>` got dropped.

The fix keeps the table as JSX (`mdxJsxFlowElement`) whenever any structural child carries attributes, so they survive through to the rendered HTML. Attribute-free tables continue down the normal markdown-table path. Even though the node types of these elements change, I've verified that it doesn't change rendering, and also how it looks in the editor.

## 🧪 QA tips

1. Open the mdxish editor or the playground and paste the following:
   ```markdown
   <table>
   <thead>
   <tr><th class="head">A</th><th>B</th></tr>
   </thead>
   <tbody>
   <tr><td colspan="2" style="color:red">merged</td></tr>
   </tbody>
   </table>
   ```
2. The cell text should be in red, and the cell spans the whole length of the table
3. Inspect the rendered DOM — `class="head"`, `colspan="2"`, and `style="color:red"` should all be present on the corresponding `<th>`/`<td>`.
4. Paste the following to verify attributes on structural wrappers (`<thead>`, `<tbody>`, `<colgroup>`, `<col>`) also survive:
   ```markdown
   <table>
   <colgroup class="cols">
   <col style="width:40%" />
   <col style="width:60%" />
   </colgroup>
   <thead class="head-group">
   <tr><th>A</th><th>B</th></tr>
   </thead>
   <tbody align="left">
   <tr><td>x</td><td>y</td></tr>
   </tbody>
   </table>
   ```
   Inspect the DOM — `class="cols"` on `<colgroup>`, `style="width:40%"`/`style="width:60%"` on the `<col>`s, `class="head-group"` on `<thead>`, and `align="left"` on `<tbody>` should all be present.
5. Verify a plain attribute-less `<table>` still renders normally (no regression on the common path).