### PR TITLE
fix(mdxish): handle orphan void closers in JSX table cells

### DIFF
--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -4,7 +4,7 @@ import type { MdxJsxTextElement } from 'mdast-util-mdx';
 import { toHtml } from 'hast-util-to-html';
 
 import { mdxish, mdxishAstProcessor } from '../../lib/mdxish';
-import { collectNodes, findAllElementsByTagName, parseMdxishWithSource, roundTripMdxish, mdastV6Wrapper } from '../helpers';
+import { collectNodes, findAllElementsByTagName, parseMdxishWithSource, roundTripMdxish } from '../helpers';
 
 const astProcessor = (md: string): Root => {
   const { processor, parserReadyContent } = mdxishAstProcessor(md);

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -4,7 +4,7 @@ import type { MdxJsxTextElement } from 'mdast-util-mdx';
 import { toHtml } from 'hast-util-to-html';
 
 import { mdxish, mdxishAstProcessor } from '../../lib/mdxish';
-import { collectNodes, findAllElementsByTagName, parseMdxishWithSource, roundTripMdxish } from '../helpers';
+import { collectNodes, findAllElementsByTagName, parseMdxishWithSource, roundTripMdxish, mdastV6Wrapper } from '../helpers';
 
 const astProcessor = (md: string): Root => {
   const { processor, parserReadyContent } = mdxishAstProcessor(md);
@@ -522,6 +522,116 @@ describe('mdxish tables transformation', () => {
       const html = toHtml(tables[0]);
       expect(html).not.toContain('&#x3C;/li>');
       expect(html).not.toContain('&lt;/li>');
+    });
+
+    // Special case for void tag <br>: In legacy magic blocks, orphan </br> is treated
+    // as a legit line break and not stripped like other void tags like </hr> or </img>.
+    it('considers orphan </br> as a line break and not have it break the table', () => {
+      const doc = `<Table align={["left","left"]}>
+  <thead>
+    <tr>
+      <th>Field</th>
+      <th>Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>**Instant Failover**</td>
+      <td>
+        Select one of these options:
+
+        - **First**.
+        - **Second**.
+        - **Third**. Disabled<br /><br />Second paragraph</br><br />Third paragraph</br>
+      </td>
+    </tr>
+  </tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const cells = findAllElementsByTagName(tables[0], 'td');
+      expect(cells).toHaveLength(2);
+
+      const lists = findAllElementsByTagName(tables[0], 'ul');
+      expect(lists).toHaveLength(1);
+      const items = findAllElementsByTagName(lists[0], 'li');
+      expect(items).toHaveLength(3);
+
+      const strongs = findAllElementsByTagName(tables[0], 'strong');
+      const strongText = strongs.map(s => JSON.stringify(s)).join(' ');
+      expect(strongText).toContain('Instant Failover');
+      expect(strongText).toContain('First');
+      expect(strongText).toContain('Second');
+      expect(strongText).toContain('Third');
+
+      // Per HTML5 spec, a lone </br> is rewritten as a <br> break — not stripped.
+      const breaks = findAllElementsByTagName(tables[0], 'br');
+      expect(breaks).toHaveLength(5);
+
+      const html = toHtml(tables[0]);
+      expect(html).toContain('Disabled<br><br>Second paragraph<br><br>Third paragraph<br>');
+      expect(html).not.toContain('&#x3C;/br>');
+      expect(html).not.toContain('&lt;/br>');
+      expect(html).not.toContain('</br>');
+      expect(html).not.toContain('Second paragraph/');
+    });
+
+    it.each([
+      ['hr', '<hr>'],
+      ['img', '<img src="x.png" alt="x">'],
+      ['input', '<input type="text">'],
+    ])('strips an orphan </%s> closer for void element', (tag, opener) => {
+      const doc = `<Table>
+  <thead><tr><th>A</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>before ${opener} middle </${tag}> after **bold**</td>
+    </tr>
+  </tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const cells = findAllElementsByTagName(tables[0], 'td');
+      expect(cells).toHaveLength(1);
+
+      const strongs = findAllElementsByTagName(tables[0], 'strong');
+      expect(strongs).toHaveLength(1);
+
+      const html = toHtml(tables[0]);
+      expect(html).not.toContain(`&#x3C;/${tag}>`);
+      expect(html).not.toContain(`&lt;/${tag}>`);
+      expect(html).not.toContain('**bold**');
+    });
+
+    it('strips multiple orphan void closers mixed with valid markdown', () => {
+      const doc = `<Table>
+  <thead><tr><th>A</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>line one</br> line two</hr> [link](https://example.com) tail</td>
+    </tr>
+  </tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const anchors = findAllElementsByTagName(tables[0], 'a');
+      expect(anchors).toHaveLength(1);
+      expect(anchors[0].properties).toMatchObject({ href: 'https://example.com' });
+
+      const html = toHtml(tables[0]);
+      expect(html).not.toContain('&#x3C;/br>');
+      expect(html).not.toContain('&lt;/br>');
+      expect(html).not.toContain('&#x3C;/hr>');
+      expect(html).not.toContain('&lt;/hr>');
     });
 
     it('preserves an HTML comment containing tag-like text in a cell', () => {

--- a/processor/transform/mdxish/tables/repair-unclosed-tags.ts
+++ b/processor/transform/mdxish/tables/repair-unclosed-tags.ts
@@ -31,13 +31,15 @@ const findOrphanClosers = (html: string): OrphanCloser[] => {
   let match: RegExpExecArray | null;
   while ((match = HTML_TAG_TOKEN_RE.exec(masked)) !== null) {
     const name = match[2].toLowerCase();
+
     // eslint-disable-next-line no-continue
     if (!isStandardHtmlTag(name)) continue;
-    // `br` orphan closers are owned by the walker's onOpen path — htmlparser2
-    // normalizes them to opener events per HTML5 spec, and the walker rewrites
-    // them to `<br/>` there. Skip here to avoid a double-write collision.
+
+    // Special case for <br>: htmlparser2 will normalize orphan </br> to <br>
+    // so we don't need to handle it here.
     // eslint-disable-next-line no-continue
     if (name === 'br' && match[1] === '/') continue;
+
     const isVoid = HTML_VOID_ELEMENTS.has(name);
     if (match[1] === '/') {
       // Other void closers (`</hr>`, `</img>`, ...) have no HTML5 rewrite rule
@@ -94,15 +96,18 @@ export const repairUnclosedTags = (html: string): RepairResult => {
         return;
       }
       if (HTML_VOID_ELEMENTS.has(name.toLowerCase())) {
+        // MDX requires void elements to be self-closing (`<br/>`, not `<br>`)
+        // so we need to rewrite them to self closing tags.
         if (isStrayCloser) {
-          // htmlparser2 normalizes stray closers like `</br>` into opener
-          // events per the HTML5 spec; mirror that by rewriting the bytes
-          // into a valid self-closed tag so mdxjs accepts them.
+          // htmlparser2 may normalize some stray closers like `</br>` into opener
+          // events <br> per the HTML5 spec. In this case remove the closing /
+          // and fully rewrite the tag to self closing.
           inserts.push({ offset: start, text: `<${name}/>`, consumes: end - start });
           return;
+        } else if (!isSelfClosing) {
+          // Slots in the / right before the closing >
+          inserts.push({ offset: end - 1, text: '/' });
         }
-        // MDX requires void elements to be self-closing (`<br/>`, not `<br>`).
-        if (!isSelfClosing) inserts.push({ offset: end - 1, text: '/' });
         return;
       }
       openTags.push({ name, start, end });

--- a/processor/transform/mdxish/tables/repair-unclosed-tags.ts
+++ b/processor/transform/mdxish/tables/repair-unclosed-tags.ts
@@ -18,22 +18,39 @@ const HTML_TAG_TOKEN_RE = /<(\/)?([a-zA-Z][a-zA-Z0-9-]*)\b[^>]*>/g;
  * source for `</name>` tokens that don't pair with any prior unmatched
  * `<name>` and return their spans so the caller can drop them.
  */
-const findOrphanClosers = (html: string): { length: number; offset: number }[] => {
+interface OrphanCloser {
+  length: number;
+  offset: number;
+}
+
+const findOrphanClosers = (html: string): OrphanCloser[] => {
   const masked = maskNonTagRegions(html);
   const stack: string[] = [];
-  const orphans: { length: number; offset: number }[] = [];
+  const orphans: OrphanCloser[] = [];
   HTML_TAG_TOKEN_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = HTML_TAG_TOKEN_RE.exec(masked)) !== null) {
     const name = match[2].toLowerCase();
-    // Non-HTML names and void elements are handled by the main walker.
     // eslint-disable-next-line no-continue
-    if (!isStandardHtmlTag(name) || HTML_VOID_ELEMENTS.has(name)) continue;
+    if (!isStandardHtmlTag(name)) continue;
+    // `br` orphan closers are owned by the walker's onOpen path — htmlparser2
+    // normalizes them to opener events per HTML5 spec, and the walker rewrites
+    // them to `<br/>` there. Skip here to avoid a double-write collision.
+    // eslint-disable-next-line no-continue
+    if (name === 'br' && match[1] === '/') continue;
+    const isVoid = HTML_VOID_ELEMENTS.has(name);
     if (match[1] === '/') {
+      // Other void closers (`</hr>`, `</img>`, ...) have no HTML5 rewrite rule
+      // and must be stripped before the strict mdxjs parse runs.
+      if (isVoid) {
+        orphans.push({ offset: match.index, length: match[0].length });
+        // eslint-disable-next-line no-continue
+        continue;
+      }
       const idx = stack.lastIndexOf(name);
       if (idx === -1) orphans.push({ offset: match.index, length: match[0].length });
       else stack.length = idx;
-    } else if (!match[0].endsWith('/>')) {
+    } else if (!isVoid && !match[0].endsWith('/>')) {
       stack.push(name);
     }
   }
@@ -69,7 +86,7 @@ export const repairUnclosedTags = (html: string): RepairResult => {
   const openTags: { end: number; name: string; start: number }[] = [];
 
   walkTags(html, {
-    onOpen({ name, start, end }) {
+    onOpen({ name, start, end, isSelfClosing, isStrayCloser }) {
       // Escape non-HTML names (custom components, typos, `<arbitrary-tag>`)
       // so MDX treats them as literal text instead of expecting a closer
       if (!isStandardHtmlTag(name)) {
@@ -77,11 +94,15 @@ export const repairUnclosedTags = (html: string): RepairResult => {
         return;
       }
       if (HTML_VOID_ELEMENTS.has(name.toLowerCase())) {
+        if (isStrayCloser) {
+          // htmlparser2 normalizes stray closers like `</br>` into opener
+          // events per the HTML5 spec; mirror that by rewriting the bytes
+          // into a valid self-closed tag so mdxjs accepts them.
+          inserts.push({ offset: start, text: `<${name}/>`, consumes: end - start });
+          return;
+        }
         // MDX requires void elements to be self-closing (`<br/>`, not `<br>`).
-        // If the source open tag doesn't end with `/`, inject one before the
-        // `>` so it parses. `end` is one past `>`, so `end - 2` is the char
-        // immediately before `>`.
-        if (html[end - 2] !== '/') inserts.push({ offset: end - 1, text: '/' });
+        if (!isSelfClosing) inserts.push({ offset: end - 1, text: '/' });
         return;
       }
       openTags.push({ name, start, end });

--- a/processor/transform/mdxish/tables/tag-walker.ts
+++ b/processor/transform/mdxish/tables/tag-walker.ts
@@ -19,6 +19,17 @@ interface TagEvent {
   start: number;
 }
 
+/**
+ * `isSelfClosing` — source ends with `/>`.
+ * `isStrayCloser` — source starts with `</`. htmlparser2 follows the HTML5
+ *   spec and rewrites stray void closers (`</br>`, `</p>`) into `onopentag`
+ *   events; this flag lets consumers tell that apart from a real opener.
+ */
+interface OpenEvent extends TagEvent {
+  isSelfClosing: boolean;
+  isStrayCloser: boolean;
+}
+
 // Implicit means the tag was opened but not closed
 interface CloseEvent extends TagEvent {
   implicit: boolean;
@@ -26,7 +37,7 @@ interface CloseEvent extends TagEvent {
 
 interface TagWalkHandlers {
   onClose?: (event: CloseEvent) => void;
-  onOpen?: (event: TagEvent) => void;
+  onOpen?: (event: OpenEvent) => void;
 }
 
 /**
@@ -43,7 +54,15 @@ export const walkTags = (html: string, handlers: TagWalkHandlers)=> {
   const parser: Parser = new Parser(
     {
       onopentag(name) {
-        handlers.onOpen?.({ name, start: parser.startIndex, end: tagEnd(parser) });
+        const start = parser.startIndex;
+        const end = tagEnd(parser);
+        handlers.onOpen?.({
+          name,
+          start,
+          end,
+          isSelfClosing: html[end - 2] === '/',
+          isStrayCloser: html[start + 1] === '/',
+        });
       },
       onclosetag(name, implicit) {
         handlers.onClose?.({ name, start: parser.startIndex, end: tagEnd(parser), implicit });


### PR DESCRIPTION
| 🎫 Resolve RM-16736 |
| :-----------------: |

## 🎯 What does this PR do?

A `<Table>` cell containing an orphan **void** closing tag (e.g. `</br>`, `</hr>`, `</img>`) made the whole table fall out of the mdxish JSX pipeline

**Cause.** The orphan-closer scrub added in #1480 (`findOrphanClosers`) explicitly skipped void elements with a comment claiming "the main walker handles those" — but the walker's `onClose` *also* returns early for void elements, so nobody actually stripped them. `</br>` survived to mdxjs and threw.

A second related bug: htmlparser2 follows the HTML5 spec and rewrites stray `</br>` into an `onopentag('br')` event. The walker's void-opener path then injected a self-close `/` into those bytes (turning `</br>` into `</br/>`), which still didn't parse, and post-#1480 even collided with the strip to leave a literal `/` artifact in the output.

**Solution.**
- `tag-walker.ts` now classifies opener events with `isSelfClosing` and `isStrayCloser` so consumers don't have to peek at source bytes.
- `repair-unclosed-tags.ts` `onOpen` uses `isStrayCloser` to detect htmlparser2's HTML5 rewrite of `</br>` and replaces the closer bytes with a valid self-closed `<br/>` (mirroring how browsers render it). Other void closers fall through to `findOrphanClosers`, which now strips them.

## 🧪 QA tips

Should render as a proper table with `**bold**`, bulleted list, and three `<br>`s in the cell — not raw markdown text:

```mdx
<Table align={["left","left"]}>
  <thead>
    <tr><th>Field</th><th>Action</th></tr>
  </thead>
  <tbody>
    <tr>
      <td>**Instant Failover**</td>
      <td>
        Select one of these options:

        - **Automatic**. Auto-pick next origin.
        - **Custom**. You pick the failover order.
        - **Off**. Disabled.<br /><br />With failover, request hits maintenance page. </br> <br />Data center must be listed in the load balancer config.</br>
      </td>
    </tr>
  </tbody>
</Table>
```

- [ ] Markdown inside the cell (`**bold**`, `- list`) renders, not literal `*` characters.
- [ ] Lone `</br>` renders as a line break (HTML5 spec parity), not as a literal `/`.
- [ ] Other void orphan closers (`</hr>`, `</img>`, `</input>`) are stripped silently.
- [ ] Existing orphan `</li>` test (#1480) and unrelated table fixtures still pass.

## 📸 Screenshot or Loom

<!-- TODO: attach before/after of the ticket repro -->