### PR TITLE
fix(gh/release): use GITHUB_TOKEN for publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Publish release
         run: npm run release # configured in .releaserc
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }} # auth push to remote repo
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # auth push to remote repo
 
       # Push release changes to the remote.
       #


### PR DESCRIPTION
## 🎯 What does this PR do?

- [x] use the built-in `GITHUB_TOKEN` for publish step
