### PR TITLE
fix: code elements stripped from td elements

### DIFF
--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -209,7 +209,7 @@ describe('mdxish tables transformation', () => {
     });
   });
 
-  describe('given raw HTML table with raw markdown in td cells', () => {
+  describe('given raw HTML table', () => {
     it('should render markdown syntax in plain-text cells', () => {
       const md = `<table>
   <thead>
@@ -224,9 +224,7 @@ describe('mdxish tables transformation', () => {
       const html = toHtml(mdxish(md));
       expect(html).toContain('<strong>bold</strong>');
     });
-  });
 
-  describe('given raw HTML table with inline <code> elements', () => {
     it('should preserve <code> wrappers in td cells', () => {
       const md = `<table>
   <thead>
@@ -243,5 +241,21 @@ describe('mdxish tables transformation', () => {
       expect(html).toContain('<code>action</code>');
       expect(html).toContain('<code>penalty box</code>');
     });
+  });
+
+  it('renders inline HTML elements and markdown syntax as markup', () => {
+    const md = `<table>
+<thead>
+  <tr><th>Header</th></tr>
+</thead>
+<tbody>
+  <tr>
+    <td>**bold** and <code>code</code></td>
+  </tr>
+</tbody>
+</table>`;
+    const html = toHtml(mdxish(md));
+    expect(html).toContain('<code>code</code>');
+    expect(html).toContain('<strong>bold</strong>');
   });
 });

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -209,6 +209,23 @@ describe('mdxish tables transformation', () => {
     });
   });
 
+  describe('given raw HTML table with raw markdown in td cells', () => {
+    it('should render markdown syntax in plain-text cells', () => {
+      const md = `<table>
+  <thead>
+    <tr><th>Header</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>**bold** text</td>
+    </tr>
+  </tbody>
+</table>`;
+      const html = toHtml(mdxish(md));
+      expect(html).toContain('<strong>bold</strong>');
+    });
+  });
+
   describe('given raw HTML table with inline <code> elements', () => {
     it('should preserve <code> wrappers in td cells', () => {
       const md = `<table>

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -208,4 +208,23 @@ describe('mdxish tables transformation', () => {
       ],
     });
   });
+
+  describe('given raw HTML table with inline <code> elements', () => {
+    it('should preserve <code> wrappers in td cells', () => {
+      const md = `<table>
+  <thead>
+    <tr><th>Attribute</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>action</code></td>
+      <td>If true, <code>penalty box</code> is enabled.</td>
+    </tr>
+  </tbody>
+</table>`;
+      const html = toHtml(mdxish(md));
+      expect(html).toContain('<code>action</code>');
+      expect(html).toContain('<code>penalty box</code>');
+    });
+  });
 });

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -86,15 +86,9 @@ const parseTableNode = (processor: typeof tableNodeProcessor, node: Html): Root 
  * Check if children are only text nodes that might contain markdown
  */
 const isTextOnly = (children: unknown[]): boolean => {
-  return children.every(child => {
-    if (child && typeof child === 'object' && 'type' in child) {
-      if (child.type === 'text') return true;
-      if (child.type === 'mdxJsxTextElement' && 'children' in child && Array.isArray(child.children)) {
-        return child.children.every((c: unknown) => c && typeof c === 'object' && 'type' in c && c.type === 'text');
-      }
-    }
-    return false;
-  });
+  return children.every(
+    child => child && typeof child === 'object' && 'type' in child && child.type === 'text',
+  );
 };
 
 /**


### PR DESCRIPTION
| 🎫 Resolve RM-16555 |
| :-----------------: |

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

Fixes `<code>` elements (and other inline HTML elements) being silently dropped from raw HTML `<table>` cells on round-trip through the MdxishEditor.

The fix removes the `mdxJsxTextElement` branch from `isTextOnly`. The function now only returns `true` for cells containing plain unprocessed `text` nodes (raw markdown). Cells where MDX has already correctly parsed inline elements are left untouched.

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->



1. Open a page in the MdxishEditor containing a raw HTML `<table>` with `<td><code>value</code></td>` cells — [example](https://techdocs.akamai.com/terraform/v10.2/docs/as-ds-peanlty-box#attributes). 

```
<table>
    <thead>
        <th>Attribute</th>
        <th>Description</th>
    </thead>
    <tbody>
        <tr>
            <td><code>action</code></td>
            <td>Action taken <ul><li><code>any time the penalty box</code> is triggered.</li></ul> ...</td>
        </tr>
        <tr>
            <td><code>enabled</code></td>
            <td>If true, <code>penalty box protections</code> are enabled.</td>
        </tr>
    </tbody>
</table>
```

2. Verify the `<code>` elements in the markdown render with code styling.

3. Verify that cells containing raw markdown (e.g., `<td>**bold** text</td>`) still render with proper bold formatting, confirming the re-parse path still works for plain text cells.

