### PR TITLE
fix: don't parse content of <code> elements in table cells

### DIFF
--- a/__tests__/parsers/tables.test.ts
+++ b/__tests__/parsers/tables.test.ts
@@ -1,6 +1,7 @@
 import type { Element } from 'hast';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 
+import { toHtml } from 'hast-util-to-html';
 import { removePosition } from 'unist-util-remove-position';
 
 import { mdast } from '../../lib';
@@ -1052,6 +1053,46 @@ None of the following content will get rendered!`;
       removePosition(ast, { force: true });
 
       expect(ast).toMatchSnapshot();
+    });
+  });
+
+  describe('code content preservation in table cells', () => {
+    it('preserves <code> content containing {expression} patterns verbatim (RM-16556)', () => {
+      const doc = `<table>
+    <thead>
+        <th>Attribute</th>
+        <th>Description</th>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>action</code></td>
+            <td>Contains: <ul><li><code>deny_custom_{custom_deny_id}</code>. Custom action.</li></ul></td>
+        </tr>
+    </tbody>
+</table>`;
+
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).toContain('<code>deny_custom_{custom_deny_id}</code>');
+    });
+
+    it('does not apply emphasis to underscores inside <code> elements in table cells', () => {
+      const doc = `<table>
+    <thead><tr><th>Name</th><th>Type</th></tr></thead>
+    <tbody>
+        <tr>
+          <td>field</td>
+          <td>Contains: <ul><li><code>snake_case_value</code></li><li><code>another_name_here</code></li></ul></td>
+        </tr>
+    </tbody>
+</table>`;
+
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).toContain('<code>snake_case_value</code>');
+      expect(html).toContain('<code>another_name_here</code>');
     });
   });
 });

--- a/processor/transform/mdxish/normalize-malformed-md-syntax.ts
+++ b/processor/transform/mdxish/normalize-malformed-md-syntax.ts
@@ -256,8 +256,17 @@ const normalizeEmphasisAST: Plugin = () => (tree: Root) => {
   visit(tree, 'text', function visitor(node: Text, index, parent: Parent) {
     if (index === undefined || !parent) return undefined;
 
-    // Skip if inside code blocks or inline code
+    // Skip if inside code blocks, inline code, or MDX JSX <code> elements.
+    // The parent type check for mdxJsxTextElement/mdxJsxFlowElement handles
+    // raw HTML <code>...</code> inside table cells, which the table re-parser
+    // parses as MDX JSX (not as an mdast `inlineCode` node).
     if (parent.type === 'inlineCode' || parent.type === 'code') {
+      return undefined;
+    }
+    if (
+      (parent.type === 'mdxJsxTextElement' || parent.type === 'mdxJsxFlowElement') &&
+      'name' in parent && parent.name === 'code'
+    ) {
       return undefined;
     }
 

--- a/processor/transform/mdxish/normalize-malformed-md-syntax.ts
+++ b/processor/transform/mdxish/normalize-malformed-md-syntax.ts
@@ -257,12 +257,12 @@ const normalizeEmphasisAST: Plugin = () => (tree: Root) => {
     if (index === undefined || !parent) return undefined;
 
     // Skip if inside code blocks, inline code, or MDX JSX <code> elements.
-    // The parent type check for mdxJsxTextElement/mdxJsxFlowElement handles
-    // raw HTML <code>...</code> inside table cells, which the table re-parser
-    // parses as MDX JSX (not as an mdast `inlineCode` node).
     if (parent.type === 'inlineCode' || parent.type === 'code') {
       return undefined;
     }
+    // The parent type check for mdxJsxTextElement/mdxJsxFlowElement handles
+    // raw HTML <code>...</code> inside table cells, which the table re-parser
+    // parses as MDX JSX (not as an mdast `inlineCode` node).
     if (
       (parent.type === 'mdxJsxTextElement' || parent.type === 'mdxJsxFlowElement') &&
       'name' in parent && parent.name === 'code'


### PR DESCRIPTION
| 🎫 Resolve RM-16556 |
| :-----------------: |

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

Fixes `<code>` content containing underscores and variable expressions `{...}` being parsed as mdxish-flavored markdown when inside a table cell. We want to treat the content of a `<code>` element as raw text!

## 🧪 QA tips

```
<table>
    <thead>
        <th>Attribute</th>
        <th>Description</th>
    </thead>
    <tbody>
        <tr>
            <td><code>action</code></td>
            <td>Action taken any time the penalty box is triggered. Contains: <ul><li><code>alert</code>. Event recorded.</li><li><code>deny</code>. Event blocked.</li><li><code>deny_custom_{custom_deny_id}</code>. Took your custom action against the event.</li><li><code>none</code>. No action taken.</li></ul></td>
        </tr>
        <tr>
            <td><code>enabled</code></td>
            <td>If true, penalty box protections are enabled.</td>
        </tr>
    </tbody>
</table>
```

- Above snippet should render `<code>deny_custom_{custom_deny_id}</code>` correctly.


## 📸 Screenshot or Loom

| Before | After |
| --- | --- |
| <img width="1058" height="500" alt="CleanShot 2026-05-13 at 15 38 52@2x" src="https://github.com/user-attachments/assets/1ce96363-234d-41b3-8fea-f5f9344c2f74" /> | <img width="1124" height="608" alt="CleanShot 2026-05-13 at 15 37 54@2x" src="https://github.com/user-attachments/assets/ced06cde-681d-463e-b2e4-2b32f25cf51d" /> |


