### PR TITLE
fix(mdxish) deindent HTMLBlock content relative to opening tag

### DIFF
--- a/__tests__/lib/mdxish/html-blocks.test.ts
+++ b/__tests__/lib/mdxish/html-blocks.test.ts
@@ -280,7 +280,8 @@ there`;
 <p>Hello</p>
 
 <p>World</p>
-</div>\`}</HTMLBlock></td>
+</div>
+\`}</HTMLBlock></td>
     </tr>
   </tbody>
 </Table>`;
@@ -307,8 +308,10 @@ there`;
       <td>**bold** here</td>
       <td><HTMLBlock>{\`<ul>
 <li>one</li>
+
 <li>two</li>
-</ul>\`}</HTMLBlock></td>
+</ul>
+\`}</HTMLBlock></td>
     </tr>
   </tbody>
 </Table>`;
@@ -320,7 +323,7 @@ there`;
       const strongs = findAllElementsByTagName(tree, 'strong');
       expect(strongs.length).toBeGreaterThan(0);
       expect(JSON.stringify(strongs[0])).toContain('bold');
-      expect(htmlBlockPayloads(tree)).toStrictEqual(['<ul>\n<li>one</li>\n<li>two</li>\n</ul>']);
+      expect(htmlBlockPayloads(tree)).toStrictEqual(['<ul>\n<li>one</li>\n\n<li>two</li>\n</ul>']);
     });
 
     it('renders inside a lowercase <table> cell', () => {
@@ -331,7 +334,8 @@ there`;
 <p>a</p>
 
 <p>b</p>
-</section>\`}</HTMLBlock></td>
+</section>
+\`}</HTMLBlock></td>
     </tr>
   </tbody>
 </table>`;
@@ -387,7 +391,8 @@ there`;
 <span>one</span>
 
 <span>uno</span>
-</div>\`}</HTMLBlock></td>
+</div>
+\`}</HTMLBlock></td>
       <td><HTMLBlock>{\`<span>two</span>\`}</HTMLBlock></td>
     </tr>
   </tbody>

--- a/__tests__/lib/mdxish/html-blocks.test.ts
+++ b/__tests__/lib/mdxish/html-blocks.test.ts
@@ -277,9 +277,9 @@ there`;
     <tr>
       <td>Custom</td>
       <td><HTMLBlock>{\`<div style="color: red;">
-  <p>Hello</p>
+<p>Hello</p>
 
-  <p>World</p>
+<p>World</p>
 </div>\`}</HTMLBlock></td>
     </tr>
   </tbody>
@@ -294,7 +294,7 @@ there`;
 
       // Newlines (including the blank line) inside the content must survive the
       // table re-parse and not fragment the HTMLBlock.
-      expect(htmlBlockPayloads(tree)).toStrictEqual(['<div style="color: red;">\n  <p>Hello</p>\n\n  <p>World</p>\n</div>']);
+      expect(htmlBlockPayloads(tree)).toStrictEqual(['<div style="color: red;">\n<p>Hello</p>\n\n<p>World</p>\n</div>']);
     });
 
     it('still renders markdown in a sibling text cell', () => {
@@ -306,9 +306,8 @@ there`;
     <tr>
       <td>**bold** here</td>
       <td><HTMLBlock>{\`<ul>
-  <li>one</li>
-
-  <li>two</li>
+<li>one</li>
+<li>two</li>
 </ul>\`}</HTMLBlock></td>
     </tr>
   </tbody>
@@ -321,7 +320,7 @@ there`;
       const strongs = findAllElementsByTagName(tree, 'strong');
       expect(strongs.length).toBeGreaterThan(0);
       expect(JSON.stringify(strongs[0])).toContain('bold');
-      expect(htmlBlockPayloads(tree)).toStrictEqual(['<ul>\n  <li>one</li>\n\n  <li>two</li>\n</ul>']);
+      expect(htmlBlockPayloads(tree)).toStrictEqual(['<ul>\n<li>one</li>\n<li>two</li>\n</ul>']);
     });
 
     it('renders inside a lowercase <table> cell', () => {
@@ -329,16 +328,16 @@ there`;
   <tbody>
     <tr>
       <td><HTMLBlock>{\`<section>
-  <p>a</p>
+<p>a</p>
 
-  <p>b</p>
+<p>b</p>
 </section>\`}</HTMLBlock></td>
     </tr>
   </tbody>
 </table>`;
 
       const tree = mdxish(md);
-      expect(htmlBlockPayloads(tree)).toStrictEqual(['<section>\n  <p>a</p>\n\n  <p>b</p>\n</section>']);
+      expect(htmlBlockPayloads(tree)).toStrictEqual(['<section>\n<p>a</p>\n\n<p>b</p>\n</section>']);
       expectFullyConverted(tree);
     });
 
@@ -385,9 +384,9 @@ there`;
   <tbody>
     <tr>
       <td><HTMLBlock>{\`<div>
-  <span>one</span>
+<span>one</span>
 
-  <span>uno</span>
+<span>uno</span>
 </div>\`}</HTMLBlock></td>
       <td><HTMLBlock>{\`<span>two</span>\`}</HTMLBlock></td>
     </tr>
@@ -401,7 +400,7 @@ there`;
       const htmlBlocks = findAllElementsByTagName(tree, 'html-block');
       expect(htmlBlocks).toHaveLength(2);
       expect(htmlBlocks[0].properties).toMatchObject({
-        html: '<div>\n  <span>one</span>\n\n  <span>uno</span>\n</div>',
+        html: '<div>\n<span>one</span>\n\n<span>uno</span>\n</div>',
       });
       expect(htmlBlocks[1].properties).toMatchObject({ html: '<span>two</span>' });
     });

--- a/__tests__/transformers/mdxish-html-blocks.test.ts
+++ b/__tests__/transformers/mdxish-html-blocks.test.ts
@@ -100,6 +100,20 @@ describe('mdxish html blocks transformer', () => {
         properties: { html: '<ul>\n  <li>one</li>\n  <li>two</li>\n</ul>' },
       });
     });
+
+    it('starts indent relative to the HTMLBlock opening tag', () => {
+      const markdown = `
+  <HTMLBlock>{\`first
+second
+   third
+  fourth
+  \`}</HTMLBlock>`;
+      const tree = mdxish(markdown);
+      const htmlBlock = findElementByTagName(tree, 'html-block');
+      expect(htmlBlock).toMatchObject({
+        properties: { html: 'first\nsecond\n third\nfourth' },
+      });
+    });
   });
 
   describe('node structure', () => {

--- a/processor/transform/mdxish/mdxish-html-blocks.ts
+++ b/processor/transform/mdxish/mdxish-html-blocks.ts
@@ -74,8 +74,18 @@ const jsxAttr = (element: HtmlBlockJsx, name: string): string | undefined => {
 };
 
 /** Builds an `html-block` from a raw attribute string and (unparsed) body. */
-const htmlBlockFromRaw = (attrs: string, html: string, position: HTMLBlock['position']): HTMLBlock =>
-  createHtmlBlockNode(formatHtmlForMdxish(html), position, toRunScripts(rawAttr(attrs, 'runScripts')), rawAttr(attrs, 'safeMode'));
+const htmlBlockFromRaw = (
+  attrs: string,
+  html: string,
+  position: HTMLBlock['position'],
+  openingTagIndent = 0,
+): HTMLBlock =>
+  createHtmlBlockNode(
+    formatHtmlForMdxish(html, openingTagIndent),
+    position,
+    toRunScripts(rawAttr(attrs, 'runScripts')),
+    rawAttr(attrs, 'safeMode'),
+  );
 
 /**
  * Splits a raw `html` node that embeds one or more `<HTMLBlock>`s into
@@ -92,7 +102,12 @@ const splitRawHtmlBlocks = (node: Html): RootContent[] | null => {
   for (let i = 0; i < segments.length; i += 3) {
     const [text, attrs, body] = segments.slice(i, i + 3);
     if (text) parts.push({ type: 'html', value: text });
-    if (body !== undefined) parts.push(htmlBlockFromRaw(attrs, body, node.position));
+    if (body !== undefined) {
+      // The opening tag's column equals the length of the line it starts on
+      // (the text run since the previous newline preceding the match).
+      const openingTagIndent = text.slice(text.lastIndexOf('\n') + 1).length;
+      parts.push(htmlBlockFromRaw(attrs, body, node.position, openingTagIndent));
+    }
   }
   return parts;
 };
@@ -126,8 +141,9 @@ const mdxishHtmlBlocks = (): Transform => tree => {
         child => child.type === 'mdxFlowExpression' || child.type === 'mdxTextExpression',
       ) as { value?: string } | undefined;
 
+      const openingTagIndent = (element.position?.start.column ?? 1) - 1;
       parent.children[index] = createHtmlBlockNode(
-        formatHtmlForMdxish(extractTemplateLiteral(exprChild?.value)),
+        formatHtmlForMdxish(extractTemplateLiteral(exprChild?.value), openingTagIndent),
         element.position,
         toRunScripts(jsxAttr(element, 'runScripts')),
         jsxAttr(element, 'safeMode'),
@@ -171,7 +187,8 @@ const mdxishHtmlBlocks = (): Transform => tree => {
         })
         .join('');
 
-      children.splice(i, closeIdx - i + 1, htmlBlockFromRaw(openMatch[1], body, open.position));
+      const openingTagIndent = (open.position?.start.column ?? 1) - 1;
+      children.splice(i, closeIdx - i + 1, htmlBlockFromRaw(openMatch[1], body, open.position, openingTagIndent));
     }
   });
 };

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -162,11 +162,18 @@ export const isMDXEsm = (node: Node): node is MdxjsEsm => {
  * and unindents the HTML.
  *
  * @param {string} html - cooked HTML payload (callers strip any template-literal backticks first)
+ * @param {number} [openingTagIndent=0] - column the `<HTMLBlock>` opening tag sits at, used to
+ *   dedent each content line so its indentation reads relative to the tag, not the line start
  * @returns {string} processed HTML
  */
-export function formatHtmlForMdxish(html: string): string {
+export function formatHtmlForMdxish(html: string, openingTagIndent = 0): string {
   // Removes the leading/trailing newlines
   let cleaned = html.replace(/^\s*\n|\n\s*$/g, '');
+
+  // Strip up lines relative to the opening HTMLBlock tag's indentation
+  if (openingTagIndent > 0) {
+    cleaned = cleaned.replace(new RegExp(`^[ \\t]{1,${openingTagIndent}}`, 'gm'), '');
+  }
 
   // Convert literal \n sequences to actual newlines only inside <pre> and <code>.
   // Because <pre> needs to respect the newline visual and

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -170,9 +170,18 @@ export function formatHtmlForMdxish(html: string, openingTagIndent = 0): string 
   // Removes the leading/trailing newlines
   let cleaned = html.replace(/^\s*\n|\n\s*$/g, '');
 
-  // Strip up lines relative to the opening HTMLBlock tag's indentation
+  // Strip / deindent the lines in the HTML string so that the indents are relative
+  // to the opening HTMLBlock tag, not the literal line start
+  // Keep any deeper indent
   if (openingTagIndent > 0) {
-    cleaned = cleaned.replace(new RegExp(`^[ \\t]{1,${openingTagIndent}}`, 'gm'), '');
+    cleaned = cleaned
+      .split('\n')
+      .map(line => {
+        let i = 0;
+        while (i < openingTagIndent && (line[i] === ' ' || line[i] === '\t')) i += 1;
+        return line.slice(i);
+      })
+      .join('\n');
   }
 
   // Convert literal \n sequences to actual newlines only inside <pre> and <code>.


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

While fixing HTMLBlocks not rendering inside Tables in mdxish, I noticed that once it worked, an editor round trip would unexpectedly indent the block content lines in the editor, even though the rendering is fine & not affected. See this demo:

https://github.com/user-attachments/assets/5b3fa862-b493-417b-b48f-fac82650133b

The root issue is actually the HTMLBlock transformer in the engine captures the content verbatim from the source, each
content line's leading whitespace is exactly the characters that sit between the backticks, measured from column 1. Since the Table content is indented in serialisation, the leading whitespaces exist. 

The fix I went for here is in the block content extraction code, we pass in the `<HTMLBlock>` opening tag position & deindent each line relative to that, instead of the starting column. I think it makes sense to use the tag as the anchor column, there's a few ways we can decide that. I also think the fix should be the engine side cause I don't think it should capture the content verbatim anyway (briefly considered putting fix in the editor). 

Note that this happens in MDX as well. Haven't investigated yet but it's likely it's an engine issue as well and not the editor.

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

The fix deindents each `<HTMLBlock>` content line **relative to the opening tag's column**, not the start of the line. To verify, paste each example into the mdxish editor, confirm it renders correctly, then do an editor round-trip (e.g. view as Markdown and reopen) — the content lines should **not** gain extra leading indentation.

- [ ] **Indented `<HTMLBlock>` (nested under a list item)**

  ````md
  1. Here is some custom HTML:

     <HTMLBlock>{`
     <div style="color: red;">
       <p>Hello</p>
       <p>World</p>
     </div>
     `}</HTMLBlock>
  ````

  The extracted content should be deindented relative to the `<HTMLBlock>` tag, so the `<div>` sits at column 0 and the `<p>`s keep their relative 2-space indent:

  ```html
  <div style="color: red;">
    <p>Hello</p>
    <p>World</p>
  </div>
  ```

  Before the fix, every round-trip would keep the list's 3-space indentation on each line (and compound it on repeated trips).

- [ ] **`<HTMLBlock>` inside a `<Table>` cell**

  ````md
  <Table>
    <thead>
      <tr><th>Name</th><th>Markup</th></tr>
    </thead>
    <tbody>
      <tr>
        <td>Custom</td>
        <td><HTMLBlock>{`<div style="color: red;">
    <p>Hello</p>
    <p>World</p>
  </div>`}</HTMLBlock></td>
      </tr>
    </tbody>
  </Table>
  ````

  The table should stay a JSX `<Table>` and the cell should render the raw HTML. The extracted content should preserve the author's relative indentation without the table-cell serialization indentation leaking into the lines:

  ```html
  <div style="color: red;">
    <p>Hello</p>
    <p>World</p>
  </div>
  ```

## 📸 Screenshot or Loom

Demo of block inside Table where the indents are retained:

https://github.com/user-attachments/assets/68178bd0-0d44-4ebc-8dbb-86be1b2fad8a