### PR TITLE
fix(mdxish): render table body rows when there's no <tbody> wrapper

### DIFF
--- a/__tests__/parsers/tables.test.ts
+++ b/__tests__/parsers/tables.test.ts
@@ -1170,4 +1170,24 @@ None of the following content will get rendered!`;
       expect(html).toContain('<code>another_name_here</code>');
     });
   });
+
+  describe('tables with no <tbody> wrapper', () => {
+    it.each([['Table'], ['table']])(
+      'still renders all the rows in a <%s> with no <tbody> wrapper',
+      tag => {
+        const doc = `<${tag}>
+  <thead><tr><th>col</th></tr></thead>
+  <tr><td>row 1</td></tr>
+  <tr><td>row 2</td></tr>
+</${tag}>`;
+
+        const hast = mdxish(doc);
+        const tables = findAllElementsByTagName(hast, 'table');
+        expect(tables).toHaveLength(1);
+
+        const rows = findAllElementsByTagName(tables[0], 'tr');
+        expect(rows).toHaveLength(3);
+      },
+    );
+  });
 });

--- a/__tests__/parsers/tables.test.ts
+++ b/__tests__/parsers/tables.test.ts
@@ -1190,4 +1190,27 @@ None of the following content will get rendered!`;
       },
     );
   });
+
+  describe('tables with no <thead> wrapper', () => {
+    it.each([['Table'], ['table']])(
+      'still renders all the rows in a <%s> with no <thead> wrapper',
+      tag => {
+        const doc = `<${tag}>
+  <tr><th>col</th></tr>
+  <tr><td>row 1</td></tr>
+  <tr><td>row 2</td></tr>
+</${tag}>`;
+
+        const hast = mdxish(doc);
+        const tables = findAllElementsByTagName(hast, 'table');
+        expect(tables).toHaveLength(1);
+
+        const rows = findAllElementsByTagName(tables[0], 'tr');
+        expect(rows).toHaveLength(3);
+
+        const headerRow = findAllElementsByTagName(tables[0], 'th');
+        expect(headerRow).toHaveLength(1);
+      },
+    );
+  });
 });

--- a/__tests__/parsers/tables.test.ts
+++ b/__tests__/parsers/tables.test.ts
@@ -1173,7 +1173,7 @@ None of the following content will get rendered!`;
 
   describe('tables with no <tbody> wrapper', () => {
     it.each([['Table'], ['table']])(
-      'still renders all the rows in a <%s> with no <tbody> wrapper',
+      'still renders all the body rows in a <%s> but <thead> exists',
       tag => {
         const doc = `<${tag}>
   <thead><tr><th>col</th></tr></thead>
@@ -1189,11 +1189,9 @@ None of the following content will get rendered!`;
         expect(rows).toHaveLength(3);
       },
     );
-  });
 
-  describe('tables with no <thead> wrapper', () => {
     it.each([['Table'], ['table']])(
-      'still renders all the rows in a <%s> with no <thead> wrapper',
+      'still renders all the body rows in a <%s> when <thead> also does not exist',
       tag => {
         const doc = `<${tag}>
   <tr><th>col</th></tr>

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
       },
       {
         "path": "dist/main.node.js",
-        "maxSize": "947KB"
+        "maxSize": "950KB"
       }
     ]
   },

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -248,16 +248,36 @@ const processTableNode = (
       n.type === 'paragraph' && 'children' in n && Array.isArray(n.children) ? (n.children as Node[]) : [n],
     );
 
-  visit(node as Node, isMDXElement, (child: MdxJsxFlowElement | MdxJsxTextElement) => {
-    if (child.name !== 'thead' && child.name !== 'tbody') return;
+  // Iterate the table's direct children in document order. Rows may live
+  // inside a `<thead>`/`<tbody>` section, or sit bare directly under the table
+  // with no section wrapper — both are collected here so the first row becomes
+  // the markdown table header.
+  const tableChildren = flattenSectionChildren(node.children as Node[]);
+  tableChildren.forEach(child => {
+    if (!isMDXElement(child)) return;
+    const childElement = child as MdxJsxFlowElement | MdxJsxTextElement;
 
-    const sectionChildren = flattenSectionChildren(child.children as Node[]);
+    // Path for a `<tr>` directly under the table, without a `<thead>`/`<tbody>` wrapper.
+    if (childElement.name === 'tr') {
+      children.push({
+        type: 'tableRow' as const,
+        children: collectCells(childElement as Node),
+        position: childElement.position,
+      });
+      return;
+    }
+
+    // Path for when the rows are wrapped in a `<thead>`/`<tbody>`
+    // We visit & collect the entire rows under them directly here
+    if (childElement.name !== 'thead' && childElement.name !== 'tbody') return;
+
+    const sectionChildren = flattenSectionChildren(childElement.children as Node[]);
     const hasRow = sectionChildren.some(
       c => isMDXElement(c) && (c as MdxJsxFlowElement | MdxJsxTextElement).name === 'tr',
     );
 
     if (hasRow) {
-      visit(child as Node, isMDXElement, (row: MdxJsxFlowElement | MdxJsxTextElement) => {
+      visit(childElement as Node, isMDXElement, (row: MdxJsxFlowElement | MdxJsxTextElement) => {
         if (row.name !== 'tr') return;
         children.push({
           type: 'tableRow' as const,
@@ -269,19 +289,20 @@ const processTableNode = (
       // No `<tr>`, chunk bare cells into rows using the prior row's column
       // count (e.g. from `<thead>`), so 4 bare `<td>`s under a 2-col header
       // become 2 rows of 2.
-      const cells = collectCells(child as Node);
+      const cells = collectCells(childElement as Node);
       if (cells.length === 0) return;
       const cols = children[0]?.children?.length || cells.length;
       for (let i = 0; i < cells.length; i += cols) {
         children.push({
           type: 'tableRow' as const,
           children: cells.slice(i, i + cols),
-          position: child.position,
+          position: childElement.position,
         });
       }
     }
   });
 
+  // Output the markdown table node
   const firstRow = children[0];
   const columnCount = firstRow?.children?.length || 0;
   const alignArray: Table['align'][number][] =


### PR DESCRIPTION
| 🎫 Resolve CX-3468 |
| :-----------------: |

## 🎯 What does this PR do?

In MDXish, there's a specific issue when an HTML table's body rows are written directly under `<table>`/`<Table>` without a `<tbody>` wrapper, and there exists a `<thead>`, those body rows were dropped, only the header rendered. The cause of this is that the markdown-table conversion only collected rows nested inside `<thead>`/`<tbody>`. remarkMdx parses bare `<tr>`s as siblings of `<thead>`, so they were never picked up. We now also collect `<tr>`s sitting directly under the table, in document order, so every row renders.

## 🧪 QA tips

Body rows with no `<tbody>` wrapper should now all render (works for both `<table>` and `<Table>`):

```markdown
<table>
  <thead><tr><th>col</th></tr></thead>
  <tr><td>row 1</td></tr>
  <tr><td>row 2</td></tr>
</table>
```

```markdown
<Table>
  <thead><tr><th>Name</th><th>Role</th></tr></thead>
  <tr><td>Ada</td><td>Engineer</td></tr>
  <tr><td>Linus</td><td>Maintainer</td></tr>
</Table>
```

Sanity-check that tables which already use `<tbody>` still render unchanged:

```markdown
<table>
  <thead><tr><th>col</th></tr></thead>
  <tbody>
    <tr><td>row 1</td></tr>
    <tr><td>row 2</td></tr>
  </tbody>
</table>
```

- [ ] All body rows render in tables without a `<tbody>` wrapper
- [ ] Tables with a `<tbody>` wrapper are unaffected

## 📸 Screenshot or Loom

**Before**:

<img width="1575" height="678" alt="Screenshot 2026-06-03 at 9 45 01 am" src="https://github.com/user-attachments/assets/8744f447-6d37-4cac-8505-e6ac14a0c6ac" />

**After**:

<img width="1578" height="679" alt="Screenshot 2026-06-03 at 9 45 18 am" src="https://github.com/user-attachments/assets/699c7cfc-6c42-401d-84af-a14c3777fedb" />

