### PR TITLE
feat: include emoji and bgcolor in recipe attrs

### DIFF
--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -826,10 +826,11 @@ ${JSON.stringify(
   });
 
   describe('recipe block', () => {
-    it('should restore tutorial-tile block to Recipe component', () => {
+    it('should restore tutorial-tile block to Recipe component with display attrs', () => {
       const md = `[block:tutorial-tile]
 {
   "emoji": "🦉",
+  "backgroundColor": "#018ef5",
   "slug": "whoaaa",
   "title": "WHOAAA"
 }
@@ -843,14 +844,15 @@ ${JSON.stringify(
       expect(recipeElement.tagName).toBe('Recipe');
       expect(recipeElement.properties.slug).toBe('whoaaa');
       expect(recipeElement.properties.title).toBe('WHOAAA');
+      expect(recipeElement.properties.emoji).toBe('🦉');
+      expect(recipeElement.properties.backgroundColor).toBe('#018ef5');
     });
 
-    it('should restore recipe block to Recipe component', () => {
+    it('should restore recipe block to Recipe component without display attrs', () => {
       const md = `[block:recipe]
 {
   "slug": "test-recipe",
-  "title": "Test Recipe",
-  "emoji": "👉"
+  "title": "Test Recipe"
 }
 [/block]`;
 
@@ -862,6 +864,42 @@ ${JSON.stringify(
       expect(recipeElement.tagName).toBe('Recipe');
       expect(recipeElement.properties.slug).toBe('test-recipe');
       expect(recipeElement.properties.title).toBe('Test Recipe');
+      expect(recipeElement.properties.emoji).toBeUndefined();
+      expect(recipeElement.properties.backgroundColor).toBeUndefined();
+    });
+
+    it('should restore a recipe block with emoji but no backgroundColor', () => {
+      const md = `[block:tutorial-tile]
+{
+  "slug": "emoji-only",
+  "title": "Emoji Only",
+  "emoji": "🦉"
+}
+[/block]`;
+
+      const ast = mdxish(md);
+      const recipeElement = ast.children[0] as Element;
+      expect(recipeElement.tagName).toBe('Recipe');
+      expect(recipeElement.properties.slug).toBe('emoji-only');
+      expect(recipeElement.properties.emoji).toBe('🦉');
+      expect(recipeElement.properties.backgroundColor).toBeUndefined();
+    });
+
+    it('should restore a recipe block with backgroundColor but no emoji', () => {
+      const md = `[block:tutorial-tile]
+{
+  "slug": "bg-only",
+  "title": "Background Only",
+  "backgroundColor": "#018ef5"
+}
+[/block]`;
+
+      const ast = mdxish(md);
+      const recipeElement = ast.children[0] as Element;
+      expect(recipeElement.tagName).toBe('Recipe');
+      expect(recipeElement.properties.slug).toBe('bg-only');
+      expect(recipeElement.properties.backgroundColor).toBe('#018ef5');
+      expect(recipeElement.properties.emoji).toBeUndefined();
     });
   });
 

--- a/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
+++ b/__tests__/lib/mdxish/mdxish-jsx-to-mdast.test.ts
@@ -373,6 +373,26 @@ Body content
         expect(recipeNode.emoji).toBe('🍳');
         expect(recipeNode.backgroundColor).toBe('#fff');
       });
+
+      it('should preserve emoji when backgroundColor is omitted', () => {
+        const md = '<Recipe slug="emoji-only" title="Emoji Only" emoji="🦉" />';
+        const ast = processWithNewTypes(md);
+
+        const recipeNode = ast.children[0] as Recipe;
+        expect(recipeNode.slug).toBe('emoji-only');
+        expect(recipeNode.emoji).toBe('🦉');
+        expect(recipeNode.backgroundColor).toBeFalsy();
+      });
+
+      it('should preserve backgroundColor when emoji is omitted', () => {
+        const md = '<Recipe slug="bg-only" title="Background Only" backgroundColor="#018ef5" />';
+        const ast = processWithNewTypes(md);
+
+        const recipeNode = ast.children[0] as Recipe;
+        expect(recipeNode.slug).toBe('bg-only');
+        expect(recipeNode.backgroundColor).toBe('#018ef5');
+        expect(recipeNode.emoji).toBeFalsy();
+      });
     });
 
     describe('unknown components', () => {

--- a/__tests__/migration/recipes.test.ts
+++ b/__tests__/migration/recipes.test.ts
@@ -30,12 +30,12 @@ Or on a line by itself:
       <Callout icon="🚀" theme="default">
         ### Launch Example Code:
 
-        <Recipe slug="amend-modify-receviers-name-headers" title="Amend - Modify Recevier's Name - Headers" />
+        <Recipe backgroundColor="#0b1c36" emoji="👉" slug="amend-modify-receviers-name-headers" title="Amend - Modify Recevier's Name - Headers" />
       </Callout>
 
       Or on a line by itself:
 
-      <Recipe slug="amend-modify-receviers-name-headers" title="Amend - Modify Recevier's Name - Headers" />
+      <Recipe backgroundColor="#0b1c36" emoji="👉" slug="amend-modify-receviers-name-headers" title="Amend - Modify Recevier's Name - Headers" />
       "
     `);
   });

--- a/__tests__/transformers/readme-to-mdx.test.ts
+++ b/__tests__/transformers/readme-to-mdx.test.ts
@@ -22,7 +22,31 @@ describe('readme-to-mdx transformer', () => {
     };
 
     expect(mdx(ast)).toMatchInlineSnapshot(`
-      "<Recipe slug="test-id" title="Test" />
+      "<Recipe backgroundColor="red" emoji="🦉" slug="test-id" title="Test" />
+      "
+    `);
+  });
+
+  it('preserves emoji and backgroundColor on the Recipe JSX', () => {
+    const markdown = '<Recipe slug="test-id" title="Test" emoji="🦉" backgroundColor="#018ef5" />';
+    expect(mdx(mdast(markdown))).toMatchInlineSnapshot(`
+      "<Recipe slug="test-id" title="Test" emoji="🦉" backgroundColor="#018ef5" />
+      "
+    `);
+  });
+
+  it('preserves emoji on Recipe JSX when backgroundColor is omitted', () => {
+    const markdown = '<Recipe slug="emoji-only" title="Emoji Only" emoji="🦉" />';
+    expect(mdx(mdast(markdown))).toMatchInlineSnapshot(`
+      "<Recipe slug="emoji-only" title="Emoji Only" emoji="🦉" />
+      "
+    `);
+  });
+
+  it('preserves backgroundColor on Recipe JSX when emoji is omitted', () => {
+    const markdown = '<Recipe slug="bg-only" title="Background Only" backgroundColor="#018ef5" />';
+    expect(mdx(mdast(markdown))).toMatchInlineSnapshot(`
+      "<Recipe slug="bg-only" title="Background Only" backgroundColor="#018ef5" />
       "
     `);
   });

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -602,7 +602,7 @@ function transformMagicBlock(
       const recipeNode: MdxJsxFlowElement = {
         type: 'mdxJsxFlowElement',
         name: 'Recipe',
-        attributes: toAttributes(recipeJson, ['slug', 'title']),
+        attributes: toAttributes(recipeJson, ['slug', 'title', 'emoji', 'backgroundColor']),
         children: [],
         position: undefined,
       };

--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -12,6 +12,7 @@ import { NodeTypes } from '../../enums';
 import { toAttributes } from '../utils';
 
 const imageAttrs = ['align', 'alt', 'caption', 'border', 'height', 'src', 'title', 'width', 'lazy', 'className'];
+const recipeJsxAttrs = ['slug', 'title', 'emoji', 'backgroundColor'];
 
 const readmeToMdx = (): Transform => tree => {
   // Unwrap pinned nodes, replace rdme-pin with its child node
@@ -59,7 +60,7 @@ const readmeToMdx = (): Transform => tree => {
     parent.children.splice(index, 1, {
       type: 'mdxJsxFlowElement',
       name: 'Recipe',
-      attributes: toAttributes(attrs, ['slug', 'title']),
+      attributes: toAttributes(attrs, recipeJsxAttrs),
       children: [],
     });
   });
@@ -70,7 +71,7 @@ const readmeToMdx = (): Transform => tree => {
     parent.children.splice(index, 1, {
       type: 'mdxJsxFlowElement',
       name: 'Recipe',
-      attributes: toAttributes(attrs, ['slug', 'title']),
+      attributes: toAttributes(attrs, recipeJsxAttrs),
       children: [],
     });
   });


### PR DESCRIPTION
| 🎫 Resolve RM-15742 |
| :-----------------: |

## 🎯 What does this PR do?

Both `readme-to-mdx transformer` and `mdxish magic-block-transformer` were emitting `<Recipe>` JSX with only `slug` and `title`, stripping every other attr. That forced the renderer in the monorepo to make another API call for each tile just to discover the icon and background color, producing the visible cascade in the ticket. 

This PR widens the JSX attribute allowlist in both transformers to also pass through `emoji` and `backgroundColor`, so markdown that already carries those values can be painted from markdown alone with no API round-trip. 

> Behavior is purely additive, `toAttributes` drops null/undefined/empty values, so old markdown without these attrs still round-trips byte-identical.

See this monorepo PR that implements this PR: https://github.com/readmeio/readme/pull/18991

## 🧪 QA tips

_See monorepo PR_

## 📸 Screenshot or Loom

_See monorepo PR_
