### PR TITLE
fix(mdxish): stop orphan closer tags from breaking table parsing

### DIFF
--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -226,19 +226,11 @@ describe('mdxish tables transformation', () => {
 </tbody>
 </table>`;
 
-    it('splits the html node so fenced code blocks become code mdast nodes', () => {
+    it('parses fenced code blocks inside the cell as code mdast nodes', () => {
       const ast = astProcessor(malformed);
-
-      expect(ast).toMatchObject({
-        type: 'root',
-        children: expect.arrayContaining([
-          expect.objectContaining({
-            type: 'code',
-            value: '2.16.0.0/13',
-          }),
-          expect.objectContaining({ type: 'html' }),
-        ]),
-      });
+      const codes = collectNodes(ast, 'code');
+      expect(codes).toHaveLength(1);
+      expect(codes[0]).toMatchObject({ type: 'code', value: '2.16.0.0/13' });
     });
 
     it('renders fenced code blocks as <pre><code> HTML rather than raw backticks', () => {
@@ -488,6 +480,48 @@ describe('mdxish tables transformation', () => {
 
       const cells = findAllElementsByTagName(tables[0], 'td');
       expect(cells).toHaveLength(1);
+    });
+
+    it('strips orphan closing tags that have no matching opener', () => {
+      const doc = `<Table align={["left","left"]}>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Status</td>
+      <td>
+        Current state.
+
+        Values:<ul><li>**active**. running. <li>**inactive**. stopped.</ul></li>
+      </td>
+    </tr>
+    <tr>
+      <td>Type</td>
+      <td>Normal value here.</td>
+    </tr>
+  </tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const cells = findAllElementsByTagName(tables[0], 'td');
+      expect(cells).toHaveLength(4);
+
+      const strongs = findAllElementsByTagName(tables[0], 'strong');
+      expect(strongs.length).toBeGreaterThanOrEqual(2);
+      const strongText = strongs.map(s => JSON.stringify(s)).join(' ');
+      expect(strongText).toContain('active');
+      expect(strongText).toContain('inactive');
+
+      const html = toHtml(tables[0]);
+      expect(html).not.toContain('&#x3C;/li>');
+      expect(html).not.toContain('</li>'.replace('<', '&lt;'));
     });
 
     it('escapes a non-HTML tag name instead of trying to close it', () => {

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -524,6 +524,103 @@ describe('mdxish tables transformation', () => {
       expect(html).not.toContain('&lt;/li>');
     });
 
+    it('preserves an HTML comment containing tag-like text in a cell', () => {
+      const doc = `<Table>
+  <thead><tr><th>A</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><!-- TODO: handle </li> case --> body text</td>
+    </tr>
+  </tbody>
+</Table>`;
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const cells = findAllElementsByTagName(tables[0], 'td');
+      expect(cells).toHaveLength(1);
+
+      const html = toHtml(tables[0]);
+      expect(html).toContain('body text');
+      expect(html).toContain('<!-- TODO: handle </li> case -->');
+    });
+
+    it('preserves attribute values that contain a > character', () => {
+      const doc = `<Table>
+  <thead><tr><th>A</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><a title="a > b" href="https://example.com">link</a> after</td>
+    </tr>
+  </tbody>
+</Table>`;
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const anchors = findAllElementsByTagName(tables[0], 'a');
+      expect(anchors).toHaveLength(1);
+      expect(anchors[0].properties).toMatchObject({
+        href: 'https://example.com',
+        title: 'a > b',
+      });
+
+      const html = toHtml(tables[0]);
+      expect(html).toContain('after');
+    });
+
+    it('normalizes interleaved misnesting like <b><i>x</b></i>', () => {
+      const doc = `<Table>
+  <thead><tr><th>A</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><b><i>x</b></i> after</td>
+    </tr>
+  </tbody>
+</Table>`;
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const bolds = findAllElementsByTagName(tables[0], 'b');
+      const italics = findAllElementsByTagName(tables[0], 'i');
+      expect(bolds).toHaveLength(1);
+      expect(italics).toHaveLength(1);
+
+      const html = toHtml(tables[0]);
+      expect(html).toContain('x');
+      expect(html).toContain('after');
+      // No stray closers should leak through as escaped text.
+      expect(html).not.toContain('&#x3C;/');
+      expect(html).not.toContain('&lt;/');
+    });
+
+    it('preserves an HTML comment when the orphan-closer scanner is forced to run', () => {
+      const doc = `<Table>
+  <thead><tr><th>A</th></tr></thead>
+  <tbody>
+    <tr>
+      <td><!-- handle </li> case --> body <ul><li>x</ul></li></td>
+    </tr>
+  </tbody>
+</Table>`;
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const lists = findAllElementsByTagName(tables[0], 'ul');
+      expect(lists).toHaveLength(1);
+      const items = findAllElementsByTagName(lists[0], 'li');
+      expect(items).toHaveLength(1);
+
+      const html = toHtml(tables[0]);
+      expect(html).toContain('<!-- handle </li> case -->');
+      expect(html).toContain('body');
+      // The trailing orphan </li> after </ul> should not survive as escaped text.
+      expect(html).not.toContain('&#x3C;/li>');
+      expect(html).not.toContain('&lt;/li>');
+    });
+
     it('escapes a non-HTML tag name instead of trying to close it', () => {
       const doc = `<Table>
   <thead><tr><th>A</th><th>B</th></tr></thead>

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -521,7 +521,7 @@ describe('mdxish tables transformation', () => {
 
       const html = toHtml(tables[0]);
       expect(html).not.toContain('&#x3C;/li>');
-      expect(html).not.toContain('</li>'.replace('<', '&lt;'));
+      expect(html).not.toContain('&lt;/li>');
     });
 
     it('escapes a non-HTML tag name instead of trying to close it', () => {

--- a/processor/transform/mdxish/tables/remap-positions.ts
+++ b/processor/transform/mdxish/tables/remap-positions.ts
@@ -17,9 +17,10 @@ const buildOffsetMapper = (inserts: Insert[]): ((repaired: number) => number) =>
   // Pre-compute each insert's start in repaired-space.
   let acc = 0;
   const segments = inserts.map(ins => {
+    const consumes = ins.consumes ?? 0;
     const repairedStart = ins.offset + acc;
-    acc += ins.text.length;
-    return { origOffset: ins.offset, len: ins.text.length, repairedStart };
+    acc += ins.text.length - consumes;
+    return { origOffset: ins.offset, consumes, len: ins.text.length, repairedStart };
   });
 
   return (repaired: number): number => {
@@ -27,7 +28,10 @@ const buildOffsetMapper = (inserts: Insert[]): ((repaired: number) => number) =>
     // clamp to the insert's anchor so consumers slice a real boundary.
     const hit = segments.find(seg => seg.repairedStart < repaired && repaired < seg.repairedStart + seg.len);
     if (hit) return hit.origOffset;
-    const shift = segments.reduce((acc2, seg) => (seg.repairedStart < repaired ? acc2 + seg.len : acc2), 0);
+    const shift = segments.reduce(
+      (acc2, seg) => (seg.repairedStart < repaired ? acc2 + seg.len - seg.consumes : acc2),
+      0,
+    );
     return repaired - shift;
   };
 };

--- a/processor/transform/mdxish/tables/repair-unclosed-tags.ts
+++ b/processor/transform/mdxish/tables/repair-unclosed-tags.ts
@@ -5,6 +5,10 @@ import { applyInserts, type Insert, type RepairResult } from './utils';
 
 const isStandardHtmlTag = (name: string): boolean => STANDARD_HTML_TAGS.has(name.toLowerCase());
 
+// Intentionally simpler than htmlparser2: `[^>]*` does not honor `>` inside
+// quoted attribute values. That's acceptable here because the main walker
+// (htmlparser2) handles attribute parsing; this scan only needs to locate
+// orphan closers, which can't appear inside an attribute value anyway.
 const HTML_TAG_TOKEN_RE = /<(\/)?([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>/g;
 
 /**
@@ -22,9 +26,10 @@ const findOrphanClosers = (html: string): { length: number; offset: number }[] =
   let match: RegExpExecArray | null;
   while ((match = HTML_TAG_TOKEN_RE.exec(masked)) !== null) {
     const name = match[2].toLowerCase();
-    if (!isStandardHtmlTag(name) || HTML_VOID_ELEMENTS.has(name)) {
-      // Skip; non-HTML names and void elements are handled by the main walker.
-    } else if (match[1] === '/') {
+    // Non-HTML names and void elements are handled by the main walker.
+    // eslint-disable-next-line no-continue
+    if (!isStandardHtmlTag(name) || HTML_VOID_ELEMENTS.has(name)) continue;
+    if (match[1] === '/') {
       const idx = stack.lastIndexOf(name);
       if (idx === -1) orphans.push({ offset: match.index, length: match[0].length });
       else stack.length = idx;

--- a/processor/transform/mdxish/tables/repair-unclosed-tags.ts
+++ b/processor/transform/mdxish/tables/repair-unclosed-tags.ts
@@ -1,9 +1,39 @@
 import { HTML_VOID_ELEMENTS, STANDARD_HTML_TAGS } from '../../../../utils/common-html-words';
 
-import { walkTags } from './tag-walker';
+import { maskNonTagRegions, walkTags } from './tag-walker';
 import { applyInserts, type Insert, type RepairResult } from './utils';
 
 const isStandardHtmlTag = (name: string): boolean => STANDARD_HTML_TAGS.has(name.toLowerCase());
+
+const HTML_TAG_TOKEN_RE = /<(\/)?([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>/g;
+
+/**
+ * htmlparser2 silently drops closing tags that have no matching opener
+ * (e.g. the trailing `</li>` in `<ul><li>x</ul></li>`), leaving them in the
+ * source makes mdxjs choke on the dangling closer. Scan the masked
+ * source for `</name>` tokens that don't pair with any prior unmatched
+ * `<name>` and return their spans so the caller can drop them.
+ */
+const findOrphanClosers = (html: string): { length: number; offset: number }[] => {
+  const masked = maskNonTagRegions(html);
+  const stack: string[] = [];
+  const orphans: { length: number; offset: number }[] = [];
+  HTML_TAG_TOKEN_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HTML_TAG_TOKEN_RE.exec(masked)) !== null) {
+    const name = match[2].toLowerCase();
+    if (!isStandardHtmlTag(name) || HTML_VOID_ELEMENTS.has(name)) {
+      // Skip; non-HTML names and void elements are handled by the main walker.
+    } else if (match[1] === '/') {
+      const idx = stack.lastIndexOf(name);
+      if (idx === -1) orphans.push({ offset: match.index, length: match[0].length });
+      else stack.length = idx;
+    } else if (!match[0].endsWith('/>')) {
+      stack.push(name);
+    }
+  }
+  return orphans;
+};
 
 /**
  * MDX requires a JSX inline tag and its closer to live on the same line — not
@@ -59,6 +89,10 @@ export const repairUnclosedTags = (html: string): RepairResult => {
       inserts.push({ offset: findOffsetToPlaceCloser(html, openTag.end, start), text: `</${name}>` });
     },
   });
+
+  findOrphanClosers(html).forEach(({ offset, length }) =>
+    inserts.push({ offset, text: '', consumes: length }),
+  );
 
   return applyInserts(html, inserts);
 };

--- a/processor/transform/mdxish/tables/tag-walker.ts
+++ b/processor/transform/mdxish/tables/tag-walker.ts
@@ -3,7 +3,7 @@ import { Parser } from 'htmlparser2';
 /**
  * Skip certain regions / parts of the content that htmlparser2 should not handle
  */
-const maskNonTagRegions = (html: string): string =>
+export const maskNonTagRegions = (html: string): string =>
   html
     .replace(/```[\s\S]*?```|``(?:[^`]|`(?!`))*``|`[^`\n]*`/g, m => ' '.repeat(m.length))
     // `<<NAME>>` is legacy variable syntax — without masking,

--- a/processor/transform/mdxish/tables/utils.ts
+++ b/processor/transform/mdxish/tables/utils.ts
@@ -1,6 +1,7 @@
 import type { Node } from 'mdast';
 
 export interface Insert {
+  consumes?: number;
   offset: number;
   text: string;
 }
@@ -53,13 +54,14 @@ export const applyInserts = (html: string, inserts: Insert[]): RepairResult => {
 
   let out = '';
   let cursor = 0;
-  sorted.forEach(({ offset, text }) => {
+  sorted.forEach(({ offset, text, consumes = 0 }) => {
     const clamped = Math.min(Math.max(offset, cursor), html.length);
     if (clamped > cursor) {
       out += html.slice(cursor, clamped);
       cursor = clamped;
     }
     out += text;
+    cursor = Math.min(cursor + consumes, html.length);
   });
   return { value: out + html.slice(cursor), inserts: sorted };
 };


### PR DESCRIPTION
| 🎫 Resolve RM-16736 |
| :-----------------: |

## 🎯 What does this PR do?

A `<Table>` whose cell contained an *orphan closing tag* (a closer with no matching opener — e.g. the trailing `</li>` in `<ul><li>x <li>y</ul></li>`) was still falling out of the mdxish pipeline. The whole `<Table>` got handed to `rehypeRaw` and cell-level markdown (`**bold**`, lists, links) was never parsed.

The fallback chain from #1465 (`repairUnclosedTags` → `normalizeTagSpacing`) covered unclosed openers and asymmetric spacing, but not orphan closers. Root cause is `htmlparser2`: it silently drops closing tags that have no matching opener — no `onclosetag` event fires — so the existing repair walker couldn't see them.

This PR adds a separate orphan-closer scan that *strips* the dangling closer from the source before the strict mdxjs parse runs. The supporting changes generalise the existing repair infrastructure: `Insert` gains an optional `consumes` field so an entry can replace source bytes in addition to inserting text, and the offset mapper accounts for `consumes` so MDAST positions still remap to the original source.

- `findOrphanClosers` regex-walks the masked source maintaining its own open/close stack; any `</name>` with no matching opener is recorded as an `{offset, length}` span and turned into a delete-style `Insert` (`text: ''`, `consumes: length`).
- `maskNonTagRegions` is now exported from `tag-walker.ts` so the orphan scanner reuses the same code-span / `<<legacy-variable>>` / `\<` skip rules — no false positives from `</li>` inside `` `code` ``.

## 🧪 QA tips

These should now render as proper tables with cell-level markdown parsed (not raw HTML with literal `**`):

**1. The ticket's repro — orphan `</li>` after `</ul>`:**

```mdx
<Table align={["left","left"]}>
  <thead>
    <tr>
      <th>Field</th>
      <th>Description</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Status</td>
      <td>
        Current state of the request.

        One of these values may appear:<ul><li>**active**. The request is currently running. <li>**inactive**. The request has stopped.</ul></li>
      </td>
    </tr>
    <tr>
      <td>Type</td>
      <td>Normal value here.</td>
    </tr>
  </tbody>
</Table>
```

`**active**` / `**inactive**` should be bold inside the bulleted list. No literal `</li>` should appear in the rendered cell.

**2. Lowercase `<table>` with stray `</td></tr>` (existing test fixture):**

```md
<table>
<thead>
<th>IPv4</th>
</thead>
<tbody>
<tr>
<td>

```                 <- unescape this
2.16.0.0/13
```

</td>
</tr>
</td>
</tr>
</tbody>
</table>
```

## 📸 Screenshot or Loom

Before | After
-- | --
<img width="674" height="613" alt="Screenshot 2026-05-21 at 16 33 57" src="https://github.com/user-attachments/assets/b4c0fc07-6c21-4d23-9413-82f83a3bea75" /> | <img width="600" height="605" alt="Screenshot 2026-05-21 at 16 33 06" src="https://github.com/user-attachments/assets/e5eb7ae5-62b6-4f10-a1a5-f677d2910ef0" />
