### PR TITLE
fix(mdxish): terminate html flow block when opener has trailing text

### DIFF
--- a/__tests__/transformers/terminate-html-flow-blocks.test.ts
+++ b/__tests__/transformers/terminate-html-flow-blocks.test.ts
@@ -167,6 +167,42 @@ const x = 1;
 [/block]`);
     });
 
+    it('inserts blank line after an opening HTML tag with trailing text', () => {
+      const input = `<li> test
+[block:parameters]
+{
+  "data": {
+    "h-0": "Heading",
+    "0-0": "Content"
+  },
+  "cols": 1,
+  "rows": 1,
+  "align": [
+    "left",
+    "left"
+  ]
+}
+[/block]`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<li> test
+
+[block:parameters]
+{
+  "data": {
+    "h-0": "Heading",
+    "0-0": "Content"
+  },
+  "cols": 1,
+  "rows": 1,
+  "align": [
+    "left",
+    "left"
+  ]
+}
+[/block]`);
+    });
+
     it('inserts blank line when HTML line has text content between and after tags', () => {
       const input = `<div><p>Inner text</p></div>Outer text
 [block:callout]

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -6,6 +6,10 @@ const STANDALONE_HTML_LINE_REGEX = /^(<[a-z][^<>]*>|<\/[a-z][^<>]*>)+\s*$/;
 
 const HTML_LINE_WITH_CONTENT_REGEX = /^<[a-z][^<>]*>.*<\/[a-z][^<>]*>(?:[^<]*)$/;
 
+// Tag at start of line + trailing text, no closer (e.g. `<li> test`). CommonMark
+// still opens an HTML block here, so we terminate it.
+const HTML_LINE_WITH_TRAILING_CONTENT_REGEX = /^(<[a-z][^<>]*>|<\/[a-z][^<>]*>)\s*\S/;
+
 const TABLE_STRUCTURE_TAGS = ['table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'caption', 'colgroup'];
 
 // Tags whose contents must be preserved as is, inserting a blank line after the
@@ -20,7 +24,11 @@ const RAW_CONTENT_TAG_MATCHERS = RAW_CONTENT_TAGS.map(tag => ({
 }));
 
 function isLineHtml(line: string) {
-  return STANDALONE_HTML_LINE_REGEX.test(line) || HTML_LINE_WITH_CONTENT_REGEX.test(line);
+  return (
+    STANDALONE_HTML_LINE_REGEX.test(line) ||
+    HTML_LINE_WITH_CONTENT_REGEX.test(line) ||
+    HTML_LINE_WITH_TRAILING_CONTENT_REGEX.test(line)
+  );
 }
 
 // True if any RAW_CONTENT_TAGS opener on this line is not closed on the same line.


### PR DESCRIPTION
| 🎫 Resolve RM-16379 |
| :-----------------: |

## 🎯 What does this PR do?

Magic blocks placed directly under an opening HTML tag with trailing text were rendering as literal text because CommonMark consumed them into the HTML flow block. The `terminateHtmlFlowBlocks` preprocessor only recognized lines that were purely tags or had a matched open+close pair, so `<li>` test slipped past `isLineHtml` and no blank-line terminator was inserted. 

Adds a third regex (`HTML_LINE_WITH_TRAILING_CONTENT_REGEX`) for lines that start with a lowercase HTML tag followed by trailing text

## 🧪 QA tips

```
 <li> test
[block:parameters]
{
  "data": {
    "h-0": "Heading",
    "0-0": "Content"
  },
  "cols": 1,
  "rows": 1,
  "align": [
    "left",
    "left"
  ]
}
[/block]
```

verify that the table renders as expected

## 📸 Screenshot or Loom

Before | After
-- | --
<img width="665" height="326" alt="Screenshot 2026-05-29 at 14 25 42" src="https://github.com/user-attachments/assets/06b09814-a077-4ee9-bda1-1aa5bb0d9765" /> | <img width="711" height="413" alt="Screenshot 2026-05-29 at 14 25 28" src="https://github.com/user-attachments/assets/4d2f9577-c1cb-4689-9833-f1c3b7ac1bb3" />

_monorepo showcase_
<img width="860" height="392" alt="Screenshot 2026-05-29 at 14 41 10" src="https://github.com/user-attachments/assets/0fffc8f4-53d5-4da7-a393-962fefda25ba" />
