### PR TITLE
fix(mdxish): demote undefined jsx tag to plain text

### DIFF
--- a/__tests__/compilers/plain.test.ts
+++ b/__tests__/compilers/plain.test.ts
@@ -169,9 +169,8 @@ describe('mdxish plain compiler', () => {
     const markdown = '<not valid jsx>';
 
     const hast = mdxish(markdown);
-    // Angle brackets without a valid tag are filtered out by rehypeRaw/rehypeMdxishComponents
-    // So we expect empty children or no children
-    expect(hast.children).toHaveLength(0);
+    const text = JSON.stringify(hast);
+    expect(text).toContain('not valid jsx');
   });
 
   it('preserves text content at root level', () => {

--- a/__tests__/compilers/reusable-content.test.js
+++ b/__tests__/compilers/reusable-content.test.js
@@ -53,13 +53,13 @@ describe('reusable content compiler', () => {
 });
 
 describe('mdxish reusable content compiler', () => {
-  it('removes undefined reusable content blocks', () => {
+  it('renders undefined reusable content blocks as literal text (CX-3284)', () => {
     const doc = '<Undefined />';
 
     const hast = mdxish(doc);
 
-    // Unknown components are filtered out by rehypeMdxishComponents
-    expect(hast.children).toHaveLength(0);
+    expect(hast.children.length).toBeGreaterThan(0);
+    expect(JSON.stringify(hast)).toContain('Undefined');
   });
 
   it('processes defined reusable content blocks as components', () => {

--- a/__tests__/compilers/reusable-content.test.js
+++ b/__tests__/compilers/reusable-content.test.js
@@ -53,7 +53,7 @@ describe('reusable content compiler', () => {
 });
 
 describe('mdxish reusable content compiler', () => {
-  it('renders undefined reusable content blocks as literal text (CX-3284)', () => {
+  it('renders undefined reusable content blocks as literal text', () => {
     const doc = '<Undefined />';
 
     const hast = mdxish(doc);

--- a/__tests__/processor/plugin/mdxish-components.test.ts
+++ b/__tests__/processor/plugin/mdxish-components.test.ts
@@ -6,16 +6,15 @@ import { describe, it, expect } from 'vitest';
 import { mix, mdxish } from '../../../lib';
 
 describe('rehypeMdxishComponents', () => {
-  it('should remove non-existent custom components from the tree', () => {
+  it('renders unresolved PascalCase tags as literal text instead of dropping them (CX-3284)', () => {
     const md = `<MyDemo> from inside </MyDemo>
 Hello
 <Custom>`;
     const html = mix(md);
-    // Should only contain "Hello" and not the non-existent component tags or their content
     expect(html).toContain('Hello');
-    expect(html).not.toContain('MyDemo');
-    expect(html).not.toContain('from inside');
-    expect(html).not.toContain('Custom');
+    expect(html).toContain('MyDemo');
+    expect(html).toContain('from inside');
+    expect(html).toContain('Custom');
   });
 
   it('should preserve existing custom components', () => {
@@ -28,42 +27,41 @@ Hello`;
     expect(result).toContain('Hello');
   });
 
-  it('should remove nested non-existent components', () => {
+  it('preserves nested unresolved components and their content as literal text', () => {
     const md = `<Outer>
   <Inner>nested content</Inner>
   Hello
 </Outer>`;
     const result = mix(md);
-    expect(result).not.toContain('Hello');
-    expect(result).not.toContain('Outer');
-    expect(result).not.toContain('Inner');
-    expect(result).not.toContain('nested content');
+    expect(result).toContain('Hello');
+    expect(result).toContain('Outer');
+    expect(result).toContain('Inner');
+    expect(result).toContain('nested content');
   });
 
-  it('should handle mixed existing and non-existent components', () => {
-    // componentExists only checks if the key exists, so we can use a minimal mock
+  it('handles mixed existing and non-existent components (renders unknown as text)', () => {
     const ExistingComponent = {} as CustomComponents[string];
     const md = `<ExistingComponent>Keep this</ExistingComponent>
-<NonExistent>Remove this</NonExistent>
+<NonExistent>Show this</NonExistent>
 Hello`;
     const result = mix(md, { components: { ExistingComponent } });
     expect(result).toContain('ExistingComponent');
     expect(result).toContain('Keep this');
     expect(result).toContain('Hello');
-    expect(result).not.toContain('NonExistent');
-    expect(result).not.toContain('Remove this');
+    expect(result).toContain('NonExistent');
+    expect(result).toContain('Show this');
   });
 
-  it('should preserve regular HTML tags', () => {
+  it('preserves regular HTML tags and renders unknown components as text alongside them', () => {
     const md = `<div>This is HTML</div>
-<NonExistentComponent>Remove this</NonExistentComponent>
+<NonExistentComponent>Show this</NonExistentComponent>
 Hello`;
     const result = mix(md);
     expect(result).toContain('<div>');
     expect(result).toContain('This is HTML');
     expect(result).toContain('Hello');
-    expect(result).not.toContain('NonExistentComponent');
-    expect(result).not.toContain('Remove this');
+    expect(result).toContain('NonExistentComponent');
+    expect(result).toContain('Show this');
   });
 
   it('should parse Image caption as markdown with decoded HTML entities', () => {
@@ -92,7 +90,7 @@ Hello`;
     expect(code).toBeDefined();
   });
 
-  it('should correctly handle real-life cases', () => {
+  it('preserves all content even when mixing unknown components with real content (no silent drops)', () => {
     const md = `<MyDemoComponent message="Hello from MDX!">Hello world!</MyDemoComponent>
 Reusable content should work the same way:
 <ContentBlock />
@@ -102,10 +100,10 @@ hello
   <Inner> from inside </Inner>
 </Outer>`;
     const result = mix(md);
-    expect(result).not.toContain('Hello world!');
+    expect(result).toContain('Hello world!');
     expect(result).toContain('Reusable content should work the same way:');
     expect(result).toContain('hello');
-    expect(result).not.toContain('from inside');
+    expect(result).toContain('from inside');
   });
 });
 

--- a/__tests__/processor/plugin/mdxish-components.test.ts
+++ b/__tests__/processor/plugin/mdxish-components.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect } from 'vitest';
 import { mix, mdxish } from '../../../lib';
 
 describe('rehypeMdxishComponents', () => {
-  it('renders unresolved PascalCase tags as literal text instead of dropping them (CX-3284)', () => {
+  it('renders unresolved PascalCase tags as literal text instead of dropping them', () => {
     const md = `<MyDemo> from inside </MyDemo>
 Hello
 <Custom>`;

--- a/__tests__/transformers/demote-unresolved-jsx-tags-subprocessors.test.ts
+++ b/__tests__/transformers/demote-unresolved-jsx-tags-subprocessors.test.ts
@@ -1,0 +1,713 @@
+import type { CustomComponents } from '../../types';
+
+import { describe, expect, it } from 'vitest';
+
+import { mix } from '../../lib';
+
+const Registered = {} as CustomComponents[string];
+
+describe('demoteUnresolvedJsxTags — bug repros at scale', () => {
+  it('preserves the original CX-3284 input', () => {
+    const html = mix('<Batch_id>_<File_Type>_<Version>.csv\n');
+    expect(html).toContain('Version');
+    expect(html).toContain('.csv');
+  });
+
+  it('preserves text after a bare unresolved opener at end of line', () => {
+    const html = mix('Hello\n<Custom>\n');
+    expect(html).toContain('Hello');
+    expect(html).toContain('Custom');
+  });
+
+  it('preserves text after multiple unresolved openers in sequence', () => {
+    const html = mix('<Alpha>\n<Beta>\n<Gamma>\nfinal text\n');
+    expect(html).toContain('final text');
+  });
+
+  it('preserves heading content following an unresolved tag', () => {
+    const html = mix('# <Version> heading text\n');
+    expect(html).toContain('heading text');
+  });
+
+  it('preserves list item content following an unresolved tag', () => {
+    const html = mix('- <Foo> item one\n- another item\n');
+    expect(html).toContain('item one');
+    expect(html).toContain('another item');
+  });
+
+  it('preserves blockquote content following an unresolved tag', () => {
+    const html = mix('> <Bar> quoted\n');
+    expect(html).toContain('quoted');
+  });
+
+  it('preserves a paragraph after a paragraph containing only an unresolved tag', () => {
+    const html = mix('<Solo>\n\nNext paragraph here.\n');
+    expect(html).toContain('Next paragraph here.');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — must NOT demote', () => {
+  it('leaves lowercase <br /> alone', () => {
+    const html = mix('Line one<br />line two\n');
+    expect(html).toContain('<br>');
+  });
+
+  it('leaves lowercase <div> alone', () => {
+    const html = mix('<div>html content</div>\n');
+    expect(html).toContain('<div>');
+    expect(html).toContain('html content');
+  });
+
+  it('leaves lowercase <span> with attribute alone', () => {
+    const html = mix('<span class="foo">text</span>\n');
+    expect(html).toContain('<span');
+    expect(html).toContain('text');
+  });
+
+  it('leaves UPPERCASE HTML elements (DIV/SPAN) alone — they are still standard HTML', () => {
+    const htmlA = mix('<DIV>uppercase div</DIV>\n');
+    expect(htmlA).toContain('uppercase div');
+    const htmlB = mix('<SPAN>uppercase span</SPAN>\n');
+    expect(htmlB).toContain('uppercase span');
+  });
+
+  it('leaves <hr /> alone', () => {
+    const html = mix('text\n<hr />\nmore text\n');
+    expect(html).toContain('<hr>');
+  });
+
+  it('preserves registered components without demotion', () => {
+    const html = mix('<Registered>kept</Registered>\n', { components: { Registered } });
+    expect(html).toContain('Registered');
+    expect(html).toContain('kept');
+  });
+
+  it('preserves built-in Callout', () => {
+    const html = mix('<Callout icon="📘">callout body</Callout>\n');
+    expect(html).toContain('callout body');
+  });
+
+  it('does not touch tags inside fenced code blocks', () => {
+    const html = mix('```\n<Version>\n```\n');
+    expect(html).toContain('&#x3C;Version>');
+  });
+
+  it('does not touch tags inside inline code', () => {
+    const html = mix('Use `<Version>` carefully.\n');
+    expect(html).toContain('&#x3C;Version>');
+    expect(html).toContain('carefully');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — tag form variations', () => {
+  it('demotes self-closing unresolved tag <Foo />', () => {
+    const html = mix('Before <Foo /> after\n');
+    expect(html).toContain('Foo');
+    expect(html).toContain('Before');
+    expect(html).toContain('after');
+  });
+
+  it('demotes opening-only <Foo>', () => {
+    const html = mix('Before <Foo> after\n');
+    expect(html).toContain('Foo');
+    expect(html).toContain('Before');
+    expect(html).toContain('after');
+  });
+
+  it('demotes closing-only </Foo>', () => {
+    const html = mix('text </Foo> more\n');
+    expect(html).toContain('text');
+    expect(html).toContain('more');
+  });
+
+  it('demotes paired <Foo>x</Foo>', () => {
+    const html = mix('<Foo>middle</Foo>\n');
+    expect(html).toContain('Foo');
+    expect(html).toContain('middle');
+  });
+
+  it('demotes tag with attributes <Foo prop="x">', () => {
+    const html = mix('Before <Foo prop="x"> after\n');
+    expect(html).toContain('Before');
+    expect(html).toContain('after');
+  });
+
+  it('demotes tag with multiple attributes', () => {
+    const html = mix('Before <Foo a="1" b="2"> after\n');
+    expect(html).toContain('Before');
+    expect(html).toContain('after');
+  });
+
+  it('demotes single-letter PascalCase tag <X>', () => {
+    const html = mix('Use <X> please\n');
+    expect(html).toContain('Use');
+    expect(html).toContain('please');
+  });
+
+  it('demotes PascalCase tag with digits <Version2>', () => {
+    const html = mix('<Version2>.txt\n');
+    expect(html).toContain('.txt');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — mixed and adjacency', () => {
+  it('keeps registered components when adjacent to unresolved tags', () => {
+    const html = mix(
+      '<Registered>kept</Registered>\n<Unresolved> tail\n',
+      { components: { Registered } },
+    );
+    expect(html).toContain('kept');
+    expect(html).toContain('tail');
+  });
+
+  it('preserves text between two unresolved tags', () => {
+    const html = mix('<Alpha> middle text <Beta> tail\n');
+    expect(html).toContain('middle text');
+    expect(html).toContain('tail');
+  });
+
+  it('handles unresolved tag with code adjacent', () => {
+    const html = mix('See `inline code` and <Foo> after\n');
+    expect(html).toContain('inline code');
+    expect(html).toContain('after');
+  });
+
+  it('preserves Markdown link text adjacent to unresolved tag', () => {
+    const html = mix('Visit [link text](https://example.com) <Foo> done\n');
+    expect(html).toContain('link text');
+    expect(html).toContain('done');
+  });
+
+  it('renders many scattered unresolved tags without dropping content', () => {
+    const html = mix('a <One> b <Two> c <Three> d <Four> e <Five> f\n');
+    expect(html).toContain('a ');
+    expect(html).toContain(' b ');
+    expect(html).toContain(' c ');
+    expect(html).toContain(' d ');
+    expect(html).toContain(' e ');
+    expect(html).toContain(' f');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — does not break adjacent transformers', () => {
+  it('frontmatter still parses with unresolved tag in body', () => {
+    const md = '---\ntitle: Test\n---\n\n<Version> body\n';
+    const html = mix(md);
+    expect(html).toContain('body');
+  });
+
+  it('table cells render with unresolved tag inside', () => {
+    const md = '| col1 | col2 |\n| --- | --- |\n| <Foo> | bar |\n';
+    const html = mix(md);
+    expect(html).toContain('bar');
+    expect(html).toContain('col1');
+  });
+
+  it('emphasis and unresolved tag together', () => {
+    const html = mix('*emphasis* and <Foo> more\n');
+    expect(html).toContain('emphasis');
+    expect(html).toContain('more');
+  });
+
+  it('strong and unresolved tag together', () => {
+    const html = mix('**bold** and <Foo> more\n');
+    expect(html).toContain('bold');
+    expect(html).toContain('more');
+  });
+
+  it('does not interfere with HTML comments', () => {
+    const html = mix('<!-- comment -->\nbody\n');
+    expect(html).toContain('body');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — round-trip safety', () => {
+  it('renders the same text content for repeated mixes', () => {
+    const md = 'Path is <Batch_id>_<File_Type>_<Version>.csv today.\n';
+    const html1 = mix(md);
+    const html2 = mix(md);
+    expect(html1).toEqual(html2);
+  });
+
+  it('does not throw on empty input', () => {
+    expect(() => mix('')).not.toThrow();
+  });
+
+  it('does not throw on input with only whitespace', () => {
+    expect(() => mix('   \n\n   ')).not.toThrow();
+  });
+
+  it('does not throw on input that is only an unresolved tag', () => {
+    expect(() => mix('<Lonely>\n')).not.toThrow();
+  });
+
+  it('does not throw on deeply nested unresolved tags', () => {
+    const md = '<A><B><C><D><E>x</E></D></C></B></A>\n';
+    expect(() => mix(md)).not.toThrow();
+  });
+
+  it('handles a very long sequence of unresolved tags', () => {
+    const md = `${Array.from({ length: 50 }, (_, i) => `<Tag${i}>`).join(' ')  } end\n`;
+    const html = mix(md);
+    expect(html).toContain('end');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — subprocessor contexts: tables', () => {
+  it('GFM table cell with unresolved opener does not eat following cell', () => {
+    const md = '| header1 | header2 |\n| --- | --- |\n| <Foo> | second |\n';
+    const html = mix(md);
+    expect(html).toContain('second');
+    expect(html).toContain('header1');
+    expect(html).toContain('header2');
+  });
+
+  it('GFM table cell with paired unresolved tag preserves contents and siblings', () => {
+    const md = '| h1 | h2 |\n| --- | --- |\n| <Foo>cell text</Foo> | next |\n';
+    const html = mix(md);
+    expect(html).toContain('cell text');
+    expect(html).toContain('next');
+  });
+
+  it('GFM table cell with unresolved self-closing tag preserves siblings', () => {
+    const md = '| h1 | h2 |\n| --- | --- |\n| <Foo /> | survived |\n';
+    const html = mix(md);
+    expect(html).toContain('survived');
+  });
+
+  it('multi-row GFM table preserves all rows when a cell has an unresolved tag', () => {
+    const md = [
+      '| h1 | h2 |',
+      '| --- | --- |',
+      '| <Foo> | row1col2 |',
+      '| row2col1 | <Bar> |',
+      '| row3col1 | row3col2 |',
+      '',
+    ].join('\n');
+    const html = mix(md);
+    expect(html).toContain('row1col2');
+    expect(html).toContain('row2col1');
+    expect(html).toContain('row3col1');
+    expect(html).toContain('row3col2');
+  });
+
+  it('JSX <Table> with unresolved cell content still renders other cells', () => {
+    const md = [
+      '<Table align={[null,null]}>',
+      '  <thead>',
+      '    <tr>',
+      '      <th>h1</th>',
+      '      <th>h2</th>',
+      '    </tr>',
+      '  </thead>',
+      '  <tbody>',
+      '    <tr>',
+      '      <td>row containing <Foo></td>',
+      '      <td>untouched cell</td>',
+      '    </tr>',
+      '  </tbody>',
+      '</Table>',
+      '',
+    ].join('\n');
+    const html = mix(md);
+    expect(html).toContain('untouched cell');
+    expect(html).toContain('h1');
+    expect(html).toContain('h2');
+  });
+
+  it('table cell with mix of registered and unresolved tags', () => {
+    const md = [
+      '| h |',
+      '| --- |',
+      '| <Registered>kept</Registered> and <Unresolved> after |',
+      '',
+    ].join('\n');
+    const html = mix(md, { components: { Registered } });
+    expect(html).toContain('kept');
+    expect(html).toContain('after');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — subprocessor contexts: callouts', () => {
+  it('blockquote-style callout with unresolved opener does not lose body', () => {
+    const md = '> 📘 Title\n>\n> body with <Foo> in it\n';
+    const html = mix(md);
+    expect(html).toContain('Title');
+    expect(html).toContain('body with');
+    expect(html).toContain('in it');
+  });
+
+  it('JSX <Callout> with unresolved tag in body keeps body text', () => {
+    const md = '<Callout icon="📘">\n  Use <Foo> in the placeholder.\n</Callout>\n';
+    const html = mix(md);
+    expect(html).toContain('in the placeholder');
+  });
+
+  it('JSX <Callout> with paired unresolved tag inside keeps surrounding text', () => {
+    const md = '<Callout icon="📘">\n  Before <Foo>middle</Foo> after\n</Callout>\n';
+    const html = mix(md);
+    expect(html).toContain('Before');
+    expect(html).toContain('middle');
+    expect(html).toContain('after');
+  });
+
+  it('nested callout content with unresolved tag survives', () => {
+    const md = [
+      '<Callout icon="🚧">',
+      '',
+      '> nested quote with <Bar> inside',
+      '',
+      '</Callout>',
+      '',
+    ].join('\n');
+    const html = mix(md);
+    expect(html).toContain('nested quote with');
+    expect(html).toContain('inside');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — subprocessor contexts: code blocks', () => {
+  it('fenced code block with language preserves PascalCase tags inside', () => {
+    const md = '```jsx\n<Version>\nconst x = <Foo />\n```\n';
+    const html = mix(md);
+    expect(html).toContain('Version');
+    expect(html).toContain('Foo');
+  });
+
+  it('fenced code block with title attribute preserves PascalCase tags inside', () => {
+    const md = '```jsx title="example.jsx"\n<Component />\n```\n';
+    const html = mix(md);
+    expect(html).toContain('Component');
+  });
+
+  it('indented code block preserves PascalCase tags inside', () => {
+    const md = '    <Indented>\n    plain\n';
+    const html = mix(md);
+    expect(html).toContain('Indented');
+  });
+
+  it('inline code spans preserve PascalCase tags', () => {
+    const html = mix('Try `<Inline />` syntax.\n');
+    expect(html).toContain('Inline');
+    expect(html).toContain('syntax');
+  });
+
+  it('code block adjacent to demoted tag both render correctly', () => {
+    const md = '<Foo>\n\n```\n<Bar>\n```\n\nText after\n';
+    const html = mix(md);
+    expect(html).toContain('Foo');
+    expect(html).toContain('Bar');
+    expect(html).toContain('Text after');
+  });
+
+  it('code tabs (multiple fenced blocks) preserve content with PascalCase tags', () => {
+    const md = '```js\nconst a = <One />\n```\n```ts\nconst b = <Two />\n```\n';
+    const html = mix(md);
+    expect(html).toContain('One');
+    expect(html).toContain('Two');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — subprocessor contexts: recipes / embeds / images', () => {
+  it('built-in <Image /> with unresolved tag in caption keeps both rendering', () => {
+    const md = '<Image src="x.png" alt="img" caption="caption with <Foo>" />\n\nbody after\n';
+    const html = mix(md);
+    expect(html).toContain('body after');
+  });
+
+  it('built-in <Embed /> next to unresolved tag survives', () => {
+    const md = '<Embed url="https://example.com" title="ex" />\n\n<Custom>\n\nfinal\n';
+    const html = mix(md);
+    expect(html).toContain('final');
+  });
+
+  it('Recipe block followed by unresolved tag keeps both rendering', () => {
+    const md = '<Recipe slug="r" title="recipe" />\n\n<Solo>\n\nlast paragraph\n';
+    const html = mix(md);
+    expect(html).toContain('last paragraph');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — magic blocks and HTML blocks', () => {
+  it('magic image block survives with unresolved tag adjacent', () => {
+    const md = '[block:image]\n{"images":[{"image":["x.png","alt"]}]}\n[/block]\n\n<Foo>\n\ntail\n';
+    const html = mix(md);
+    expect(html).toContain('tail');
+  });
+
+  it('magic callout block survives with unresolved tag adjacent', () => {
+    const md = '[block:callout]\n{"type":"info","body":"hi"}\n[/block]\n\n<Foo> after\n';
+    const html = mix(md);
+    expect(html).toContain('after');
+  });
+
+  it('html-block (curly-braced) with unresolved tag adjacent', () => {
+    const md = '[block:html]\n{"html":"<div>raw</div>"}\n[/block]\n\n<Foo>\n\ntail\n';
+    const html = mix(md);
+    expect(html).toContain('tail');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — list contexts', () => {
+  it('ordered list items with unresolved tag preserve item text', () => {
+    const md = '1. first <Foo> item\n2. second item\n3. third item\n';
+    const html = mix(md);
+    expect(html).toContain('first');
+    expect(html).toContain('item');
+    expect(html).toContain('second item');
+    expect(html).toContain('third item');
+  });
+
+  it('task list items with unresolved tag', () => {
+    const md = '- [ ] todo <Foo>\n- [x] done\n';
+    const html = mix(md);
+    expect(html).toContain('todo');
+    expect(html).toContain('done');
+  });
+
+  it('nested lists with unresolved tag at deep level', () => {
+    const md = '- outer\n  - inner <Foo>\n  - inner two\n- outer two\n';
+    const html = mix(md);
+    expect(html).toContain('outer');
+    expect(html).toContain('inner two');
+    expect(html).toContain('outer two');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — heading and link contexts', () => {
+  it('h1 through h6 with unresolved tags', () => {
+    for (let level = 1; level <= 6; level += 1) {
+      const md = `${'#'.repeat(level)} <Foo> heading text\n`;
+      const html = mix(md);
+      expect(html).toContain('heading text');
+    }
+  });
+
+  it('link with unresolved tag in label', () => {
+    const md = '[label <Foo>](https://example.com) and after\n';
+    const html = mix(md);
+    expect(html).toContain('label');
+    expect(html).toContain('after');
+  });
+
+  it('image with unresolved tag in alt text', () => {
+    const md = '![alt <Foo> text](image.png) caption\n';
+    const html = mix(md);
+    expect(html).toContain('caption');
+  });
+
+  it('reference-style link with unresolved tag', () => {
+    const md = '[ref][1] and <Foo> tail\n\n[1]: https://example.com\n';
+    const html = mix(md);
+    expect(html).toContain('tail');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — emphasis interactions', () => {
+  it('unresolved tag inside emphasis', () => {
+    const html = mix('*emph <Foo> text*\n');
+    expect(html).toContain('emph');
+    expect(html).toContain('text');
+  });
+
+  it('unresolved tag inside strong', () => {
+    const html = mix('**bold <Foo> text**\n');
+    expect(html).toContain('bold');
+    expect(html).toContain('text');
+  });
+
+  it('unresolved tag with strikethrough', () => {
+    const html = mix('~~strike <Foo> text~~\n');
+    expect(html).toContain('strike');
+    expect(html).toContain('text');
+  });
+
+  it('underscores in tag name + emphasis underscores nearby', () => {
+    const md = '_emph_ then <Underscore_Tag> then *more*\n';
+    const html = mix(md);
+    expect(html).toContain('emph');
+    expect(html).toContain('more');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — pathological inputs', () => {
+  it('malformed tag with embedded angle bracket in attribute does not crash', () => {
+    expect(() => mix('Try <Foo attr="a>b"> done\n')).not.toThrow();
+  });
+
+  it('tag with whitespace-only content', () => {
+    const html = mix('<Foo>   </Foo>\n');
+    expect(typeof html).toBe('string');
+  });
+
+  it('tag immediately followed by another tag', () => {
+    const html = mix('<Foo><Bar><Baz>\nend\n');
+    expect(html).toContain('end');
+  });
+
+  it('mismatched open/close tags', () => {
+    expect(() => mix('<Foo></Bar>\n')).not.toThrow();
+  });
+
+  it('tag at very start of document', () => {
+    const html = mix('<Foo> at start\n');
+    expect(html).toContain('at start');
+  });
+
+  it('tag at very end of document', () => {
+    const html = mix('end <Foo>\n');
+    expect(html).toContain('end');
+  });
+
+  it('mixture of resolved and unresolved tags repeated 100 times', () => {
+    const segments: string[] = [];
+    for (let i = 0; i < 100; i += 1) {
+      segments.push(`<Registered>kept${i}</Registered>`);
+      segments.push(`<NotResolved${i}> filler${i}`);
+    }
+    const md = `${segments.join('\n\n')  }\n`;
+    const html = mix(md, { components: { Registered } });
+    expect(html).toContain('kept0');
+    expect(html).toContain('kept99');
+    expect(html).toContain('filler0');
+    expect(html).toContain('filler99');
+  });
+
+  it('input with all newlines and tabs', () => {
+    expect(() => mix('\n\t\n\t\t<Foo>\n\t\n')).not.toThrow();
+  });
+
+  it('tag with very long attribute string', () => {
+    const long = 'x'.repeat(5000);
+    expect(() => mix(`<Foo attr="${long}"> after\n`)).not.toThrow();
+  });
+
+  it('tag whose name is a single uppercase letter', () => {
+    const html = mix('<X> after\n');
+    expect(html).toContain('after');
+  });
+
+  it('tag inside a footnote reference does not break', () => {
+    const md = 'text[^1] and <Foo>\n\n[^1]: footnote with <Bar> inside\n';
+    expect(() => mix(md)).not.toThrow();
+  });
+});
+
+describe('demoteUnresolvedJsxTags — known component name forms (must NOT demote)', () => {
+  it('known component with PascalCase variation matches via getComponentName', () => {
+    const html = mix('<Mycomponent>kept</Mycomponent>\n', {
+      components: { MyComponent: Registered as CustomComponents[string] },
+    });
+    expect(html).toContain('kept');
+  });
+
+  it('case-insensitive match preserves component (lowercase typed)', () => {
+    const html = mix('<mycomponent>kept</mycomponent>\n', {
+      components: { MyComponent: Registered as CustomComponents[string] },
+    });
+    expect(html).toContain('kept');
+  });
+
+  it('snake_case_to_PascalCase conversion preserves user-defined component', () => {
+    const html = mix('<my_component>kept</my_component>\n', {
+      components: { MyComponent: Registered as CustomComponents[string] },
+    });
+    expect(html).toContain('kept');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — adjacent text adjacency in html nodes', () => {
+  it('html node where tag has trailing text in same node — still demotes whole html node', () => {
+    const html = mix('> <Bar> trailing inside blockquote\n');
+    expect(html).toContain('trailing inside blockquote');
+  });
+
+  it('html node with unresolved tag followed by punctuation', () => {
+    const html = mix('start <Foo>!\n');
+    expect(html).toContain('start');
+    expect(html).toContain('!');
+  });
+
+  it('html node with tag inside a complete paragraph mid-sentence', () => {
+    const html = mix('Here is <Foo> in middle of sentence.\n');
+    expect(html).toContain('Here is');
+    expect(html).toContain('in middle of sentence');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — nested components', () => {
+  it('unresolved inside registered Callout: text content rendered correctly', () => {
+    const html = mix('<Callout icon="📘">\n  Use <Foo /> here\n</Callout>\n');
+    expect(html).toContain('Use');
+    expect(html).toContain('here');
+  });
+
+  it('unresolved inside unresolved: full source preserved as text', () => {
+    const html = mix('<Outer><Inner>nested content</Inner></Outer>\nafter\n');
+    expect(html).toContain('after');
+    expect(html).toContain('Outer');
+    expect(html).toContain('Inner');
+    expect(html).toContain('nested content');
+  });
+
+  it('triple-nested unresolved tags survive without dropping siblings', () => {
+    const html = mix('<A><B><C>x</C></B></A>\nafter\n');
+    expect(html).toContain('after');
+  });
+
+  it('registered nested inside unresolved (outer wins as literal text)', () => {
+    const html = mix(
+      '<Unknown>\n  <Callout icon="📘">inner callout</Callout>\n</Unknown>\nafter\n',
+      { components: { Unknown: Registered as CustomComponents[string] } },
+    );
+    expect(html).toContain('after');
+  });
+
+  it('mixed registered & unresolved siblings inside a registered parent', () => {
+    const html = mix(
+      '<Callout icon="📘">\n  <Foo /> followed by text and <Bar />\n</Callout>\nlast line\n',
+    );
+    expect(html).toContain('followed by text and');
+    expect(html).toContain('last line');
+  });
+
+  it('deeply nested through callout + list + unresolved tags', () => {
+    const md = [
+      '<Callout icon="📘">',
+      '',
+      '- item one with <Foo>',
+      '- item two with <Bar />',
+      '- item three',
+      '',
+      '</Callout>',
+      'tail',
+    ].join('\n');
+    const html = mix(md);
+    expect(html).toContain('item one with');
+    expect(html).toContain('item three');
+    expect(html).toContain('tail');
+  });
+
+  it('unresolved tag inside table cell inside callout', () => {
+    const md = [
+      '<Callout icon="📘">',
+      '',
+      '| h1 | h2 |',
+      '| --- | --- |',
+      '| <Foo> | survived |',
+      '',
+      '</Callout>',
+      'after',
+    ].join('\n');
+    const html = mix(md);
+    expect(html).toContain('survived');
+    expect(html).toContain('after');
+  });
+});
+
+describe('demoteUnresolvedJsxTags — runtime/special components must NOT demote', () => {
+  it('preserves <Variable variable="name" /> (runtime component)', () => {
+    const html = mix('<Variable variable="name" />\n');
+    expect(JSON.stringify(html)).toContain('Variable');
+  });
+});

--- a/__tests__/transformers/demote-unresolved-jsx-tags-subprocessors.test.ts
+++ b/__tests__/transformers/demote-unresolved-jsx-tags-subprocessors.test.ts
@@ -7,7 +7,7 @@ import { mix } from '../../lib';
 const Registered = {} as CustomComponents[string];
 
 describe('demoteUnresolvedJsxTags — bug repros at scale', () => {
-  it('preserves the original CX-3284 input', () => {
+  it('preserves the original  input', () => {
     const html = mix('<Batch_id>_<File_Type>_<Version>.csv\n');
     expect(html).toContain('Version');
     expect(html).toContain('.csv');

--- a/__tests__/transformers/demote-unresolved-jsx-tags.test.ts
+++ b/__tests__/transformers/demote-unresolved-jsx-tags.test.ts
@@ -46,4 +46,41 @@ describe('demote unresolved PascalCase JSX tags', () => {
     expect(html).toContain('Callout');
     expect(html).toContain('hello');
   });
+
+  it('demotes camelCase tags that start with lowercase (e.g. <myTag>)', () => {
+    const html = mix('Hello <myTag>world</myTag> tail\n');
+
+    expect(html).toContain('Hello');
+    expect(html).toContain('world');
+    expect(html).toContain('tail');
+  });
+
+  it('demotes a bare camelCase opener (e.g. <myThing>)', () => {
+    const html = mix('Use <myThing> please\n');
+
+    expect(html).toContain('Use');
+    expect(html).toContain('please');
+  });
+
+  it('demotes ALL-UPPERCASE unresolved tags (e.g. <XYZ>)', () => {
+    const html = mix('Use <XYZ>content</XYZ> please\n');
+
+    expect(html).toContain('content');
+    expect(html).toContain('please');
+  });
+
+  it('demotes lowercase unknown tags so they do not swallow following text', () => {
+    const html = mix('<Batch_id>_<File_Type>_<version>.csv\n');
+
+    expect(html).toContain('version');
+    expect(html).toContain('.csv');
+    expect(html).not.toMatch(/<version[\s>]/);
+  });
+
+  it('demotes a bare lowercase unknown tag', () => {
+    const html = mix('xx_<version>.csv\n');
+
+    expect(html).toContain('.csv');
+    expect(html).not.toMatch(/<version[\s>]/);
+  });
 });

--- a/__tests__/transformers/demote-unresolved-jsx-tags.test.ts
+++ b/__tests__/transformers/demote-unresolved-jsx-tags.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { mix } from '../../lib';
+
+describe('demote unresolved PascalCase JSX tags', () => {
+  it('renders text after an unknown <Version> tag instead of dropping it', () => {
+    const html = mix('<Batch_id>_<File_Type>_<Version>.csv\n');
+
+    expect(html).toContain('Version');
+    expect(html).toContain('.csv');
+  });
+
+  it('escapes a bare unknown PascalCase opening tag as literal text', () => {
+    const html = mix('Use <Version> in the filename.\n');
+
+    expect(html).toContain('Version');
+    expect(html).toContain('in the filename.');
+  });
+
+  it('escapes a paired unknown PascalCase tag with content', () => {
+    const html = mix('Hello <Foo>world</Foo>!\n');
+
+    expect(html).toContain('Foo');
+    expect(html).toContain('world');
+    expect(html).toContain('!');
+  });
+
+  it('renders content following multiple unknown PascalCase tags', () => {
+    const html = mix('<Alpha> middle <Beta> tail\n');
+
+    expect(html).toContain('middle');
+    expect(html).toContain('tail');
+  });
+
+  it('leaves lowercase HTML tags alone', () => {
+    const html = mix('Line one<br />line two\n');
+
+    expect(html).toContain('<br>');
+    expect(html).toContain('Line one');
+    expect(html).toContain('line two');
+  });
+
+  it('still renders known custom components', () => {
+    const html = mix('<Callout icon="📘">hello</Callout>\n');
+
+    expect(html).toContain('Callout');
+    expect(html).toContain('hello');
+  });
+});

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -31,6 +31,7 @@ import mdxishInlineMdxComponents from '../processor/transform/mdxish/components/
 import mdxishMdxComponentBlocks from '../processor/transform/mdxish/components/mdx-blocks';
 import mdxishSelfClosingBlocks from '../processor/transform/mdxish/components/self-closing-blocks';
 import { processSnakeCaseComponent } from '../processor/transform/mdxish/components/snake-case-components';
+import demoteUnresolvedJsxTags from '../processor/transform/mdxish/demote-unresolved-jsx-tags';
 import evaluateExpressions from '../processor/transform/mdxish/evaluate-expressions';
 import generateSlugForHeadings from '../processor/transform/mdxish/heading-slugs';
 import magicBlockTransformer from '../processor/transform/mdxish/magic-blocks/magic-block-transformer';
@@ -265,6 +266,7 @@ export function mdxish(mdContent: string, opts: MdxishOpts = {}): Root {
   const { processor, parserReadyContent } = mdxishAstProcessor(contentWithoutComments, opts);
 
   processor
+    .use(demoteUnresolvedJsxTags, { components }) // Convert unresolved PascalCase tags (e.g. user-typed <Version>) to literal text in view-mode rendering
     .use(safeMode ? undefined : evaluateExpressions) // Evaluate self-contained MDX expressions (e.g. `{1+1}`)
     .use(remarkBreaks)
     .use(variablesCodeResolver, { variables }) // Resolve <<...>> and {user.*} inside code and inline code nodes

--- a/processor/transform/mdxish/demote-unresolved-jsx-tags.ts
+++ b/processor/transform/mdxish/demote-unresolved-jsx-tags.ts
@@ -13,25 +13,25 @@ interface Options {
   components: CustomComponents;
 }
 
-const LEADING_TAG_REGEX = /^<\/?([A-Za-z][A-Za-z0-9]*)\b/;
+const LEADING_TAG_REGEX = /^<\/?([A-Za-z][\w-]*)\b/;
 
-function isUnresolvedPascalCase(tagName: string, components: CustomComponents): boolean {
-  if (!/^[A-Z]/.test(tagName)) return false;
+function isUnresolvedTag(tagName: string, components: CustomComponents): boolean {
   if (STANDARD_HTML_TAGS.has(tagName.toLowerCase())) return false;
   if (RUNTIME_COMPONENT_TAGS.has(tagName)) return false;
   return !getComponentName(tagName, components);
 }
 
 /**
- * A user typing `<Version>` (a PascalCase tag that resembles a JSX component
- * but isn't registered) parses to either a raw `html` MDAST node or an
- * `mdxJsx{Flow,Text}Element`. Downstream, parse5 opens a `<version>` element
- * and `rehypeMdxishComponents` removes it along with every sibling that got
- * slurped in as its children — silently dropping page content.
+ * A user typing `<Version>`, `<myTag>`, or `<version>` (any tag that resembles
+ * JSX/HTML but isn't a registered component) parses to either a raw `html`
+ * MDAST node or an `mdxJsx{Flow,Text}Element`. Downstream, parse5 opens it as
+ * an empty element and slurps the following siblings as its children — which
+ * then either get silently dropped by `rehypeMdxishComponents` (mixed-case) or
+ * swallow surrounding content into an unrenderable custom element (lowercase).
  *
- * Demote unresolved PascalCase tags to plain text so they round-trip as
- * literal `<Tag>` characters instead of vanishing. Lowercase HTML tags and
- * registered components are left untouched.
+ * Demote any unresolved tag — regardless of case — to plain text so it
+ * round-trips as literal `<Tag>` characters instead of mangling the page.
+ * Standard HTML tags and registered components are left untouched.
  */
 const demoteUnresolvedJsxTags: Plugin<[Options], Root> = ({ components }) => (tree, file) => {
   const source = (file as VFile)?.toString?.() ?? '';
@@ -39,7 +39,7 @@ const demoteUnresolvedJsxTags: Plugin<[Options], Root> = ({ components }) => (tr
   visit(tree, 'html', (node: Html) => {
     const match = LEADING_TAG_REGEX.exec(node.value);
     if (!match) return;
-    if (!isUnresolvedPascalCase(match[1], components)) return;
+    if (!isUnresolvedTag(match[1], components)) return;
 
     (node as unknown as { type: string; value: string }).type = 'text';
   });
@@ -49,7 +49,7 @@ const demoteUnresolvedJsxTags: Plugin<[Options], Root> = ({ components }) => (tr
     if (!parent || index === undefined) return;
 
     const jsxNode = node as MdxJsxFlowElement | MdxJsxTextElement;
-    if (!jsxNode.name || !isUnresolvedPascalCase(jsxNode.name, components)) return;
+    if (!jsxNode.name || !isUnresolvedTag(jsxNode.name, components)) return;
 
     const startOffset = jsxNode.position?.start?.offset;
     const endOffset = jsxNode.position?.end?.offset;

--- a/processor/transform/mdxish/demote-unresolved-jsx-tags.ts
+++ b/processor/transform/mdxish/demote-unresolved-jsx-tags.ts
@@ -1,0 +1,68 @@
+import type { CustomComponents } from '../../../types';
+import type { Html, Node, Parent, Root } from 'mdast';
+import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
+import type { Plugin } from 'unified';
+import type { VFile } from 'vfile';
+
+import { visit } from 'unist-util-visit';
+
+import { getComponentName } from '../../../lib/utils/mdxish/mdxish-get-component-name';
+import { RUNTIME_COMPONENT_TAGS, STANDARD_HTML_TAGS } from '../../../utils/common-html-words';
+
+interface Options {
+  components: CustomComponents;
+}
+
+const LEADING_TAG_REGEX = /^<\/?([A-Za-z][A-Za-z0-9]*)\b/;
+
+function isUnresolvedPascalCase(tagName: string, components: CustomComponents): boolean {
+  if (!/^[A-Z]/.test(tagName)) return false;
+  if (STANDARD_HTML_TAGS.has(tagName.toLowerCase())) return false;
+  if (RUNTIME_COMPONENT_TAGS.has(tagName)) return false;
+  return !getComponentName(tagName, components);
+}
+
+/**
+ * A user typing `<Version>` (a PascalCase tag that resembles a JSX component
+ * but isn't registered) parses to either a raw `html` MDAST node or an
+ * `mdxJsx{Flow,Text}Element`. Downstream, parse5 opens a `<version>` element
+ * and `rehypeMdxishComponents` removes it along with every sibling that got
+ * slurped in as its children — silently dropping page content.
+ *
+ * Demote unresolved PascalCase tags to plain text so they round-trip as
+ * literal `<Tag>` characters instead of vanishing. Lowercase HTML tags and
+ * registered components are left untouched.
+ */
+const demoteUnresolvedJsxTags: Plugin<[Options], Root> = ({ components }) => (tree, file) => {
+  const source = (file as VFile)?.toString?.() ?? '';
+
+  visit(tree, 'html', (node: Html) => {
+    const match = LEADING_TAG_REGEX.exec(node.value);
+    if (!match) return;
+    if (!isUnresolvedPascalCase(match[1], components)) return;
+
+    (node as unknown as { type: string; value: string }).type = 'text';
+  });
+
+  visit(tree, (node: Node, index, parent) => {
+    if (node.type !== 'mdxJsxFlowElement' && node.type !== 'mdxJsxTextElement') return;
+    if (!parent || index === undefined) return;
+
+    const jsxNode = node as MdxJsxFlowElement | MdxJsxTextElement;
+    if (!jsxNode.name || !isUnresolvedPascalCase(jsxNode.name, components)) return;
+
+    const startOffset = jsxNode.position?.start?.offset;
+    const endOffset = jsxNode.position?.end?.offset;
+    const original = startOffset !== undefined && endOffset !== undefined
+      ? source.slice(startOffset, endOffset)
+      : `<${jsxNode.name}>`;
+
+    (parent as Parent).children[index] = {
+      type: 'text',
+      value: original,
+      position: jsxNode.position,
+    } as unknown as Parent['children'][number];
+  });
+};
+
+export default demoteUnresolvedJsxTags;


### PR DESCRIPTION
| 🎫 Resolve CX-3284 |
| :-----------------: |

## 🎯 What does this PR do?

When we encounter stuff like 

```
<Blob_Blob>_<Foo_Bar>_<Version>
```
the angle bracket tags arent actually valid tags and they are considered as undefined so they vanish in the rendered output. the main argument is that sometimes we want to specifically preserve this behaviour, so we change that

> [!IMPORTANT]
this is a breaking change in how we handle undefined/unresolvable mdx tags

instead of vanishing or returning undefined, when we encounter these undefined tags, we simply demote them to plain text

## 🧪 QA tips

Use the testing snippet and make sure that `<Version` is not gone in the rendered version

## 📸 Screenshot or Loom

Before | After
-- | --
<img width="492" height="270" alt="Screenshot 2026-05-18 at 13 12 06" src="https://github.com/user-attachments/assets/0f164048-e08d-465a-9802-a398d00db6e2" /> | <img width="438" height="284" alt="Screenshot 2026-05-18 at 13 11 38" src="https://github.com/user-attachments/assets/de96bb5c-072e-4496-a4da-a899f1a997f1" />

for this
```
<Blob_Blob>_<Foo_Bar>_<Version>trailing text

<Blob_Blob>_<Foo_Bar>_<version>trailing text

<Blob_Blob>_<Foo_Bar>_<object>real html tag
```