### PR TITLE
fix(mdxish): bail orphaned `<Tag>` openers before they eat sibling blocks

### DIFF
--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -1,4 +1,4 @@
-import type { Parent, Root } from 'mdast';
+import type { Code, Heading, Parent, Root } from 'mdast';
 
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
@@ -7,7 +7,12 @@ import { mdxComponentFromMarkdown } from '../../lib/mdast-util/mdx-component';
 import { mdxComponent } from '../../lib/micromark/mdx-component';
 import mdxishComponentBlocks from '../../processor/transform/mdxish/components/mdx-blocks';
 import mdxishSelfClosingBlocks from '../../processor/transform/mdxish/components/self-closing-blocks';
-import { collectNodes } from '../helpers';
+import { collectNodes, parseMdxish } from '../helpers';
+
+interface MdxJsxFlowElement extends Parent {
+  name?: string;
+  type: 'mdxJsxFlowElement';
+}
 
 /**
  * Helper to parse markdown and apply the component block plugins.
@@ -516,6 +521,478 @@ Some text with <Anchor href="https://readme.com">link</Anchor> inline.`;
         type: 'mdxJsxFlowElement',
         name: 'MyComponent',
         attributes: [{ type: 'mdxJsxAttribute', name: 'foo', value: 'bar' }],
+      });
+    });
+  });
+
+  describe('unclosed `<Tag>` opener does not swallow following blocks', () => {
+    const counts = (tree: Root) => ({
+      callouts: collectNodes(tree, 'rdme-callout').length,
+      headings: tree.children.filter(c => c.type === 'heading').length,
+      lists: collectNodes(tree, 'list').length,
+      tables: collectNodes(tree, 'table').length,
+      code: collectNodes(tree, 'code').length,
+      mdxFlow: collectNodes(tree, 'mdxJsxFlowElement').length,
+    });
+
+    describe('original repro', () => {
+      it('parses both callouts when separated by `<Batch_id>_<File_Type>_<Version>.csv`', () => {
+        const md = `> 📘 Success
+>
+> Vitae reprehenderit at aliquid error voluptates eum dignissimos.
+
+<Batch_id>_<File_Type>_<Version>.csv
+
+> 📘 Success
+>
+> Vitae reprehenderit at aliquid error voluptates eum dignissimos.
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(2);
+      });
+
+      it('still parses both callouts when the first tag is escaped (existing workaround)', () => {
+        const md = `> 📘 Success
+>
+> Body one.
+
+\\<Batch_id>_<File_Type>_<Version>.csv
+
+> 📘 Success
+>
+> Body two.
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(2);
+      });
+    });
+
+    describe('block-level siblings after an unclosed opener line', () => {
+      it('preserves a following callout', () => {
+        const md = `<Foo>_<Bar>.csv
+
+> 📘 Heads up
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('preserves a following ATX heading', () => {
+        const md = `<Foo>_<Bar>.csv
+
+# Real heading
+`;
+        const tree = parseMdxish(md);
+        const headings = tree.children.filter(c => c.type === 'heading');
+        expect(headings).toHaveLength(1);
+        expect(headings[0]).toMatchObject({ depth: 1 });
+      });
+
+      it('preserves a following unordered list', () => {
+        const md = `<Foo>_<Bar>.zip
+
+- one
+- two
+- three
+`;
+        const tree = parseMdxish(md);
+        const lists = collectNodes<Parent>(tree, 'list');
+        expect(lists).toHaveLength(1);
+        expect(lists[0].children).toHaveLength(3);
+      });
+
+      it('preserves a following fenced code block', () => {
+        const md = `<Foo>_<Bar>.csv
+
+\`\`\`js
+const x = 1;
+\`\`\`
+`;
+        const tree = parseMdxish(md);
+        const code = collectNodes<Code>(tree, 'code');
+        expect(code).toHaveLength(1);
+        expect(code[0].lang).toBe('js');
+        expect(code[0].value).toBe('const x = 1;');
+      });
+
+      it('preserves a following GFM table', () => {
+        const md = `<Foo>_<Bar>.csv
+
+| h1 | h2 |
+| -- | -- |
+| a  | b  |
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).tables).toBeGreaterThanOrEqual(1);
+      });
+
+      it('preserves a following real PascalCase component', () => {
+        const md = `<Foo>_<Bar>.csv
+
+<RealComponent foo="bar" />
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.map(n => n.name)).toContain('RealComponent');
+      });
+
+      it('preserves multiple following blocks together', () => {
+        const md = `<Outer>_<Inner>_<X>.csv
+
+# Title
+
+> 📘 Tip
+>
+> Body.
+
+- item
+
+\`\`\`
+code
+\`\`\`
+`;
+        const tree = parseMdxish(md);
+        const c = counts(tree);
+        expect(c.headings).toBe(1);
+        expect(c.callouts).toBe(1);
+        expect(c.lists).toBe(1);
+        expect(c.code).toBe(1);
+      });
+    });
+
+    describe('multiple unclosed openers in series', () => {
+      it('does not swallow subsequent callouts when several broken lines appear', () => {
+        const md = `<Alpha>_<Beta>.csv
+
+<Gamma>_<Delta>.csv
+
+> 📘 Survives
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+    });
+
+    describe('nested inside containers', () => {
+      it('does not swallow content inside the same callout as the broken line', () => {
+        const md = `> 📘 Title
+>
+> intro
+>
+> <Foo>_<Bar>.csv
+>
+> trailing line still inside
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+        const callouts = collectNodes<Parent>(tree, 'rdme-callout');
+        const text = JSON.stringify(callouts[0]);
+        expect(text).toContain('trailing line still inside');
+      });
+
+      it('parses a callout that follows a broken line, both inside a list item', () => {
+        const md = `- top item
+
+  <Foo>_<Bar>.csv
+
+  > 📘 inside list
+  >
+  > body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('preserves headings nested under a broken line in document order', () => {
+        const md = `<A>_<B>.csv
+
+## Heading two
+
+text
+`;
+        const tree = parseMdxish(md);
+        const headings = tree.children.filter((c): c is Heading => c.type === 'heading');
+        expect(headings).toHaveLength(1);
+        expect(headings[0].depth).toBe(2);
+      });
+
+      it('keeps a broken line inside a heading from breaking the next callout', () => {
+        const md = `# Heading with <Foo>_<Bar> noise
+
+> 📘 Tip
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).headings).toBe(1);
+        expect(counts(tree).callouts).toBe(1);
+      });
+    });
+
+    describe('non-regression — real component shapes still parse', () => {
+      it('still parses a standard multi-line `<Outer>…</Outer>` block', () => {
+        const md = `<Outer>
+
+inside
+
+</Outer>
+
+> 📘 After
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.map(n => n.name)).toContain('Outer');
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('still parses a single-line `<Foo>text</Foo>` block', () => {
+        const md = `<Foo>hello</Foo>
+
+> 📘 After
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.map(n => n.name)).toContain('Foo');
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('still parses a self-closing `<Foo />` followed by a callout', () => {
+        const md = `<Foo />
+
+> 📘 After
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.map(n => n.name)).toContain('Foo');
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('still parses nested same-name components when properly closed', () => {
+        const md = `<Outer>
+
+<Outer>inner</Outer>
+
+</Outer>
+
+> 📘 After
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.filter(n => n.name === 'Outer')).toHaveLength(2);
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('parses `<Callout>Hello\\n</Callout>` (plain content, closer next line)', () => {
+        const md = `<Callout>Hello
+</Callout>
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.map(n => n.name)).toContain('Callout');
+      });
+
+      it('parses `<Callout>first\\n\\nsecond\\n</Callout>` (multi-paragraph body)', () => {
+        const md = `<Callout>First paragraph.
+
+Second paragraph
+</Callout>
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.map(n => n.name)).toContain('Callout');
+      });
+
+      it('parses `<Callout>x <strong>y</strong>\\n</Callout>` (matched inline tag on opener line)', () => {
+        const md = `<Callout>Hello <strong>Hello</strong>
+</Callout>
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.map(n => n.name)).toContain('Callout');
+      });
+
+      it('parses nested `<Callout>` with inline tag and multi-paragraph body', () => {
+        const md = `<Callout>First paragraph.
+
+<Callout>Hello <strong>Hello</strong>
+</Callout>
+
+Second paragraph
+</Callout>
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.filter(n => n.name === 'Callout')).toHaveLength(2);
+      });
+    });
+
+    describe('inside real PascalCase parent components', () => {
+      it('parses a callout sibling when the broken line is inside a real outer component', () => {
+        const md = `<Outer>
+
+<Foo>_<Bar>.csv
+
+> 📘 Inside Outer
+>
+> body
+
+</Outer>
+`;
+        const tree = parseMdxish(md);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        const outer = flow.find(n => n.name === 'Outer');
+        expect(outer).toBeDefined();
+        const calloutsInside = collectNodes(outer as Parent, 'rdme-callout');
+        expect(calloutsInside).toHaveLength(1);
+      });
+
+      it('parses a callout immediately after a real outer component closes', () => {
+        const md = `<Outer>
+
+<Foo>_<Bar>.csv
+
+</Outer>
+
+> 📘 After outer
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+        const flow = collectNodes<MdxJsxFlowElement>(tree, 'mdxJsxFlowElement');
+        expect(flow.map(n => n.name)).toContain('Outer');
+      });
+    });
+
+    describe('stress scenarios', () => {
+      it('handles a long document littered with broken opener lines and real callouts', () => {
+        const md = `# Top
+
+<A>_<B>.csv
+
+> 📘 One
+>
+> body
+
+<C>_<D>.zip
+
+> 📘 Two
+>
+> body
+
+<E>_<F>.tar
+
+> 📘 Three
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(3);
+        expect(counts(tree).headings).toBe(1);
+      });
+
+      it('does not consume the only callout when the opener uses a real component-style name', () => {
+        const md = `<Image>_<source>.png
+
+> 📘 After
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('handles an indented broken line followed by a callout', () => {
+        const md = `   <Foo>_<Bar>.csv
+
+> 📘 After indent
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('does not crash and parses callout when document ends mid-broken-opener', () => {
+        const md = `> 📘 First
+>
+> body
+
+<Trailing>_<Unclosed>`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('parses both callouts when the broken line is in a deeply nested list item', () => {
+        const md = `- top
+  - nested
+    - <Foo>_<Bar>.csv
+
+> 📘 After deep list
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('survives multiple consecutive broken lines without a blank between', () => {
+        const md = `<A>_<B>.csv
+<C>_<D>.zip
+<E>_<F>.tar
+
+> 📘 After three
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+    });
+
+    describe('whitespace and adjacency variants', () => {
+      it('survives when the callout follows immediately with no blank line', () => {
+        const md = `<Foo>_<Bar>.csv
+> 📘 Tight
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('survives when the broken opener has trailing whitespace', () => {
+        const md = `<Foo>_<Bar>.csv   ${''}
+
+> 📘 Trailing whitespace
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
+      });
+
+      it('survives when the broken opener has a tab between filename tokens', () => {
+        const md = `<Foo>\t_<Bar>.csv
+
+> 📘 Tab after
+>
+> body
+`;
+        const tree = parseMdxish(md);
+        expect(counts(tree).callouts).toBe(1);
       });
     });
   });

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -535,6 +535,11 @@ Some text with <Anchor href="https://readme.com">link</Anchor> inline.`;
       mdxFlow: collectNodes(tree, 'mdxJsxFlowElement').length,
     });
 
+    const calloutContains = (tree: Root, text: string, index = 0) => {
+      const callouts = collectNodes<Parent>(tree, 'rdme-callout');
+      return JSON.stringify(callouts[index]).includes(text);
+    };
+
     describe('original repro', () => {
       it('parses both callouts when separated by `<Batch_id>_<File_Type>_<Version>.csv`', () => {
         const md = `> 📘 Success
@@ -577,6 +582,8 @@ Some text with <Anchor href="https://readme.com">link</Anchor> inline.`;
 `;
         const tree = parseMdxish(md);
         expect(counts(tree).callouts).toBe(1);
+        expect(calloutContains(tree, 'Heads up')).toBe(true);
+        expect(calloutContains(tree, 'body')).toBe(true);
       });
 
       it('preserves a following ATX heading', () => {
@@ -659,6 +666,8 @@ code
         expect(c.callouts).toBe(1);
         expect(c.lists).toBe(1);
         expect(c.code).toBe(1);
+        expect(calloutContains(tree, 'Tip')).toBe(true);
+        expect(calloutContains(tree, 'Body.')).toBe(true);
       });
     });
 
@@ -705,6 +714,8 @@ code
 `;
         const tree = parseMdxish(md);
         expect(counts(tree).callouts).toBe(1);
+        expect(calloutContains(tree, 'inside list')).toBe(true);
+        expect(calloutContains(tree, 'body')).toBe(true);
       });
 
       it('preserves headings nested under a broken line in document order', () => {
@@ -730,6 +741,8 @@ text
         const tree = parseMdxish(md);
         expect(counts(tree).headings).toBe(1);
         expect(counts(tree).callouts).toBe(1);
+        expect(calloutContains(tree, 'Tip')).toBe(true);
+        expect(calloutContains(tree, 'body')).toBe(true);
       });
     });
 
@@ -901,6 +914,9 @@ Second paragraph
         const tree = parseMdxish(md);
         expect(counts(tree).callouts).toBe(3);
         expect(counts(tree).headings).toBe(1);
+        expect(calloutContains(tree, 'One', 0)).toBe(true);
+        expect(calloutContains(tree, 'Two', 1)).toBe(true);
+        expect(calloutContains(tree, 'Three', 2)).toBe(true);
       });
 
       it('does not consume the only callout when the opener uses a real component-style name', () => {

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -88,6 +88,15 @@ function createTokenize(mode: 'flow' | 'text') {
     let fenceCloseLength = 0;
     let atLineStart = false;
 
+    // Bail when the opener line has unmatched tag-like tokens in its body.
+    // `<Foo>_<Bar>.csv` leaves opens > closes; matched shapes like
+    // `<Callout>x <strong>y</strong>` balance to 0. Without this,
+    // `concrete: true` causes orphan openers to eat sibling blockquotes.
+    let bodyOnOpenerLine = false;
+    let bodySawContentOnOpenerLine = false;
+    let bodyOpenersOnOpenerLine = 0;
+    let bodyClosersOnOpenerLine = 0;
+
     // Attribute parsing state
     let quoteChar: Code = null;
     let braceDepth = 0;
@@ -188,6 +197,7 @@ function createTokenize(mode: 'flow' | 'text') {
       if (code === codes.greaterThan) {
         if (isLowercaseTag && !sawBraceAttr) return nok(code);
         effects.consume(code);
+        bodyOnOpenerLine = isFlow;
         return body;
       }
 
@@ -425,9 +435,23 @@ function createTokenize(mode: 'flow' | 'text') {
 
       if (markdownLineEnding(code)) {
         if (!isFlow) return nok(code);
+        // See `bodyOnOpenerLine` declaration. Bail iff the opener line had
+        // content AND more opener-shaped tokens than closer-shaped tokens.
+        if (
+          bodyOnOpenerLine &&
+          bodySawContentOnOpenerLine &&
+          bodyOpenersOnOpenerLine > bodyClosersOnOpenerLine
+        ) {
+          return nok(code);
+        }
+        bodyOnOpenerLine = false;
         effects.exit('mdxComponentData');
         atLineStart = true;
         return bodyContinuationStart(code);
+      }
+
+      if (code !== codes.space && code !== codes.horizontalTab) {
+        bodySawContentOnOpenerLine = true;
       }
 
       if (code === codes.backslash) {
@@ -607,6 +631,7 @@ function createTokenize(mode: 'flow' | 'text') {
 
     function bodyLessThan(code: Code): State | undefined {
       if (code === codes.slash) {
+        if (bodyOnOpenerLine) bodyClosersOnOpenerLine += 1;
         effects.consume(code);
         closingTagName = '';
         return closingTagNameFirst;
@@ -614,9 +639,17 @@ function createTokenize(mode: 'flow' | 'text') {
 
       // Potential nested opening tag (same case class as the outer tag)
       if (code !== null && isAlpha(code) && isSameCaseAsTag(code)) {
+        if (bodyOnOpenerLine) bodyOpenersOnOpenerLine += 1;
         closingTagName = String.fromCharCode(code);
         effects.consume(code);
         return nestedOpenTagName;
+      }
+
+      // Tag-like token but not in nested-tracking case (different case).
+      // Count it for the opener-line bail heuristic anyway: `<strong>` in
+      // `<Callout>x <strong>y</strong></Callout>` should pair with `</strong>`.
+      if (code !== null && isAlpha(code) && bodyOnOpenerLine) {
+        bodyOpenersOnOpenerLine += 1;
       }
 
       atLineStart = false;

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -92,10 +92,10 @@ function createTokenize(mode: 'flow' | 'text') {
     // `<Foo>_<Bar>.csv` leaves opens > closes; matched shapes like
     // `<Callout>x <strong>y</strong>` balance to 0. Without this,
     // `concrete: true` causes orphan openers to eat sibling blockquotes.
-    let bodyOnOpenerLine = false;
-    let bodySawContentOnOpenerLine = false;
-    let bodyOpenersOnOpenerLine = 0;
-    let bodyClosersOnOpenerLine = 0;
+    let onOpenerLine = false;
+    let openerLineHasContent = false;
+    let openerLineOpens = 0;
+    let openerLineCloses = 0;
 
     // Attribute parsing state
     let quoteChar: Code = null;
@@ -197,7 +197,7 @@ function createTokenize(mode: 'flow' | 'text') {
       if (code === codes.greaterThan) {
         if (isLowercaseTag && !sawBraceAttr) return nok(code);
         effects.consume(code);
-        bodyOnOpenerLine = isFlow;
+        onOpenerLine = isFlow;
         return body;
       }
 
@@ -435,23 +435,19 @@ function createTokenize(mode: 'flow' | 'text') {
 
       if (markdownLineEnding(code)) {
         if (!isFlow) return nok(code);
-        // See `bodyOnOpenerLine` declaration. Bail iff the opener line had
+        // See `onOpenerLine` declaration. Bail iff the opener line had
         // content AND more opener-shaped tokens than closer-shaped tokens.
-        if (
-          bodyOnOpenerLine &&
-          bodySawContentOnOpenerLine &&
-          bodyOpenersOnOpenerLine > bodyClosersOnOpenerLine
-        ) {
+        if (onOpenerLine && openerLineHasContent && openerLineOpens > openerLineCloses) {
           return nok(code);
         }
-        bodyOnOpenerLine = false;
+        onOpenerLine = false;
         effects.exit('mdxComponentData');
         atLineStart = true;
         return bodyContinuationStart(code);
       }
 
       if (code !== codes.space && code !== codes.horizontalTab) {
-        bodySawContentOnOpenerLine = true;
+        openerLineHasContent = true;
       }
 
       if (code === codes.backslash) {
@@ -631,7 +627,7 @@ function createTokenize(mode: 'flow' | 'text') {
 
     function bodyLessThan(code: Code): State | undefined {
       if (code === codes.slash) {
-        if (bodyOnOpenerLine) bodyClosersOnOpenerLine += 1;
+        if (onOpenerLine) openerLineCloses += 1;
         effects.consume(code);
         closingTagName = '';
         return closingTagNameFirst;
@@ -639,7 +635,7 @@ function createTokenize(mode: 'flow' | 'text') {
 
       // Potential nested opening tag (same case class as the outer tag)
       if (code !== null && isAlpha(code) && isSameCaseAsTag(code)) {
-        if (bodyOnOpenerLine) bodyOpenersOnOpenerLine += 1;
+        if (onOpenerLine) openerLineOpens += 1;
         closingTagName = String.fromCharCode(code);
         effects.consume(code);
         return nestedOpenTagName;
@@ -648,8 +644,8 @@ function createTokenize(mode: 'flow' | 'text') {
       // Tag-like token but not in nested-tracking case (different case).
       // Count it for the opener-line bail heuristic anyway: `<strong>` in
       // `<Callout>x <strong>y</strong></Callout>` should pair with `</strong>`.
-      if (code !== null && isAlpha(code) && bodyOnOpenerLine) {
-        bodyOpenersOnOpenerLine += 1;
+      if (code !== null && isAlpha(code) && onOpenerLine) {
+        openerLineOpens += 1;
       }
 
       atLineStart = false;


### PR DESCRIPTION
| 🎫 Resolve RM-16615 |
| :-----------------: |

## 🎯 What does this PR do?

While triaging https://github.com/readmeio/markdown/pull/1472, I ran into this issue where an unclosed mdx tag like `<Blob>` would silently swallow any other block node openers like `>`. Basically if you put anything like

```
> 📘 Success
>
> Vitae reprehenderit at aliquid error voluptates eum dignissimos.
```
after an unclosed tag, it would not be rendered as a callout but instead as plain text. this was due to the tokenizer having `concrete: true`, making it ignore stuff like `>` since the mdx tokenizer already claimed the opening `<Blob>` and has begun processing its construct

## 🧪 QA tips

Type things like

```
<Blob_Blob>_<Foo_Bar>_<Version>trailing text

> 📘 Success
>
> Vitae reprehenderit at aliquid error voluptates eum dignissimos.
```
in the demo app and make sure the Callout is being rendered properly

## 📸 Screenshot or Loom

Before | After
-- | --
<img width="1116" height="970" alt="Screenshot 2026-05-18 at 13 08 40" src="https://github.com/user-attachments/assets/92d72ecd-a74c-4e98-a0b7-cc808f5bd267" /> | <img width="1122" height="973" alt="Screenshot 2026-05-18 at 13 09 38" src="https://github.com/user-attachments/assets/e8108cbf-1fea-4a25-b0f5-a52c88ac805a" />

for rendering this
```
> 📘 Success
>
> Vitae reprehenderit at aliquid error voluptates eum dignissimos.

<Blob_Blob>_<Foo_Bar>_<Version>trailing text

> 📘 Success
>
> Vitae reprehenderit at aliquid error voluptates eum dignissimos.

<Callout>Hello <strong>Hello</strong>
</Callout>

<Callout>First paragraph.

<Callout>Hello <strong>Hello</strong>
</Callout>

Second paragraph
</Callout>

> 📘 Actually create a title
>
> Content here&#x20;
>
> > 📘 ASD
> >
> > ADSDSD
```