### PR TITLE
fix(images): preserve captions on images in MDX

### DIFF
--- a/__tests__/transformers/readme-to-mdx.test.ts
+++ b/__tests__/transformers/readme-to-mdx.test.ts
@@ -113,6 +113,76 @@ describe('readme-to-mdx transformer', () => {
       "
     `);
   });
+
+  describe('Image', () => {
+    describe('caption', () => {
+      it('keeps a caption on a top-level Image', () => {
+        const markdown = '<Image src="https://example.com/a.png" caption="A **bold** caption" />';
+    
+        const result = mdx(mdast(markdown));
+    
+        expect(result).toMatchInlineSnapshot(`
+          "<Image src="https://example.com/a.png" caption="A **bold** caption" />
+          "
+        `);
+      });
+    
+      it('keeps a caption on an Image nested inside components', () => {
+        const markdown = `<Tabs>
+  <Tab title="One">
+    <Image src="https://example.com/a.png" caption="A caption" />
+  </Tab>
+
+  <Tab title="One"><Image src="https://example.com/a.png" caption="A caption" /></Tab>
+</Tabs>`;
+    
+        const result = mdx(mdast(markdown));
+    
+        expect(result).toMatchInlineSnapshot(`
+          "<Tabs>
+            <Tab title="One">
+              <Image src="https://example.com/a.png" caption="A caption" />
+            </Tab>
+
+            <Tab title="One">
+              <Image src="https://example.com/a.png" caption="A caption" />
+            </Tab>
+          </Tabs>
+          "
+        `);
+      });
+    
+      it('keeps both border and caption on a nested bordered Image', () => {
+        const markdown = `<Tabs>
+  <Tab title="One">
+    <Image src="https://example.com/a.png" border={true} caption="Bordered caption" />
+  </Tab>
+</Tabs>`;
+    
+        const result = mdx(mdast(markdown));
+    
+        expect(result).toMatchInlineSnapshot(`
+          "<Tabs>
+            <Tab title="One">
+              <Image border={true} src="https://example.com/a.png" caption="Bordered caption" />
+            </Tab>
+          </Tabs>
+          "
+        `);
+      });
+    
+      it('does not emit an empty Image for an empty caption', () => {
+        const markdown = '<Image src="https://example.com/a.png" caption="" />';
+    
+        const result = mdx(mdast(markdown));
+    
+        expect(result).toMatchInlineSnapshot(`
+          "![](https://example.com/a.png)
+          "
+        `);
+      });
+    });
+  })
 });
 
 describe('mdxish readme-to-mdx transformer', () => {

--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -118,9 +118,9 @@ const readmeToMdx = (): Transform => tree => {
   });
 
   visit(tree, NodeTypes.imageBlock, (image, index, parent) => {
-    // For captions, it may be parsed in the image node's children, so we need to extract it explicitly
+    // Special case for caption: Captions are parsed as children of the image node, so we need to extract them explicitly
     const captionChildren = Array.isArray(image.children) ? image.children : [];
-    // Convert the caption children to string so we can re-add it to the attributes
+    // We want to add it back to the attributes, so re-serialize it to string
     const caption = captionChildren.length ? toMarkdown({ type: 'root', children: captionChildren }).trim() : '';
     const attributes = toAttributes({ ...image, ...image.data.hProperties, ...(caption && { caption }) }, imageAttrs);
 

--- a/processor/transform/readme-to-mdx.ts
+++ b/processor/transform/readme-to-mdx.ts
@@ -5,6 +5,7 @@ import type { MdxJsxAttribute } from 'mdast-util-mdx-jsx';
 import type { Variable, HTMLBlock, Recipe } from 'types';
 
 import emojiRegex from 'emoji-regex';
+import { toMarkdown } from 'mdast-util-to-markdown';
 import { visit } from 'unist-util-visit';
 
 import { defaultIcons, themes } from '../../components/Callout';
@@ -117,7 +118,11 @@ const readmeToMdx = (): Transform => tree => {
   });
 
   visit(tree, NodeTypes.imageBlock, (image, index, parent) => {
-    const attributes = toAttributes({ ...image, ...image.data.hProperties }, imageAttrs);
+    // For captions, it may be parsed in the image node's children, so we need to extract it explicitly
+    const captionChildren = Array.isArray(image.children) ? image.children : [];
+    // Convert the caption children to string so we can re-add it to the attributes
+    const caption = captionChildren.length ? toMarkdown({ type: 'root', children: captionChildren }).trim() : '';
+    const attributes = toAttributes({ ...image, ...image.data.hProperties, ...(caption && { caption }) }, imageAttrs);
 
     if (hasExtra(attributes)) {
       parent.children.splice(index, 1, {


### PR DESCRIPTION
| 🎫 Resolve CX-3519 |
| :-----------------: |

## 🎯 What does this PR do?

There is an issue in the MDX editor where **image captions get dropped** on round-trip.

- **When:** top-level images round-trip through the working `figure` path and keep their caption, but images **nested inside another component** (`<Tabs>`/`<Callout>`/`<Accordion>`) serialize through the `image-block` visitor, which dropped it.
- **Cause:** a caption is parsed into markdown `children` (so it can render formatted), but the `image-block` serializer ignored those children, there was no path back to a `caption`.
- **Fix:** re-serialize the caption `children` back into a `caption` attribute via `toMarkdown(...)`, mirroring the existing `figure` path. Caption now round-trips at any nesting depth.

## 🧪 QA tips

Since this tests the rich mode <-> raw mode round trip, you need to test this in the readme app & locally link this branch to it.

In an MDX project, round-trip each snippet and confirm the caption is preserved.

- [ ] Top-level caption:
  ```mdx
  <Image src="https://files.readme.io/b8674d6-pizzabro.jpg" caption="A caption" />
  ```
- [ ] Nested in `<Tabs>`/`<Tab>` (core case):
  ```mdx
  <Tabs>
    <Tab title="One">
      <Image src="https://files.readme.io/b8674d6-pizzabro.jpg" caption="A caption" />
    </Tab>
  </Tabs>
  ```
- [ ] Bordered + caption keeps both:
  ```mdx
  <Image src="https://files.readme.io/b8674d6-pizzabro.jpg" border={true} caption="Bordered caption" />
  ```
- [ ] Markdown in caption renders (not literal `**`):
  ```mdx
  <Image src="https://files.readme.io/b8674d6-pizzabro.jpg" caption="A **bold** caption" />
  ```
- [ ] Empty caption stays a plain image (no broken `<Image>`):
  ```mdx
  <Image src="https://files.readme.io/b8674d6-pizzabro.jpg" caption="" />
  ```

## 📸 Screenshot or Loom

**Before (caption data is lost in the editor)**:

https://github.com/user-attachments/assets/5247dcb1-ca82-4655-9859-9ad066cf1c12

**After**:

https://github.com/user-attachments/assets/4109a424-49a9-46c6-a0c8-2ce535650dea
