### PR TITLE
fix(mdxish): skip image block promotion inside inline only parents

### DIFF
--- a/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
+++ b/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
@@ -1,6 +1,6 @@
 import type { Anchor, Callout, EmbedBlock, ImageBlock, Recipe } from '../../../types';
 import type { Root as HastRoot } from 'hast';
-import type { Paragraph, Root, RootContent, Table, TableCell } from 'mdast';
+import type { Heading, Paragraph, Root, RootContent, Table, TableCell } from 'mdast';
 
 import { NodeTypes } from '../../../enums';
 import { mdxish, mdxishAstProcessor } from '../../../lib/mdxish';
@@ -694,6 +694,75 @@ Some callout content
       const ast = processWithNewTypes(md);
       const cell = findCell(ast);
       expect(cell.children[0].type).toBe('image');
+    });
+  });
+
+  describe('magic-block image promotion is skipped inside inline-only parents', () => {
+    const findFirst = <T extends RootContent>(root: Root, predicate: (n: RootContent) => n is T): T | undefined => {
+      const stack: RootContent[] = [...root.children];
+      while (stack.length) {
+        const node = stack.shift()!;
+        if (predicate(node)) return node;
+        if ('children' in node && Array.isArray((node as { children?: unknown[] }).children)) {
+          stack.push(...((node as { children: RootContent[] }).children));
+        }
+      }
+      return undefined;
+    };
+
+    it('keeps `![](url)` alone in a heading as inline `image`', () => {
+      const ast = processWithNewTypes('## ![Logo](https://example.com/logo.png)');
+      const heading = ast.children[0] as Heading;
+      expect(heading.type).toBe('heading');
+      expect(heading.children).toHaveLength(1);
+      expect(heading.children[0].type).toBe('image');
+    });
+
+    it('keeps `![](url)` mixed with text in a heading as inline `image`', () => {
+      const ast = processWithNewTypes('## What? ![Logo](https://example.com/logo.png)');
+      const heading = ast.children[0] as Heading;
+      expect(heading.type).toBe('heading');
+      expect(heading.children.some(c => c.type === 'image')).toBe(true);
+      expect(heading.children.some(c => c.type === 'text')).toBe(true);
+    });
+
+    it('keeps `![](url)` inside a link as inline `image`', () => {
+      const ast = processWithNewTypes('[![Logo](https://example.com/logo.png)](https://example.com)');
+      const link = findFirst(ast, (n): n is RootContent & { children: RootContent[]; type: 'link' } => n.type === 'link');
+      expect(link).toBeDefined();
+      expect(link!.children[0].type).toBe('image');
+    });
+
+    it('keeps `![](url)` inside emphasis as inline `image`', () => {
+      const ast = processWithNewTypes('*![Logo](https://example.com/logo.png)*');
+      const em = findFirst(ast, (n): n is RootContent & { children: RootContent[]; type: 'emphasis' } => n.type === 'emphasis');
+      expect(em).toBeDefined();
+      expect(em!.children[0].type).toBe('image');
+    });
+
+    it('keeps `![](url)` inside strong as inline `image`', () => {
+      const ast = processWithNewTypes('**![Logo](https://example.com/logo.png)**');
+      const strong = findFirst(ast, (n): n is RootContent & { children: RootContent[]; type: 'strong' } => n.type === 'strong');
+      expect(strong).toBeDefined();
+      expect(strong!.children[0].type).toBe('image');
+    });
+
+    it('keeps `![](url)` inside delete (GFM strikethrough) as inline `image`', () => {
+      const ast = processWithNewTypes('~~![Logo](https://example.com/logo.png)~~');
+      const del = findFirst(ast, (n): n is RootContent & { children: RootContent[]; type: 'delete' } => n.type === 'delete');
+      expect(del).toBeDefined();
+      expect(del!.children[0].type).toBe('image');
+    });
+
+    it('keeps `![](url)` inside a linkReference as inline `image`', () => {
+      const md = '[![Logo](https://example.com/logo.png)][ref]\n\n[ref]: https://example.com';
+      const ast = processWithNewTypes(md);
+      const linkRef = findFirst(
+        ast,
+        (n): n is RootContent & { children: RootContent[]; type: 'linkReference' } => n.type === 'linkReference',
+      );
+      expect(linkRef).toBeDefined();
+      expect(linkRef!.children[0].type).toBe('image');
     });
   });
 

--- a/index.tsx
+++ b/index.tsx
@@ -17,6 +17,7 @@ export {
   exports,
   FLOW_TYPES,
   hast,
+  INLINE_ONLY_PARENT_TYPES,
   run,
   mdast,
   mdastV6,

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -20,6 +20,35 @@ export const FLOW_TYPES = new Set([
   'thematicBreak',
 ]);
 
+/**
+ * MDAST parent types whose children are restricted to inline content. A block-level
+ * node placed inside any of these violates the parent's content model and breaks
+ * downstream consumers
+ *
+ * Derived from the mdast spec. Seven of these are direct "phrasing content" parents:
+ *   - paragraph, heading, link, linkReference, emphasis, strong
+ *   - tableCell (phrasing minus Break)
+ *
+ * @link {https://github.com/syntax-tree/mdast}
+ *
+ * `delete` is GFM and has *transparent* content, see:
+ * @link {https://github.com/syntax-tree/mdast-util-gfm-strikethrough}
+ *
+ * its children must also be phrasing, so it belongs here too.
+ *
+ * NOTE: exported so downstream consumers can reuse and not drift away
+ */
+export const INLINE_ONLY_PARENT_TYPES = new Set([
+  'paragraph',
+  'heading',
+  'tableCell',
+  'link',
+  'linkReference',
+  'emphasis',
+  'strong',
+  'delete',
+]);
+
 // HELPER CONSTANTS FOR MDXISH RENDERING
 
 /**

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,6 @@
 export type { MdastOpts } from './ast-processor';
 
-export { componentTagPattern, FLOW_TYPES } from './constants';
+export { componentTagPattern, FLOW_TYPES, INLINE_ONLY_PARENT_TYPES } from './constants';
 export { default as astProcessor, remarkPlugins } from './ast-processor';
 export { default as compile } from './compile';
 export { default as exports } from './exports';

--- a/processor/transform/mdxish/mdxish-jsx-to-mdast.ts
+++ b/processor/transform/mdxish/mdxish-jsx-to-mdast.ts
@@ -9,6 +9,7 @@ import { SKIP, visit } from 'unist-util-visit';
 
 import { NodeTypes } from '../../../enums';
 import { mdast } from '../../../lib';
+import { INLINE_ONLY_PARENT_TYPES } from '../../../lib/constants';
 import { getAttrs, isMDXElement } from '../../utils';
 
 import { unwrapSoleParagraph } from './tables/utils';
@@ -708,15 +709,11 @@ const mdxishJsxToMdast: Plugin<[], Parent> = () => tree => {
     }
   });
 
-  // Transform magic block images (type: 'image') to image-block
-  // Images inside paragraphs are standard markdown — handled by imageTransformer, normalized below
+  // Promote magic-block images (type: 'image') to image-block, except inside inline-only
+  // parents where the image must stay inline (authors use `<Image caption="…" />` instead).
   visit(tree, 'image', (node: MagicBlockImage, index, parent: Parent | undefined) => {
     if (!parent || index === undefined) return SKIP;
-    if (parent.type === 'paragraph') return SKIP;
-
-    // `![](url)` in any tableCell stays inline. Authors who want a captioned figure use
-    // `<Image caption="…" />` JSX, which becomes `image-block` via `COMPONENT_MAP` above.
-    if (parent.type === 'tableCell') return SKIP;
+    if (INLINE_ONLY_PARENT_TYPES.has(parent.type)) return SKIP;
 
     const newNode = transformMagicBlockImage(node);
     (parent.children as Node[])[index] = newNode;


### PR DESCRIPTION
| 🎫 Resolve RM-16746 |
| :-----------------: |

## 🎯 What does this PR do?

> [!NOTE]
this only affects the mdxishEditorTypes code path

Stop promoting images to `image-block` when the parent is only allowed to have phrasing content (inline). Exports this array  (`INLINE_ONLY_PARENT_TYPES`) so that downstream consumers like our editor can make use of it and have a single source of truth and not have to worry about drifts in the future.

> [!IMPORTANT]
> Example of `paragraph` being defined to only be able to accept phrasing content children:
> 
> https://github.com/syntax-tree/mdast#paragraph:~:text=where%20content%20is%20expected.-,Its%20content%20model%20is%20phrasing%20content.,-For%20example%2C%20the%20following
> 

## 🧪 QA tips

### _Demo app testing_
paste this in the demo app
```
## What is AD Bridge? ![AD Bridge product logo](https://files.readme.io/ee3b548e9d2b920809af63a911f6d51406717f5b40eb00be9fea6251bd867fef-adb-product-icon.png)
```

toggle the `newEditorTypes` and `showAst` checkboxes. click on the MDAST option and verify that the image is now of type `image` instead of `image-block`

Before | After
-- | --
<img width="3003" height="1598" alt="Screenshot 2026-05-22 at 11 57 31" src="https://github.com/user-attachments/assets/0fe97467-4ff9-44b8-96a9-553f5466d5bc" /> | <img width="3006" height="1601" alt="Screenshot 2026-05-22 at 11 57 00" src="https://github.com/user-attachments/assets/a48e3f85-a867-4d23-8cf1-6d95b7d27d93" />

### _Monorepo testing_
link the changes in this branch into the monorepo, see the companion PR here: https://github.com/readmeio/readme/pull/18946 and paste this:
```
## What is AD Bridge? ![AD Bridge product logo](https://files.readme.io/ee3b548e9d2b920809af63a911f6d51406717f5b40eb00be9fea6251bd867fef-adb-product-icon.png)
```
in the **RICH EDITOR** (not raw mode), verify that it shows the image and heading and it is able to roundtrip properly.

## 📸 Screenshot or Loom

Before | After
-- | --
<img width="3003" height="1598" alt="Screenshot 2026-05-22 at 11 57 31" src="https://github.com/user-attachments/assets/0fe97467-4ff9-44b8-96a9-553f5466d5bc" /> | <img width="3006" height="1601" alt="Screenshot 2026-05-22 at 11 57 00" src="https://github.com/user-attachments/assets/a48e3f85-a867-4d23-8cf1-6d95b7d27d93" />

