### PR TITLE
fix(mdxish): keep JSX Callout body in body slot only in roundtrip

### DIFF
--- a/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
+++ b/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
@@ -163,6 +163,38 @@ This is a warning message.
         const calloutNode = ast.children[0] as Callout;
         expect(calloutNode.data?.hProperties?.icon).toBe('&');
       });
+
+      it('should prepend an empty title placeholder when body has no heading', () => {
+        const md = `<Callout icon="📘" theme="info">
+Content here
+</Callout>`;
+        const ast = processWithNewTypes(md);
+
+        const calloutNode = ast.children[0] as Callout;
+        expect(calloutNode.data?.hProperties?.empty).toBe(true);
+        expect(calloutNode.children[0]).toMatchObject({
+          type: 'paragraph',
+          children: [{ type: 'text', value: '' }],
+        });
+        expect(calloutNode.children[1]).toMatchObject({
+          type: 'paragraph',
+          children: [{ type: 'text', value: 'Content here' }],
+        });
+      });
+
+      it('should leave children alone when callout already starts with a heading', () => {
+        const md = `<Callout icon="📘" theme="info">
+## My Title
+
+Body content
+</Callout>`;
+        const ast = processWithNewTypes(md);
+
+        const calloutNode = ast.children[0] as Callout;
+        expect(calloutNode.data?.hProperties?.empty).toBe(false);
+        expect(calloutNode.children[0]).toMatchObject({ type: 'heading', depth: 2 });
+        expect(calloutNode.children[1]).toMatchObject({ type: 'paragraph' });
+      });
     });
 
     describe('Embed component', () => {

--- a/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
+++ b/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
@@ -289,6 +289,31 @@ describe('mdxishAstProcessor', () => {
 
       expect(ast.children[0].type).not.toBe('table');
     });
+
+    it('should round-trip a body-only JSX Callout without promoting body to title', () => {
+      const md = `<Callout icon="📘" theme="info">
+Content here
+</Callout>
+`;
+
+      const { processor, parserReadyContent } = mdxishAstProcessor(md, { newEditorTypes: true });
+      const tree = processor.runSync(processor.parse(parserReadyContent)) as Root;
+      const out = mdxishMdastToMd(tree);
+
+      expect(out).not.toMatch(/^>\s*📘\s+Content here/);
+
+      const second = mdxishAstProcessor(out, { newEditorTypes: true });
+      const tree2 = second.processor.runSync(second.processor.parse(second.parserReadyContent)) as Root;
+      const callout = tree2.children[0] as { children: { type: string }[]; data?: { hProperties?: { empty?: boolean } } };
+
+      expect(callout.data?.hProperties?.empty).toBe(true);
+      const firstChildText = ((callout.children[0] as { children?: { value?: string }[] }).children?.[0]?.value) ?? '';
+      expect(firstChildText).toBe('');
+      expect(callout.children[1]).toMatchObject({
+        type: 'paragraph',
+        children: [{ type: 'text', value: 'Content here' }],
+      });
+    });
   });
 
   it('should only normalize empty checklist items when whitespace exists after ]', () => {

--- a/processor/transform/mdxish/mdxish-jsx-to-mdast.ts
+++ b/processor/transform/mdxish/mdxish-jsx-to-mdast.ts
@@ -353,15 +353,26 @@ const transformImage = (jsx: MdxJsxFlowElement): ImageBlock => {
  */
 const transformCallout = (jsx: MdxJsxFlowElement): Callout => {
   const attrs = getAttrs<CalloutAttrs>(jsx);
-  const { empty = false, icon = '', theme = '' } = attrs;
+  const { empty: explicitEmpty = false, icon = '', theme = '' } = attrs;
+
+  // children[0] is the title slot. Prepend an empty-paragraph placeholder
+  // when JSX has no leading heading, otherwise the body round-trips into it.
+  const jsxChildren = jsx.children as Callout['children'];
+  const hasHeadingFirst = jsxChildren[0]?.type === 'heading';
+  const children = hasHeadingFirst
+    ? jsxChildren
+    : ([
+        { type: 'paragraph', children: [{ type: 'text', value: '' }] },
+        ...jsxChildren,
+      ] as Callout['children']);
 
   return {
     type: NodeTypes.callout,
-    children: jsx.children as Callout['children'],
+    children,
     data: {
       hName: 'Callout',
       hProperties: {
-        empty,
+        empty: explicitEmpty || !hasHeadingFirst,
         icon,
         theme,
       },


### PR DESCRIPTION
| 🎫 Resolve RM-16089 |
| :-----------------: |

## 🎯 What does this PR do?

We currently serialise callouts to the blockquote > syntax, so. JSX <Callout> or magic blocks [block:callout] get serialized to it. There is a bug where for JSX <Callouts> if it only defines a body and no title like:

```
<Callout icon="📘" theme="info">
Content here
</Callout>
```

its body get placed as in the top level >, which means it gets serialized to a heading in the title.

This PR fixes this behaviour by stopping this "body -> title" promotion by appending a placeholder empty title. This also shows the "Enter Optional Title" helper input in the editor.

## 🧪 QA tips

Paste this in the editor in rich mode:
```
<Callout icon="📘" theme="info">
Content here
</Callout>
```

make sure that you see the "Enter optional..." placeholder title. Toggle raw and rich mode. The "Content here" should not be promoted into a title and should still remain as the body.

## 📸 Screenshot or Loom


https://github.com/user-attachments/assets/e634d911-139a-4fc8-ba82-633fe3360055


