### PR TITLE
fix(stripComments): stop leaving empty lines when entire line is a comment

### DIFF
--- a/__tests__/lib/stripComments.test.ts
+++ b/__tests__/lib/stripComments.test.ts
@@ -356,6 +356,51 @@ end"`);
     expect(output).toContain('A name field');
   });
 
+  it('does not break an HTML block when an inner comment occupies a whole line', async () => {
+    const input = `<table>
+  <tbody>
+    <tr><td>Row 1</td></tr>
+    <!-- <tr><td>Row 2</td></tr> -->
+    <tr><td>Row 3</td></tr>
+  </tbody>
+</table>`;
+
+    const output = await stripComments(input, { mdxish: true });
+    expect(output).not.toContain('<!--');
+    expect(output).not.toMatch(/\n[ \t]+\n/);
+    expect(output).toContain('<tr><td>Row 1</td></tr>');
+    expect(output).toContain('<tr><td>Row 3</td></tr>');
+  });
+
+  it('removes only the comment line and preserves authorial blank lines around it', async () => {
+    const input = `<table>
+    <tbody>
+        <tr><td>row 1</td></tr>
+        <!-- <tr><td>commented out</td></tr> -->
+
+        <tr><td>row 2</td></tr>
+
+
+        <!-- <tr><td>another commented out</td></tr> -->
+        <tr><td>row 3</td></tr>
+    </tbody>
+</table>`;
+
+    const expected = `<table>
+    <tbody>
+        <tr><td>row 1</td></tr>
+
+        <tr><td>row 2</td></tr>
+
+
+        <tr><td>row 3</td></tr>
+    </tbody>
+</table>`;
+
+    const output = await stripComments(input, { mdxish: true });
+    expect(output).toBe(expected);
+  });
+
   it('strips comments inside jsx tables in mdxish mode', async () => {
     const input = `<!-- top comment -->
 

--- a/__tests__/lib/stripComments.test.ts
+++ b/__tests__/lib/stripComments.test.ts
@@ -365,11 +365,15 @@ end"`);
   </tbody>
 </table>`;
 
+    const expected = `<table>
+  <tbody>
+    <tr><td>Row 1</td></tr>
+    <tr><td>Row 3</td></tr>
+  </tbody>
+</table>`;
+
     const output = await stripComments(input, { mdxish: true });
-    expect(output).not.toContain('<!--');
-    expect(output).not.toMatch(/\n[ \t]+\n/);
-    expect(output).toContain('<tr><td>Row 1</td></tr>');
-    expect(output).toContain('<tr><td>Row 3</td></tr>');
+    expect(output).toBe(expected);
   });
 
   it('removes only the comment line and preserves authorial blank lines around it', async () => {
@@ -399,6 +403,40 @@ end"`);
 
     const output = await stripComments(input, { mdxish: true });
     expect(output).toBe(expected);
+  });
+
+  it('preserves authorial blank lines inside a table cell', async () => {
+    const input = `<table>
+    <tr>
+        <td>
+            line 1
+
+            line 2
+        </td>
+    </tr>
+</table>`;
+
+    const output = await stripComments(input, { mdxish: true });
+    expect(output).toBe(input);
+  });
+
+  it('preserves a fenced code block (with internal blank lines) inside a table cell', async () => {
+    const input = `<table>
+    <tr>
+        <td>
+
+\`\`\`js
+const a = 1;
+
+const b = 2;
+\`\`\`
+
+        </td>
+    </tr>
+</table>`;
+
+    const output = await stripComments(input, { mdxish: true });
+    expect(output).toBe(input);
   });
 
   it('strips comments inside jsx tables in mdxish mode', async () => {

--- a/__tests__/parsers/tables.test.ts
+++ b/__tests__/parsers/tables.test.ts
@@ -6,6 +6,7 @@ import { removePosition } from 'unist-util-remove-position';
 
 import { mdast } from '../../lib';
 import { mdxish } from '../../lib/mdxish';
+import { collapseBlankLines } from '../../processor/transform/mdxish/tables/mdxish-tables';
 import { collectNodes, findAllElementsByTagName, parseMdxishWithSource } from '../helpers';
 
 describe('table parser', () => {
@@ -1168,6 +1169,58 @@ None of the following content will get rendered!`;
 
       expect(html).toContain('<code>snake_case_value</code>');
       expect(html).toContain('<code>another_name_here</code>');
+    });
+  });
+
+  describe('lowercase <table> fallback path', () => {
+    it('keeps a block-with-whitespace-only-line intact when the mdx-aware parser throws on a cell expression', () => {
+      const doc = ['<table>', '    <tr>', '        <td>{not valid jsx}</td>', '    ', '    </tr>', '</table>'].join('\n');
+
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).not.toContain('<pre>');
+      expect(html).toContain('{not valid jsx}');
+    });
+
+    it('keeps a block-with-empty-line intact when the mdx-aware parser throws on a cell expression', () => {
+      const doc = ['<table>', '    <tr>', '        <td>{not valid jsx}</td>', '', '    </tr>', '</table>'].join('\n');
+
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).not.toContain('<pre>');
+      expect(html).toContain('{not valid jsx}');
+    });
+
+    it('collapseBlankLines: removes exactly one blank line per run, leaves every other line byte-identical', () => {
+      const input = [
+        '<table>',
+        '    <tr>',
+        '        <td>row 1</td>',
+        '    ',
+        '        <td>row 2</td>',
+        '',
+        '        <td>row 3</td>',
+        '    </tr>',
+        '</table>',
+      ].join('\n');
+
+      const output = collapseBlankLines(input);
+      const inputLines = input.split('\n');
+      const nonBlankInputLines = inputLines.filter(line => !/^[ \t]*$/.test(line));
+
+      expect(output.split('\n')).toStrictEqual(nonBlankInputLines);
+    });
+
+    it('collapseBlankLines: only consumes one blank line per run (consecutive blanks are mostly preserved)', () => {
+      expect(collapseBlankLines('a\n\n\nb')).toBe('a\n\nb');
+      expect(collapseBlankLines('a\n   \n   \nb')).toBe('a\n   \nb');
+    });
+
+    it('collapseBlankLines: does not strip trailing whitespace on non-empty lines', () => {
+      const input = 'a   \nb';
+      expect(collapseBlankLines(input)).toBe(input);
     });
   });
 });

--- a/__tests__/parsers/tables.test.ts
+++ b/__tests__/parsers/tables.test.ts
@@ -1193,7 +1193,29 @@ None of the following content will get rendered!`;
       expect(html).toContain('{not valid jsx}');
     });
 
-    it('collapseBlankLines: removes exactly one blank line per run, leaves every other line byte-identical', () => {
+    it('keeps a block-with-many-blank-lines intact', () => {
+      const doc = [
+        '<table>',
+        '    <tr>',
+        '        <td>{not valid jsx}</td>',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '',
+        '    </tr>',
+        '</table>',
+      ].join('\n');
+
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).not.toContain('<pre>');
+      expect(html).toContain('{not valid jsx}');
+    });
+
+    it('collapseBlankLines: removes every blank line, leaves every other line byte-identical', () => {
       const input = [
         '<table>',
         '    <tr>',
@@ -1213,9 +1235,10 @@ None of the following content will get rendered!`;
       expect(output.split('\n')).toStrictEqual(nonBlankInputLines);
     });
 
-    it('collapseBlankLines: only consumes one blank line per run (consecutive blanks are mostly preserved)', () => {
-      expect(collapseBlankLines('a\n\n\nb')).toBe('a\n\nb');
-      expect(collapseBlankLines('a\n   \n   \nb')).toBe('a\n   \nb');
+    it('collapseBlankLines: collapses any run of consecutive blank lines to a single newline', () => {
+      expect(collapseBlankLines('a\n\n\nb')).toBe('a\nb');
+      expect(collapseBlankLines('a\n\n\n\n\n\n\nb')).toBe('a\nb');
+      expect(collapseBlankLines('a\n   \n   \nb')).toBe('a\nb');
     });
 
     it('collapseBlankLines: does not strip trailing whitespace on non-empty lines', () => {

--- a/example/Doc.tsx
+++ b/example/Doc.tsx
@@ -53,6 +53,20 @@ const variables = {
   ],
 };
 
+interface StripState {
+  error: string | null;
+  stripped: string | null;
+}
+
+type PipelineKey = 'legacy' | 'mdxish' | 'rmdx';
+
+const EMPTY_STRIP_STATE: StripState = { error: null, stripped: null };
+const EMPTY_STRIP_STATE_MAP: Record<PipelineKey, StripState> = {
+  legacy: EMPTY_STRIP_STATE,
+  mdxish: EMPTY_STRIP_STATE,
+  rmdx: EMPTY_STRIP_STATE,
+};
+
 const Doc = () => {
   const { fixture } = useParams();
   const [searchParams] = useSearchParams();
@@ -61,7 +75,6 @@ const Doc = () => {
   const mdxish = searchParams.has('mdxish');
   const showRmdx = searchParams.has('rmdx');
 
-  type PipelineKey = 'legacy' | 'mdxish' | 'rmdx';
   const selectedPipelines: PipelineKey[] = [];
   if (showRmdx) selectedPipelines.push('rmdx');
   if (legacy) selectedPipelines.push('legacy');
@@ -88,8 +101,8 @@ const Doc = () => {
   const [rmdxHast, setRmdxHast] = useState<object | null>(null);
   const [mdxishMdast, setMdxishMdast] = useState<object | null>(null);
   const [mdxishHast, setMdxishHast] = useState<object | null>(null);
-  const [strippedMarkdown, setStrippedMarkdown] = useState<string | null>(null);
-  const [stripError, setStripError] = useState<string | null>(null);
+  const [stripByPipeline, setStripByPipeline] = useState<Record<PipelineKey, StripState>>(EMPTY_STRIP_STATE_MAP);
+  const hasAnyStripped = Object.values(stripByPipeline).some(s => s.stripped !== null);
   const [view, setView] = useState<'hast' | 'markdown' | 'mdast' | 'rendered'>('rendered');
   const showToc = fixture === 'tableOfContentsTests';
 
@@ -101,8 +114,7 @@ const Doc = () => {
   useEffect(() => {
     const sanitize = async (mode: PipelineKey) => {
       if (!stripComments) {
-        setStrippedMarkdown(null);
-        setStripError(null);
+        setStripByPipeline(prev => ({ ...prev, [mode]: EMPTY_STRIP_STATE }));
         return doc;
       }
       try {
@@ -110,15 +122,13 @@ const Doc = () => {
           mdx: mode === 'rmdx',
           mdxish: mode === 'mdxish',
         });
-        setStrippedMarkdown(sanitized);
-        setStripError(null);
+        setStripByPipeline(prev => ({ ...prev, [mode]: { stripped: sanitized, error: null } }));
         return sanitized;
       } catch (e) {
         // eslint-disable-next-line no-console
         console.error(e);
         const message = e instanceof Error ? e.message : String(e);
-        setStripError(message);
-        setStrippedMarkdown(null);
+        setStripByPipeline(prev => ({ ...prev, [mode]: { stripped: null, error: message } }));
         return null;
       }
     };
@@ -261,7 +271,7 @@ const Doc = () => {
     <div className="rdmd-demo--display">
       <section id="hub-content">
         {!ci && <h2 className="rdmd-demo--markdown-header">{name}</h2>}
-        {(strippedMarkdown !== null || showAst) && (
+        {(hasAnyStripped || showAst) && (
           <div className="rdmd-demo--view-toggle">
             <button
               className={view === 'rendered' ? 'active' : ''}
@@ -270,7 +280,7 @@ const Doc = () => {
             >
               Rendered
             </button>
-            {strippedMarkdown !== null && (
+            {hasAnyStripped && (
               <button
                 className={view === 'markdown' ? 'active' : ''}
                 onClick={() => setView('markdown')}
@@ -299,13 +309,27 @@ const Doc = () => {
             )}
           </div>
         )}
-        {stripError && (
-          <div className="rdmd-demo--strip-error">
-            <strong>stripComments error:</strong> {stripError}
+        {view === 'markdown' && hasAnyStripped ? (
+          <div className="rdmd-demo--panels">
+            {activePipelines.map(p => {
+              const { error, stripped } = stripByPipeline[p];
+              return (
+                <div key={p} className="rdmd-demo--panel">
+                  <div className="rdmd-demo--panel-label">{pipelineLabels[p]}</div>
+                  {error && (
+                    <div className="rdmd-demo--strip-error">
+                      <strong>stripComments error:</strong> {error}
+                    </div>
+                  )}
+                  {stripped !== null ? (
+                    <pre className="rdmd-demo--stripped-output">{stripped}</pre>
+                  ) : (
+                    !error && <div className="rdmd-demo--empty">No stripped output for this pipeline</div>
+                  )}
+                </div>
+              );
+            })}
           </div>
-        )}
-        {view === 'markdown' && strippedMarkdown !== null ? (
-          <pre className="rdmd-demo--stripped-output">{strippedMarkdown}</pre>
         ) : (view === 'mdast' || view === 'hast') && showAst ? (
           <div className="rdmd-demo--panels">
             {activePipelines.map(p => {

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
       },
       {
         "path": "dist/main.node.js",
-        "maxSize": "947KB"
+        "maxSize": "950KB"
       }
     ]
   },

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -61,6 +61,17 @@ const buildTableNodeProcessor = (withMdx: boolean) =>
 const tableNodeProcessor = buildTableNodeProcessor(true);
 const fallbackTableNodeProcessor = buildTableNodeProcessor(false);
 
+const BLANK_LINE_REGEX = /(\r?\n)[ \t]*\r?\n/g;
+
+/**
+ * Collapses a single blank line (empty or whitespace-only) per match so it
+ * doesn't terminate the CommonMark type-6 block when the fallback parser
+ * sees it. Non-greedy: only one blank line per run is consumed, so authorial
+ * sequences of multiple blank lines are mostly preserved.
+ */
+export const collapseBlankLines = (value: string): string =>
+  value.replace(BLANK_LINE_REGEX, '$1');
+
 /**
  * Parse the HTML node that contains the full table substring
  * into the table parts (headers, rows, cells).
@@ -355,8 +366,9 @@ const mdxishTables = (): Transform => tree => {
     } else if (node.value.startsWith('<table')) {
       // If the parsing still fails, give an opportunity to the fallback parser
       // without remarkMdx to process lowercase tables as it's likely to not
-      // have needed MDX parsing anyway
-      const fallback = parseTableNode(fallbackTableNodeProcessor, node);
+      // have needed MDX parsing anyway.
+      const sanitizedValue = collapseBlankLines(node.value);
+      const fallback = parseTableNode(fallbackTableNodeProcessor, { ...node, value: sanitizedValue });
       if (!fallback || fallback.children.length <= 1) return;
       parent.children.splice(index, 1, ...(fallback.children as typeof parent.children));
     }

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -61,11 +61,11 @@ const buildTableNodeProcessor = (withMdx: boolean) =>
 const tableNodeProcessor = buildTableNodeProcessor(true);
 const fallbackTableNodeProcessor = buildTableNodeProcessor(false);
 
-const BLANK_LINE_REGEX = /(\r?\n)[ \t]*\r?\n(?![ \t]*\r?\n)/g;
+const BLANK_LINE_REGEX = /(\r?\n)(?:[ \t]*\r?\n)+/g;
 
 /**
- * Collapses one blank line per match so it doesn't terminate the CommonMark
- * type-6 block. Non-greedy: runs of multiple blank lines lose just one.
+ * Collapses any run of blank lines (empty or whitespace-only) to a single
+ * newline so the CommonMark type-6 block isn't terminated mid-table.
  */
 export const collapseBlankLines = (value: string): string =>
   value.replace(BLANK_LINE_REGEX, '$1');

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -61,13 +61,11 @@ const buildTableNodeProcessor = (withMdx: boolean) =>
 const tableNodeProcessor = buildTableNodeProcessor(true);
 const fallbackTableNodeProcessor = buildTableNodeProcessor(false);
 
-const BLANK_LINE_REGEX = /(\r?\n)[ \t]*\r?\n/g;
+const BLANK_LINE_REGEX = /(\r?\n)[ \t]*\r?\n(?![ \t]*\r?\n)/g;
 
 /**
- * Collapses a single blank line (empty or whitespace-only) per match so it
- * doesn't terminate the CommonMark type-6 block when the fallback parser
- * sees it. Non-greedy: only one blank line per run is consumed, so authorial
- * sequences of multiple blank lines are mostly preserved.
+ * Collapses one blank line per match so it doesn't terminate the CommonMark
+ * type-6 block. Non-greedy: runs of multiple blank lines lose just one.
  */
 export const collapseBlankLines = (value: string): string =>
   value.replace(BLANK_LINE_REGEX, '$1');

--- a/processor/transform/stripComments.ts
+++ b/processor/transform/stripComments.ts
@@ -3,6 +3,9 @@ import type { Root } from 'mdast';
 import { visit, SKIP } from 'unist-util-visit';
 
 const HTML_COMMENT_REGEX = /<!--[\s\S]*?-->/g;
+// Indented whole-line comment plus trailing newline; removing the whole line
+// avoids leaving a whitespace-only line that terminates the surrounding block.
+const WHOLE_LINE_HTML_COMMENT_REGEX = /^[ \t]+<!--[\s\S]*?-->[ \t]*(?:\r?\n|$)/gm;
 export const MDX_COMMENT_REGEX = /\/\*(?:(?!\*\/)[\s\S])*\*\//g;
 
 /**
@@ -14,7 +17,10 @@ export const stripCommentsTransformer = () => {
       if (parent && typeof index === 'number') {
         // Remove HTML comments
         if (node.type === 'html' && HTML_COMMENT_REGEX.test(node.value)) {
-          const newValue = node.value.replace(HTML_COMMENT_REGEX, '').trim();
+          const newValue = node.value
+            .replace(WHOLE_LINE_HTML_COMMENT_REGEX, '')
+            .replace(HTML_COMMENT_REGEX, '')
+            .trim();
           if (newValue) {
             node.value = newValue;
           } else {


### PR DESCRIPTION
| 🎫 Resolve CX-3116 |
| :-----------------: |

## 🎯 What does this PR do?

There is actually 2 issues that arose from this ticket
1. whenever stripComments sees an entire line of html comments, it strips it by replacing it with a `""`, leaving an empty line that may break the component into 2 parts: fixed in 026c279ee8f705f0f2e56db9b50d4f2f6a69bc72
2. the table tokenizer has a fallback for `<table>`, this tokenizer doesnt know how to handle a stray empty line in the middle of a `<table>` component: fixed in 421762c7541ea70e1249fbb91c97cd4df1c72951

for the original customer site in the ticket, the issue was a mix of both. The stripComments created an empty line in a fallback `<table>` and it didnt know how to handle it, causing the original error

> [!NOTE]
i also reworked the demo app for the strip comments mode, now we can show multiple markdown outputs just like in the rendered mode. each output for each selected engine

## 🧪 QA tips

```
<table>
    <thead>
        <tr>
            <th>Hello</th>
            <th>Import something</th>
        </tr>
    </thead>
    <tbody>
        <tr colspan="2"><td>Something</td></tr>
        <tr>
            <td>Why hello there</td>
            <td>Something something</td>
        </tr>
        <!-- <tr colspan="2"><td>Manager</td></tr> -->

        <tr>
            <td><a href="foo">Cat and Dog</a></td>
            <td>
                <code>{property activation resource name}</code>
            </td>
        </tr>
    </tbody>
</table>
```

make sure that piece of code survives and is rendered correctly in the demo app and the monorepo (both admin and end user view)

## 📸 Screenshot or Loom

### Issue 1

Before | After
-- | --
<img width="1913" height="986" alt="Screenshot 2026-06-01 at 12 42 47" src="https://github.com/user-attachments/assets/4f9dced1-c9c9-434e-a25c-a0fb4ea2d38e" /> | <img width="1905" height="977" alt="Screenshot 2026-06-01 at 14 29 20" src="https://github.com/user-attachments/assets/fb1b781f-199d-4f8e-896d-f1d0d18dafc7" />

_The new improvement to the stripComments still persist intentional empty lines:_
<img width="1907" height="976" alt="Screenshot 2026-06-01 at 14 30 38" src="https://github.com/user-attachments/assets/753f3a3a-76b3-40c8-9c68-6af0849bd1ee" />

### Issue 2

Before | After
-- | --
<img width="1902" height="979" alt="Screenshot 2026-06-01 at 13 19 23" src="https://github.com/user-attachments/assets/66d23dfe-c932-4069-a07f-df84fd855f68" /> | <img width="1907" height="976" alt="Screenshot 2026-06-01 at 13 25 38" src="https://github.com/user-attachments/assets/dd8207fd-02e9-4b7f-90d9-7830c97fd616" />


