### PR TITLE
fix: dont normalize emphasis syntax within html code elements

### DIFF
--- a/__tests__/parsers/tables.test.ts
+++ b/__tests__/parsers/tables.test.ts
@@ -1094,5 +1094,32 @@ None of the following content will get rendered!`;
       expect(html).toContain('<code>snake_case_value</code>');
       expect(html).toContain('<code>another_name_here</code>');
     });
+
+    it('preserves <code> content with underscores and {expression} in GFM-style markdown tables (RM-16575)', () => {
+      const doc = `|Attribute|Description|
+|---|---|
+|\`action\`|Action taken any time the penalty box is triggered. Contains: <ul><li><code>alert</code>. Event recorded.</li><li><code>deny</code>. Event blocked.</li><li><code>deny_custom_{custom_deny_id}</code>. Took your custom action against the event.</li><li><code>none</code>. No action taken.</li></ul>|
+|\`enabled\`|If **true**, penalty box protection is enabled.|`;
+
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).toContain('<code>deny_custom_{custom_deny_id}</code>');
+      expect(html).toContain('<code>alert</code>');
+      expect(html).toContain('<code>deny</code>');
+      expect(html).toContain('<code>none</code>');
+    });
+
+    it('does not apply emphasis to underscores inside inline <code> elements in GFM tables', () => {
+      const doc = `|Name|Type|
+|---|---|
+|field|Contains: <ul><li><code>snake_case_value</code></li><li><code>another_name_here</code></li></ul>|`;
+
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).toContain('<code>snake_case_value</code>');
+      expect(html).toContain('<code>another_name_here</code>');
+    });
   });
 });

--- a/processor/transform/mdxish/normalize-malformed-md-syntax.ts
+++ b/processor/transform/mdxish/normalize-malformed-md-syntax.ts
@@ -241,6 +241,28 @@ function visitMultiNodeEmphasis(tree: Root) {
 }
 
 /**
+ * Returns true when the node at `index` inside `parent.children` sits between
+ * sibling `html` nodes that form an inline `<code>…</code>` element.
+ *
+ * In GFM tables, inline HTML like `<code>value</code>` is tokenised as
+ * separate sibling nodes — an `html` open-tag node, inline text/expression
+ * nodes, then an `html` close-tag node — rather than as an mdxJsxTextElement.
+ * We scan backwards from the current index to find the nearest `<code>` or
+ * `</code>` tag; if we hit `<code>` first the node is inside a code element.
+ */
+function isInsideInlineHtmlCode(index: number | undefined, parent: Parent): boolean {
+  if (index === undefined || !Array.isArray(parent.children)) return false;
+  for (let i = index - 1; i >= 0; i--) {
+    const sibling = parent.children[i];
+    if (sibling.type !== 'html' || !('value' in sibling) || typeof sibling.value !== 'string') continue;
+    const val = (sibling as { type: 'html'; value: string }).value.trim().toLowerCase();
+    if (val === '<code>' || val.startsWith('<code ') || val.startsWith('<code\t')) return true;
+    if (val === '</code>') return false;
+  }
+  return false;
+}
+
+/**
  * A remark plugin that normalizes malformed bold and italic markers in text nodes.
  * Detects patterns like `** bold**`, `Hello** Wrong Bold**`, `__ bold__`, `Hello__ Wrong Bold__`,
  * `* italic*`, `Hello* Wrong Italic*`, `_ italic_`, or `Hello_ Wrong Italic_`
@@ -267,6 +289,13 @@ const normalizeEmphasisAST: Plugin = () => (tree: Root) => {
       (parent.type === 'mdxJsxTextElement' || parent.type === 'mdxJsxFlowElement') &&
       'name' in parent && parent.name === 'code'
     ) {
+      return undefined;
+    }
+    // In GFM tables, inline <code>...</code> is represented as sibling `html`
+    // nodes rather than as an mdxJsxTextElement, so the check above doesn't
+    // apply. Scan backwards through siblings to see if we are enclosed by a
+    // <code>…</code> inline HTML pair.
+    if (isInsideInlineHtmlCode(index, parent)) {
       return undefined;
     }
 

--- a/processor/transform/mdxish/normalize-malformed-md-syntax.ts
+++ b/processor/transform/mdxish/normalize-malformed-md-syntax.ts
@@ -243,21 +243,18 @@ function visitMultiNodeEmphasis(tree: Root) {
 /**
  * Returns true when the node at `index` inside `parent.children` sits between
  * sibling `html` nodes that form an inline `<code>…</code>` element.
- *
- * In GFM tables, inline HTML like `<code>value</code>` is tokenised as
- * separate sibling nodes — an `html` open-tag node, inline text/expression
- * nodes, then an `html` close-tag node — rather than as an mdxJsxTextElement.
- * We scan backwards from the current index to find the nearest `<code>` or
- * `</code>` tag; if we hit `<code>` first the node is inside a code element.
  */
 function isInsideInlineHtmlCode(index: number | undefined, parent: Parent): boolean {
   if (index === undefined || !Array.isArray(parent.children)) return false;
-  for (let i = index - 1; i >= 0; i--) {
+  let i = index - 1;
+  while (i >= 0) {
     const sibling = parent.children[i];
-    if (sibling.type !== 'html' || !('value' in sibling) || typeof sibling.value !== 'string') continue;
-    const val = (sibling as { type: 'html'; value: string }).value.trim().toLowerCase();
-    if (val === '<code>' || val.startsWith('<code ') || val.startsWith('<code\t')) return true;
-    if (val === '</code>') return false;
+    if (sibling.type === 'html' && 'value' in sibling && typeof sibling.value === 'string') {
+      const val = (sibling as { type: 'html'; value: string }).value.trim().toLowerCase();
+      if (val === '<code>' || val.startsWith('<code ') || val.startsWith('<code\t')) return true;
+      if (val === '</code>') return false;
+    }
+    i -= 1;
   }
   return false;
 }


### PR DESCRIPTION

We have some normalizers in `processor/transform/mdxish/normalize-malformed-md-syntax.ts` that repair invalid syntax like `** foo**`  or `_bar _` that our legacy engine would render fine.

We don't want to parse _any_ of the content of a `<code>` block! But this normalizer as walking into `<code>` elements and converting underscores into emphasis nodes in the AST.

## 🎯 What does this PR do?
Adds `isInsideInlineHtmlCode()` check to `normalizeEmphasisAST`, which walks backwards through a node's siblings to find the nearest `<code>` or `</code>` inline HTML tag. If `<code>` is found first, the text node is inside a code element and emphasis processing is skipped

## 🧪 QA tips
```
|Attribute|Description|
|---|---|
|`action`|Action taken any time the penalty box is triggered. Contains: <ul><li><code>alert</code>. Event recorded.</li><li><code>deny</code>. Event blocked.</li><li><code>deny_custom_{custom_deny_id}</code>. Took your custom action against the event.</li><li><code>none</code>. No action taken.</li></ul>|
|`enabled`|If **true**, penalty box protection is enabled.|
```


- `<code>deny_custom_{custom_deny_id}</code>` should render with the literal underscores and braces intact — no italicised `custom`, no missing content.

- The `**true**` bold in the last row should still render correctly (the fix is scoped to nodes inside `<code>` tags).

## 📸 Screenshot or Loom
Working here locally linked to the monorepo:

https://github.com/user-attachments/assets/eab9fe85-8d88-4e7a-bf2e-7e6e15a87d73


