### PR TITLE
fix(mdxish): preserve raw-content HTML tags when unclosed on a line

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -2,13 +2,12 @@ import type { Element, Nodes as HastNode, Root as HastRoot } from 'hast';
 import type { Node, Root as MdastRoot } from 'mdast';
 
 import * as rdmd from '@readme/markdown-legacy';
-
 import { visit } from 'unist-util-visit';
 
 import { vi } from 'vitest';
 
 import { run, compile, migrate as baseMigrate, mdastV6 } from '../index';
-import { mdxishAstProcessor, type MdxishOpts } from '../lib/mdxish';
+import { mdxishAstProcessor, mdxishMdastToMd, type MdxishOpts } from '../lib/mdxish';
 
 export const silenceConsole =
   (prop: keyof Console = 'error', impl = () => {}) =>
@@ -92,6 +91,12 @@ export const parseMdxishWithSource = (
  */
 export const parseMdxish = (doc: string, opts: MdxishOpts = {}): MdastRoot =>
   parseMdxishWithSource(doc, opts).tree;
+
+/**
+ * Round-trips markdown: parse → MDAST → serialize back to markdown.
+ */
+export const roundTripMdxish = (doc: string, opts: MdxishOpts = {}): string =>
+  mdxishMdastToMd(parseMdxish(doc, opts));
 
 /**
  * Walks a unist tree (mdast or hast) and returns every node that matches.

--- a/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
+++ b/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
@@ -1,6 +1,7 @@
 import type { Root, Table } from 'mdast';
 
 import { mdxishAstProcessor, mdxishMdastToMd } from '../../../lib/mdxish';
+import { roundTripMdxish } from '../../helpers';
 
 describe('mdxishAstProcessor', () => {
   describe('deferred processing (handled by mdxish rendering pipeline)', () => {
@@ -296,9 +297,7 @@ Content here
 </Callout>
 `;
 
-      const { processor, parserReadyContent } = mdxishAstProcessor(md, { newEditorTypes: true });
-      const tree = processor.runSync(processor.parse(parserReadyContent)) as Root;
-      const out = mdxishMdastToMd(tree);
+      const out = roundTripMdxish(md, { newEditorTypes: true });
 
       expect(out).not.toMatch(/^>\s*📘\s+Content here/);
 

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -4,7 +4,7 @@ import type { MdxJsxTextElement } from 'mdast-util-mdx';
 import { toHtml } from 'hast-util-to-html';
 
 import { mdxish, mdxishAstProcessor } from '../../lib/mdxish';
-import { collectNodes, findAllElementsByTagName, parseMdxishWithSource } from '../helpers';
+import { collectNodes, findAllElementsByTagName, parseMdxishWithSource, roundTripMdxish } from '../helpers';
 
 const astProcessor = (md: string): Root => {
   const { processor, parserReadyContent } = mdxishAstProcessor(md);
@@ -920,5 +920,29 @@ describe('mdxish tables transformation', () => {
     const html = toHtml(mdxish(md));
     expect(html).toContain('<code>code</code>');
     expect(html).toContain('<strong>bold</strong>');
+  });
+
+  describe('<pre> formatting inside HTML table cells', () => {
+    it('preserves <pre> indentation when <pre> is at column 0 inside a table', () => {
+      const md = `<table>
+<tr>
+<td>
+<pre data-lang="json">
+{
+  "a": "x",
+  "b": {
+    "c": "y"
+  }
+}
+</pre>
+</td>
+</tr>
+</table>`;
+
+      const out = roundTripMdxish(md);
+      expect(out).toContain('"a": "x"');
+      expect(out).toContain('  "b"');
+      expect(out).toContain('    "c": "y"');
+    });
   });
 });

--- a/__tests__/transformers/terminate-html-flow-blocks.test.ts
+++ b/__tests__/transformers/terminate-html-flow-blocks.test.ts
@@ -99,6 +99,74 @@ Next content`;
 Next content`);
     });
 
+    it('inserts blank line after opening HTML tag when next line is a list', () => {
+      const input = `<div>
+- item one
+- item two`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+- item one
+- item two`);
+    });
+
+    it('inserts blank line after opening HTML tag when next line is a blockquote', () => {
+      const input = `<div>
+> quoted text`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+> quoted text`);
+    });
+
+    it('inserts blank line after opening HTML tag when next line is a fenced code block', () => {
+      const input = `<div>
+\`\`\`js
+const x = 1;
+\`\`\``;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+\`\`\`js
+const x = 1;
+\`\`\``);
+    });
+
+    it('inserts blank line after opening HTML tag when next line is an ordered list', () => {
+      const input = `<div>
+1. first
+2. second`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+1. first
+2. second`);
+    });
+
+    it('inserts blank line after opening HTML tag when next line is a thematic break', () => {
+      const input = `<div>
+---`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+---`);
+    });
+
+    it('inserts blank line after opening HTML tag when next line is a closing block marker', () => {
+      const input = `<div>
+[/block]`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+[/block]`);
+    });
+
     it('inserts blank line when HTML line has text content between and after tags', () => {
       const input = `<div><p>Inner text</p></div>Outer text
 [block:callout]
@@ -241,6 +309,32 @@ there
       expect(terminateHtmlFlowBlocks(input)).toBe(input);
     });
 
+    it('does not insert blank line after nested table opening tags when next line is plain content', () => {
+      const input = `<table><tr><td>
+Cell content stays put`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it.each([
+      'pre',
+      'script',
+      'style',
+      'textarea',
+      'table',
+      'thead',
+      'tbody',
+      'tfoot',
+      'tr',
+      'td',
+      'th',
+      'caption',
+      'colgroup',
+    ])('does not insert blank line after an unclosed <%s> opener with plain content', tag => {
+      const input = `<${tag}>\nplain content stays put`;
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
     it('does not modify HTML inside fenced code blocks but still terminates HTML outside them', () => {
       const input = `\`\`\`html
 <div></div>
@@ -262,6 +356,48 @@ Some text
 <p></p>
 \`\`\``);
     });
+  });
+
+  describe('CommonMark type-1 HTML openers (<pre>, <script>, <style>, <textarea>)', () => {
+    it('does not insert blank line after a <pre> opener with attributes', () => {
+      const input = `<pre data-lang="json">
+{
+  "conditionOperator": "AND"
+}
+</pre>`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not insert blank line after <pre> opener even when next line looks like a heading', () => {
+      const input = `<pre>
+# this is preformatted, not a heading
+</pre>`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not insert blank line after <pre> opener even when next line looks like a magic block', () => {
+      const input = `<pre>
+[block:callout]
+{"type":"info","body":"verbatim"}
+[/block]
+</pre>`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('treats self-closed <pre /> as closed', () => {
+      const input = `<pre />
+# Heading`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe('<pre />\n\n# Heading');
+    });
+
+    it('does not treat lookalike tags (<script-foo>) as a raw-content opener', () => {
+      expect(terminateHtmlFlowBlocks('<script-foo>\n# heading')).toBe('<script-foo>\n\n# heading');
+    });
+
   });
 
   describe('performance tests', () => {

--- a/__tests__/transformers/terminate-html-flow-blocks.test.ts
+++ b/__tests__/transformers/terminate-html-flow-blocks.test.ts
@@ -397,7 +397,6 @@ Some text
     it('does not treat lookalike tags (<script-foo>) as a raw-content opener', () => {
       expect(terminateHtmlFlowBlocks('<script-foo>\n# heading')).toBe('<script-foo>\n\n# heading');
     });
-
   });
 
   describe('performance tests', () => {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
       },
       {
         "path": "dist/main.node.js",
-        "maxSize": "945KB"
+        "maxSize": "947KB"
       }
     ]
   },

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -10,6 +10,7 @@ const TABLE_STRUCTURE_TAGS = ['table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 't
 
 // Tags whose contents must be preserved as is, inserting a blank line after the
 // opener corrupts the payload.
+// htmlRawNames here refer to <pre>, <textarea>, <script>, <style>
 const RAW_CONTENT_TAGS = [...htmlRawNames, ...TABLE_STRUCTURE_TAGS];
 
 function isLineHtml(line: string) {

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -13,18 +13,21 @@ const TABLE_STRUCTURE_TAGS = ['table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 't
 // htmlRawNames here refer to <pre>, <textarea>, <script>, <style>
 const RAW_CONTENT_TAGS = [...htmlRawNames, ...TABLE_STRUCTURE_TAGS];
 
+// The `(?=[\s/>])` lookahead avoids false matches on lookalike names like `<script-foo>`.
+const RAW_CONTENT_TAG_MATCHERS = RAW_CONTENT_TAGS.map(tag => ({
+  open: new RegExp(`<${tag}(?=[\\s/>])[^>]*?(?<!/)>`, 'gi'),
+  close: new RegExp(`</${tag}(?=[\\s>])[^>]*>`, 'gi'),
+}));
+
 function isLineHtml(line: string) {
   return STANDALONE_HTML_LINE_REGEX.test(line) || HTML_LINE_WITH_CONTENT_REGEX.test(line);
 }
 
 // True if any RAW_CONTENT_TAGS opener on this line is not closed on the same line.
-// The `(?=[\s/>])` lookahead avoids false matches on lookalike names like `<script-foo>`.
 function hasUnclosedRawContentOpener(line: string): boolean {
-  return RAW_CONTENT_TAGS.some(tag => {
-    const openRegex = new RegExp(`<${tag}(?=[\\s/>])[^>]*?(?<!/)>`, 'gi');
-    const closeRegex = new RegExp(`</${tag}(?=[\\s>])[^>]*>`, 'gi');
-    const opens = (line.match(openRegex) ?? []).length;
-    const closes = (line.match(closeRegex) ?? []).length;
+  return RAW_CONTENT_TAG_MATCHERS.some(({ open, close }) => {
+    const opens = (line.match(open) ?? []).length;
+    const closes = (line.match(close) ?? []).length;
     return opens > closes;
   });
 }

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -1,11 +1,31 @@
+import { htmlRawNames } from 'micromark-util-html-tag-name';
+
 import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
 
 const STANDALONE_HTML_LINE_REGEX = /^(<[a-z][^<>]*>|<\/[a-z][^<>]*>)+\s*$/;
 
 const HTML_LINE_WITH_CONTENT_REGEX = /^<[a-z][^<>]*>.*<\/[a-z][^<>]*>(?:[^<]*)$/;
 
+const TABLE_STRUCTURE_TAGS = ['table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'caption', 'colgroup'];
+
+// Tags whose contents must be preserved as is, inserting a blank line after the
+// opener corrupts the payload.
+const RAW_CONTENT_TAGS = [...htmlRawNames, ...TABLE_STRUCTURE_TAGS];
+
 function isLineHtml(line: string) {
   return STANDALONE_HTML_LINE_REGEX.test(line) || HTML_LINE_WITH_CONTENT_REGEX.test(line);
+}
+
+// True if any RAW_CONTENT_TAGS opener on this line is not closed on the same line.
+// The `(?=[\s/>])` lookahead avoids false matches on lookalike names like `<script-foo>`.
+function hasUnclosedRawContentOpener(line: string): boolean {
+  return RAW_CONTENT_TAGS.some(tag => {
+    const openRegex = new RegExp(`<${tag}(?=[\\s/>])[^>]*?(?<!/)>`, 'gi');
+    const closeRegex = new RegExp(`</${tag}(?=[\\s>])[^>]*>`, 'gi');
+    const opens = (line.match(openRegex) ?? []).length;
+    const closes = (line.match(closeRegex) ?? []).length;
+    return opens > closes;
+  });
 }
 
 /**
@@ -18,15 +38,16 @@ function isLineHtml(line: string) {
  *
  * @link https://spec.commonmark.org/0.29/#html-blocks
  *
- * This preprocessor inserts a blank line after standalone HTML lines when the
- * next line is non-blank and not an HTML construct (because they still might be part of the HTML flow),
- * ensuring micromark's HTML flow tokenizer terminates and subsequent content is parsed independently.
+ * This preprocessor inserts a blank line after standalone HTML lines when the next
+ * line is non-blank and not an HTML construct, ensuring micromark's HTML flow
+ * tokenizer terminates and subsequent content is parsed independently.
  *
  * Conditions:
- * 1. Only targets non-indented lines with lowercase tag names. Uppercase tags
- * (e.g., `<Table>`, `<MyComponent>`) are JSX custom components and don't
- * trigger CommonMark HTML blocks, so they are left untouched.
- * 2. Lines inside protected blocks (e.g., code blocks) should be left untouched.
+ * 1. Only non-indented lines with lowercase tag names are considered. Uppercase tags
+ *    (e.g. `<Table>`, `<MyComponent>`) are JSX custom components and don't trigger
+ *    CommonMark HTML blocks.
+ * 2. Lines inside protected blocks (e.g. fenced code) are left untouched.
+ * 3. Lines with an unclosed RAW_CONTENT_TAGS opener are exempted.
  */
 export function terminateHtmlFlowBlocks(content: string) {
   const { protectedContent, protectedCode } = protectCodeBlocks(content);
@@ -45,7 +66,7 @@ export function terminateHtmlFlowBlocks(content: string) {
 
     const isCurrentLineHtml = isLineHtml(lines[i]);
     const isNextLineHtml = isLineHtml(lines[i + 1]);
-    if (isCurrentLineHtml && !isNextLineHtml) {
+    if (isCurrentLineHtml && !isNextLineHtml && !hasUnclosedRawContentOpener(lines[i])) {
       result.push('');
     }
   }


### PR DESCRIPTION
| 🎫 Resolve CX-3411 |
| :-----------------: |

## 🎯 What does this PR do?

The `terminateHtmlFlowBlocks` preprocessor inserts a blank line after standalone HTML openers so magic blocks parse, but that same blank line terminates the enclosing type-6 block and reparses verbatim content as a Markdown paragraph, collapsing whitespace and indentation. 

Fix is additive: a `hasUnclosedRawContentOpener` guard exempts lines that open (and don't close on the same line) such as a CommonMark type-1 tag like `<pre>` or a table-structure tag (`<table>`, etc). 

## 🧪 QA tips

Paste this in the editor in MDXish

```
<table>
  <tr>
    <td>Hello</td>
    <td>
<pre data-lang="json">
{
  "a": "x",
  "b": {
    "c": "y"
  }
}
</pre>
    </td>
  </tr>
</table>
```

confirm that the contents of the `<pre>` retains the indentations. also make sure that the original issue the `terminate-html-flow-block` was meant to fix is still fixed.

```
<div><p></p></div>
[block:callout]
{
  "type": "success",
  "body": "This callout should render."
}
[/block]
<div><p></p></div>
# This heading should render
<div><p></p></div>
> This blockquote should render
<div><p></p></div>
- This list should render
<div><p></p></div>
**This paragraph should render.**
```


## 📸 Screenshot or Loom

Before | After
-- | --
<img width="820" height="495" alt="Screenshot 2026-05-20 at 13 53 29" src="https://github.com/user-attachments/assets/b110c724-972a-48d9-8bed-d4f64f5ab884" /> | <img width="667" height="340" alt="Screenshot 2026-05-20 at 13 53 03" src="https://github.com/user-attachments/assets/73a2768e-ec61-4898-b852-3c5404c63e4e" />

_Showcase in the monorepo_

https://github.com/user-attachments/assets/24fbee46-49eb-4172-96dc-4113e58b0c88

