### PR TITLE
fix(mdxish): balance unclosed HTML tags in cells in table serialization

### DIFF
--- a/__tests__/transformers/mdxish-tables-to-jsx.test.ts
+++ b/__tests__/transformers/mdxish-tables-to-jsx.test.ts
@@ -135,6 +135,96 @@ describe('mdxish-tables-to-jsx', () => {
     });
   });
 
+  describe('unclosed HTML repair in JSX cells', () => {
+    const findCellHtmlValues = (tree: Root, cellName: 'td' | 'th'): string[] => {
+      const els = collectNodes(tree, 'mdxJsxFlowElement') as (Parent & { name: string })[];
+      const cell = els.find(n => n.name === cellName);
+      if (!cell) return [];
+      return (cell.children as { type: string; value?: string }[])
+        .filter(c => c.type === 'html')
+        .map(c => c.value ?? '');
+    };
+
+    it('appends a synthetic closer for an unclosed tag in a body cell', () => {
+      const md = '| H |\n| --- |\n| <b>bold <Image src="a.png" /> |';
+      const tree = parseWithPlugin(md);
+
+      const values = findCellHtmlValues(tree, 'td');
+      expect(values).toContain('<b>');
+      expect(values).toContain('</b>');
+    });
+
+    it('appends a synthetic closer for an unclosed tag in a header cell', () => {
+      const md = '| <b>head <Image src="a.png" /> |\n| --- |\n| body |';
+      const tree = parseWithPlugin(md);
+
+      const values = findCellHtmlValues(tree, 'th');
+      expect(values).toContain('<b>');
+      expect(values).toContain('</b>');
+    });
+
+    it('closes mismatched nested tags in browser-recovery order', () => {
+      const md = '| H |\n| --- |\n| <b><i>x</b> <Image src="a.png" /> |';
+      const tree = parseWithPlugin(md);
+
+      const values = findCellHtmlValues(tree, 'td');
+      // both <b> and <i> opened, only </b> seen → balancer pops both, then
+      // appends </i> at the end since i was left dangling above the popped b
+      // (note: with the simpler pop-to-match strategy, </i> is appended).
+      expect(values).toContain('<b>');
+      expect(values).toContain('<i>');
+      expect(values).toContain('</i>');
+    });
+
+    it('empties orphan close tags so they do not render as raw text', () => {
+      const md = '| H |\n| --- |\n| </b>text <Image src="a.png" /> |';
+      const tree = parseWithPlugin(md);
+
+      const values = findCellHtmlValues(tree, 'td');
+      // the orphan </b> is mutated to empty string
+      expect(values).toContain('');
+      expect(values).not.toContain('</b>');
+    });
+
+    it('leaves void elements untouched', () => {
+      const md = '| H |\n| --- |\n| <br> <Image src="a.png" /> |';
+      const tree = parseWithPlugin(md);
+
+      const values = findCellHtmlValues(tree, 'td');
+      expect(values).not.toContain('</br>');
+    });
+
+    it('appends the closer after trailing text so the text is enclosed', () => {
+      const md =
+        '| H |\n| --- |\n| <span style="color:red">This limit ranges between 8 K and 16 K. <Image src="a.png" /> |';
+      const tree = parseWithPlugin(md);
+
+      const els = collectNodes(tree, 'mdxJsxFlowElement') as (Parent & { name: string; children: unknown[] })[];
+      const td = els.find(n => n.name === 'td');
+      expect(td).toBeDefined();
+
+      const kids = td!.children as { type: string; value?: string; name?: string }[];
+      const openIdx = kids.findIndex(c => c.type === 'html' && c.value === '<span style="color:red">');
+      const closeIdx = kids.findIndex(c => c.type === 'html' && c.value === '</span>');
+      const textIdx = kids.findIndex(c => c.type === 'text' && (c.value ?? '').includes('This limit ranges'));
+
+      expect(openIdx).toBeGreaterThanOrEqual(0);
+      expect(closeIdx).toBeGreaterThan(textIdx);
+      expect(textIdx).toBeGreaterThan(openIdx);
+    });
+
+    it('leaves a cell with balanced tags unchanged', () => {
+      const md = '| H |\n| --- |\n| <b>bold</b> <Image src="a.png" /> |';
+      const tree = parseWithPlugin(md);
+
+      const values = findCellHtmlValues(tree, 'td');
+      const openCount = values.filter(v => v === '<b>').length;
+      const closeCount = values.filter(v => v === '</b>').length;
+      expect(openCount).toBe(1);
+      expect(closeCount).toBe(1);
+    });
+  });
+
   describe('multi-child cell scanning', () => {
     it('detects flow content in any child of a cell, not just the first', () => {
       const md = '| Header |\n| --- |\n| text <Image src="a.png" /> |';

--- a/processor/transform/mdxish/tables/mdxish-tables-to-jsx.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables-to-jsx.ts
@@ -7,6 +7,8 @@ import { visit } from 'unist-util-visit';
 
 import { NodeTypes } from '../../../../enums';
 
+import { balanceHtmlInCell } from './utils';
+
 const SELF_CLOSING_JSX_REGEX = /^\s*<[A-Z][^>]*\/>\s*$/;
 
 const alignToStyle = (align: 'center' | 'left' | 'right' | null) => {
@@ -106,7 +108,7 @@ const mdxishTablesToJsx = (): Transform => tree => {
                 attributes: [],
                 type: 'mdxJsxFlowElement',
                 name: 'th',
-                children: cell.children,
+                children: balanceHtmlInCell(cell.children as Node[]) as MdxJsxFlowElement['children'],
                 ...(styles[cellIndex] && { attributes: [styles[cellIndex]] }),
               } as MdxJsxFlowElement;
             }),
@@ -127,7 +129,7 @@ const mdxishTablesToJsx = (): Transform => tree => {
               return {
                 type: 'mdxJsxFlowElement',
                 name: 'td',
-                children: cell.children,
+                children: balanceHtmlInCell(cell.children as Node[]) as MdxJsxFlowElement['children'],
                 ...(styles[cellIndex] && { attributes: [styles[cellIndex]] }),
               };
             }),

--- a/processor/transform/mdxish/tables/utils.ts
+++ b/processor/transform/mdxish/tables/utils.ts
@@ -1,4 +1,4 @@
-import type { Node } from 'mdast';
+import type { Literal, Node, Parent } from 'mdast';
 
 export const tableTags = new Set([
   'thead',
@@ -19,6 +19,94 @@ export const tableTags = new Set([
  * When there are multiple paragraphs, leave them intact — they represent distinct lines
  * of content that need to be preserved for JSX `<Table>` serialization.
  */
+// HTML void elements never have a closing tag, so they shouldn't go on the
+// balance stack.
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'source',
+  'track',
+  'wbr',
+]);
+
+// Single HTML tag with optional attributes and optional self-close. Whole-string
+// match so multi-tag values (`<a><b>`) and comments are ignored.
+const TAG_REGEX = /^<\s*(\/)?\s*([a-zA-Z][\w-]*)\b[^>]*?(\/)?\s*>$/;
+
+/**
+ * Repairs unbalanced HTML inside a JSX table cell so it can be safely emitted
+ * as JSX `<th>`/`<td>` children. Remark splits each raw tag into its own
+ * `html` node, so balancing is a stack walk:
+ *
+ * - Open tags push onto a stack.
+ * - Close tags pop the matching tag, also popping any unclosed tags nested
+ *   above it (browser-like recovery for `<b><i>x</b>`).
+ * - Orphan close tags (no matching open) have their value emptied so they
+ *   don't render as raw text.
+ * - Self-closing tags and void elements (br, hr, img, …) are ignored.
+ *
+ * Any tags left on the stack after the walk get synthetic closers appended
+ * to the cell, in reverse order.
+ */
+export const balanceHtmlInCell = (children: Node[]): Node[] => {
+  const stack: string[] = [];
+
+  const walk = (nodes: Node[]) => {
+    for (let i = 0; i < nodes.length; i += 1) {
+      const node = nodes[i];
+      if (node.type === 'html' && 'value' in node) {
+        const match = TAG_REGEX.exec((node as Literal).value);
+        // eslint-disable-next-line no-continue
+        if (!match) continue;
+        const [, slash, name, selfClose] = match;
+        const tag = name.toLowerCase();
+        // eslint-disable-next-line no-continue
+        if (VOID_ELEMENTS.has(tag) || selfClose) continue;
+        if (!slash) {
+          stack.push(tag);
+        } else {
+          const idx = stack.lastIndexOf(tag);
+          if (idx === -1) {
+            (node as Literal).value = '';
+          } else {
+            // Insert synthetic closers for any nested-but-unclosed tags above
+            // `idx` so the output is well-formed (e.g. `<b><i>x</b>` →
+            // `<b><i>x</i></b>`).
+            const danglers = stack.slice(idx + 1).reverse();
+            if (danglers.length > 0) {
+              const closers: Node[] = danglers.map(t => ({ type: 'html', value: `</${t}>` }) as Node);
+              nodes.splice(i, 0, ...closers);
+              i += closers.length;
+            }
+            stack.length = idx;
+          }
+        }
+      } else if ('children' in node && Array.isArray((node as Parent).children)) {
+        walk((node as Parent).children as Node[]);
+      }
+    }
+  };
+
+  const out = [...children];
+  walk(out);
+
+  if (stack.length === 0) return out;
+
+  const closers: Node[] = stack
+    .slice()
+    .reverse()
+    .map(tag => ({ type: 'html', value: `</${tag}>` }) as Node);
+  return [...out, ...closers];
+};
+
 export const unwrapSoleParagraph = (children: Node[]): Node[] => {
   const paragraphCount = children.filter(c => c.type === 'paragraph').length;
   if (paragraphCount !== 1) return children;


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

When using the Mdxish Editor, magic block tables will get serialised to JSX / GFM format upon editing & saving. There is an issue that arises with this, in that if there's an unclosed HTML tag in the cell (which was acceptable in magic blocks format), it will break the table if it's under JSX syntax. The root cause of this is because it is an invalid MDX, and we use `remarkMdx` in our table transformer to heavily simplify parsing.

This PR partly solves that issue by trying to repair unclosed HTML tags in table cells during serialization so it doesn't error out. The approach here is to go through the table cell nodes, visit through every HTML children, and use state machine to keep track of open & unclosed tags. If there is an unclosed tag, add a closing tag.

## 🧪 QA tips

For this, it is better to locally link the branch to the monorepo.
1. Paste a table magic block that contains an unclosed HTML in a cell & that will get parsed to JSX
2. Make changes in the editor and saved. Notice in the raw mode, the syntax is now JSX
3. In the editor, the table should not be broken, and either be a syntaxNode of the full MDX, or show the table directly
4. In view mode, the table should not be broken & renders all cells

Examples:
```
[block:parameters]
{
  "data": {
    "h-0": "Parameter",
    "h-1": "Notes",
    "0-0": "Array <object>",
    "0-1": "List of badge configurations. Each object can have:<ul><li>type (Enum: ROLLBACK, EXPRESS_DELIVERY)</li><li>enabled (default: true)</li></ul>  \n  \n**Note:** Badges can be enabled only for eligible creatives. Refer to the `eligibleBadges` field in the List Creatives API response to determine which badges are applicable for each creative\"  \n  \n**The badgeSettings objects are detailed** <p><a href=\"#C5\">**here**</a></p>",
    "1-0": "showPrice",
    "1-1": "When true, the itemxs price appears in the creative.  \nDefault is false if the field is omitted.  \n  \n_**Note: **  \nYou may set showPrice = true for eligible creatives only when exactly one item is associated with the creative._",
    "2-0": "associatedItems",
    "2-1": "Array<string>"
 },
  "cols": 3,
  "rows": 2,
  "align": [
    null,
    null,
    null,
    null,
    null
  ]
}
[/block]

[block:parameters]
{
  "data": {
    "h-0": "Description",
    "0-0": "<span style=\"color:red\">This limit ranges between 8 K and 16 K and is subject to CDN response header limits.   \n  \nTo avoid exceeding the limit, check the latest documentation and contact your support team.",
    "1-0": "100,000 bytes if you pass a string to [`createResponse`](doc:create-response#createresponse) in `responseProvider`  \n  \nNo direct limit if you pass a [stream](doc:streams)  to [`createResponse`](doc:create-response#createresponse) in `responseProvider`."
  },
  "cols": 1,
  "rows": 2,
  "align": [
    "left",
    "left"
  ]
}
[/block]
```

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
