### PR TITLE
fix(mdxish): keep md images inline when in tableCells

### DIFF
--- a/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
+++ b/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
@@ -589,6 +589,48 @@ Some callout content
 
   });
 
+  describe('magic-block image promotion in tableCells (RM-16543)', () => {
+    const cellMd = (cell: string) => `[block:parameters]
+{
+  "data": {
+    "h-0": "Header",
+    "0-0": ${JSON.stringify(cell)}
+  },
+  "cols": 1,
+  "rows": 1,
+  "align": ["left"]
+}
+[/block]`;
+
+    const findCell = (root: Root) => {
+      const table = root.children.find(c => c.type === 'table') as { children: { children: { children: unknown[]; type: string }[] }[] };
+      const bodyRow = table.children[1];
+      return bodyRow.children[0];
+    };
+
+    it('keeps `![](url)` alone in a tableCell as inline `image` (no image-block promotion)', () => {
+      // Magic-block image syntax in tableCells stays inline. Authors who want a
+      // captionable figure use `<Image caption="…" />` JSX instead.
+      const ast = processWithNewTypes(cellMd('![](https://example.com/img.png)'));
+      const cell = findCell(ast);
+      expect(cell.children).toHaveLength(1);
+      expect(cell.children[0].type).toBe('image');
+    });
+
+    it('keeps `![](url)` mixed with other inline content in a tableCell as inline `image`', () => {
+      const ast = processWithNewTypes(cellMd('![](https://example.com/img.png)<br><br>The **bold** word.'));
+      const cell = findCell(ast);
+      // Image stays as inline `image` so downstream consumers can put it in a paragraph.
+      expect(cell.children[0].type).toBe('image');
+      expect(cell.children.some(c => c.type === 'strong')).toBe(true);
+    });
+
+    it('still promotes `![](url)` at root level to image-block', () => {
+      const ast = processWithNewTypes('![](https://example.com/img.png)');
+      expect(ast.children[0].type).toBe(NodeTypes.imageBlock);
+    });
+  });
+
   describe('HTML figure reassembly', () => {
     it('should reassemble <figure> with image and figcaption into an image-block', () => {
       const md = `<figure>

--- a/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
+++ b/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
@@ -1,6 +1,6 @@
 import type { Anchor, Callout, EmbedBlock, ImageBlock, Recipe } from '../../../types';
 import type { Root as HastRoot } from 'hast';
-import type { Paragraph, Root, RootContent } from 'mdast';
+import type { Paragraph, Root, RootContent, Table, TableCell } from 'mdast';
 
 import { NodeTypes } from '../../../enums';
 import { mdxish, mdxishAstProcessor } from '../../../lib/mdxish';
@@ -602,8 +602,8 @@ Some callout content
 }
 [/block]`;
 
-    const findCell = (root: Root) => {
-      const table = root.children.find(c => c.type === 'table') as { children: { children: { children: unknown[]; type: string }[] }[] };
+    const findCell = (root: Root): TableCell => {
+      const table = root.children.find(c => c.type === 'table') as Table;
       const bodyRow = table.children[1];
       return bodyRow.children[0];
     };
@@ -628,6 +628,13 @@ Some callout content
     it('still promotes `![](url)` at root level to image-block', () => {
       const ast = processWithNewTypes('![](https://example.com/img.png)');
       expect(ast.children[0].type).toBe(NodeTypes.imageBlock);
+    });
+
+    it('keeps `![](url)` in a GFM tableCell as inline `image`', () => {
+      const md = '| Header |\n| :-- |\n| ![](https://example.com/img.png)This is a cat |';
+      const ast = processWithNewTypes(md);
+      const cell = findCell(ast);
+      expect(cell.children[0].type).toBe('image');
     });
   });
 

--- a/processor/transform/mdxish/mdxish-jsx-to-mdast.ts
+++ b/processor/transform/mdxish/mdxish-jsx-to-mdast.ts
@@ -700,6 +700,10 @@ const mdxishJsxToMdast: Plugin<[], Parent> = () => tree => {
     if (!parent || index === undefined) return SKIP;
     if (parent.type === 'paragraph') return SKIP;
 
+    // `![](url)` in any tableCell stays inline. Authors who want a captioned figure use
+    // `<Image caption="…" />` JSX, which becomes `image-block` via `COMPONENT_MAP` above.
+    if (parent.type === 'tableCell') return SKIP;
+
     const newNode = transformMagicBlockImage(node);
     (parent.children as Node[])[index] = newNode;
 


### PR DESCRIPTION
| 🎫 Resolve TICKET |
| :-----------------: |

## 🎯 What does this PR do?

Say we have this 2 tables:

```
[block:parameters]
{
  "data": {
    "h-0": "Step",
    "h-1": "MD Image Syntax",
    "0-0": "1",
    "0-1": "![](https://pethelpful.com/.image/NDowMDAwMDAwMDAwMjM5NjE3/a-maine-coon-cat-sits-in-front-of-a-window-and-looks-back.jpg?profile=w256&ar=1-1)This is an inlined image of a cat"
  },
  "cols": 2,
  "rows": 1,
  "align": ["center", "left"]
}
[/block]

[block:parameters]
{
  "data": {
    "h-0": "Step",
    "h-1": "JSX Image Syntax",
    "0-0": "1",
    "0-1": "<Image src=\"https://pethelpful.com/.image/NDowMDAwMDAwMDAwMjM5NjE3/a-maine-coon-cat-sits-in-front-of-a-window-and-looks-back.jpg?profile=w256&ar=1-1\" />This is an inlined image of a cat"
  },
  "cols": 2,
  "rows": 1,
  "align": ["center", "left"]
}
[/block]
```

The renderer renders the first table as inlined but the second as a block, which is intended. However, the new editor renders BOTH as a block level elements. The legacy editor respects the inline image as is:

Rendered | Legacy Editor | New Editor
-- | -- | --
<img width="824" height="733" alt="Screenshot 2026-05-15 at 11 00 08" src="https://github.com/user-attachments/assets/3984a776-ddfa-4ffc-9d58-b7afddab28b2" /> | <img width="818" height="520" alt="Screenshot 2026-05-15 at 11 00 59" src="https://github.com/user-attachments/assets/0e6ee726-3a83-4047-b328-f26f397e41a0" /> <br> the Image JSX isnt even rendered here but see the first table | <img width="822" height="859" alt="Screenshot 2026-05-15 at 11 00 29" src="https://github.com/user-attachments/assets/ad78f46a-df9c-45c5-8b71-259113844b5c" />

This is because all `[](url)` markdown image syntax inside any `tableCell` was being promoted to `image-block` by `mdxishJsxToMdast`. The editor's `Image.mdastToPm` has no inline branch for `image-block`, it always renders as a block `figure`. So a cell like 

```
![](url)The **bold** is here.
``` 

in the first table shatters and leaves 2 independent block nodes when it should be inlined.

This PR skips the `image → image-block` promotion when the image's parent is a `tableCell`. Standalone `![](url)` in cells stays as plain `image` mdast

> to explicitly get a captioned block level figure, use `<Image caption="…" />` JSX, which is unaffected, it goes through `COMPONENT_MAP` and still produces `image-block`.

## 🧪 QA tips

Link this branch to the monorepo and paste the table source code from above, make sure that in the editor the first table is inlined image and not a block component

_the same support should happen for regular GFM tables_
```
| Step | MD Image Syntax |
| :--: | :-- |
| 1 | ![](https://pethelpful.com/.image/NDowMDAwMDAwMDAwMjM5NjE3/a-maine-coon-cat-sits-in-front-of-a-window-and-looks-back.jpg?profile=w256&ar=1-1)This is an inlined image of a cat |

| Step | JSX Image Syntax |
| :--: | :-- |
| 1 | <Image src="https://pethelpful.com/.image/NDowMDAwMDAwMDAwMjM5NjE3/a-maine-coon-cat-sits-in-front-of-a-window-and-looks-back.jpg?profile=w256&ar=1-1" />This is an inlined image of a cat |
```

## 📸 Screenshot or Loom

With this fix, we now respect regular `![]()` syntax to be inlined

> [!NOTE]
this is an editor only change and leaves the rendering path untouched!

Before | After
-- | --
<img width="822" height="859" alt="Screenshot 2026-05-15 at 11 00 29" src="https://github.com/user-attachments/assets/ad78f46a-df9c-45c5-8b71-259113844b5c" /> | <img width="826" height="817" alt="Screenshot 2026-05-15 at 11 12 13" src="https://github.com/user-attachments/assets/462ff55c-7fdf-4743-b9df-773fb98c0c01" />

