### PR TITLE
fix(gh/release): update "sync next" step's ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
         if: "github.ref == 'refs/heads/main'"
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN }}
           branch: refs/heads/next
         continue-on-error: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,14 +51,14 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
 
-      # Merge @latest release back to @next.
+      # Merge latest release back to next.
       #
-      - name: Sync to next
+      - name: Sync main to next
         if: "github.ref == 'refs/heads/main'"
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          branch: refs/heads/next
         continue-on-error: true
 
       # Sync docs to rdmd.readme.io


### PR DESCRIPTION
## Changes

- [x] update the "Sync to Next" release step `ref`
- [x] use a PAT for the "Sync to Next" step[^1]

[^1]: Instead of the short-lived `GITHUB_TOKEN` (~[I'd guess this will fail anyways, since `next` is a protected branch](https://github.com/readmeio/markdown/pull/1515#issuecomment-4858312391)~, but it's still technically more correct.)