### PR TITLE
fix(mdxish): allow empty lines inside export declarations

### DIFF
--- a/__tests__/lib/mdxish/exports.test.ts
+++ b/__tests__/lib/mdxish/exports.test.ts
@@ -178,6 +178,70 @@ export function isOdd(n) { return n === 0 ? false : isEven(n - 1); }
 isEven(4) = {isEven(4)}.`;
       expect(mix(md)).toContain('isEven(4) = true.');
     });
+
+    // There were cases where blank lines inside a declaration body
+    // might cause errors because the brace-balancing preprocessor
+    // escaped them
+    describe('blank lines inside declaration bodies', () => {
+      it('renders an arrow component with a blank line in its body', () => {
+        const md = `export const Foo = () => {
+  const x = "hello world";
+
+  return <div>{x}</div>;
+};
+
+<Foo />`;
+        expect(() => mdxish(md)).not.toThrow();
+        expect(renderToHtml(md)).toContain('<div>hello world</div>');
+      });
+
+      it('renders an `export function` component with a blank line in its body', () => {
+        const md = `export function Greeting() {
+
+  return <div>Hey Ho</div>;
+}
+
+<Greeting />`;
+        expect(renderToHtml(md)).toContain('<div>Hey Ho</div>');
+      });
+
+      it('tolerates multiple consecutive blank lines in a body', () => {
+        const md = `export const Foo = () => {
+  const x = "spread out";
+
+
+
+  return <div>{x}</div>;
+};
+
+<Foo />`;
+        expect(renderToHtml(md)).toContain('<div>spread out</div>');
+      });
+
+      it('resolves an exported object value declared across a blank line', () => {
+        const md = `export const config = {
+  greeting: "hi",
+
+  name: "world",
+};
+
+{config.greeting} {config.name}`;
+        expect(mix(md)).toContain('hi world');
+      });
+
+      it('renders a blank-line component nested inside a Callout', () => {
+        const md = `export const Inner = () => {
+  const label = "nested";
+
+  return <strong>{label}</strong>;
+};
+
+> 👍 Heads up
+>
+> <Inner />`;
+        expect(renderToHtml(md)).toContain('<strong>nested</strong>');
+      });
+    });
   });
 
   describe('class declarations', () => {

--- a/__tests__/transformers/preprocess-jsx-expressions.test.ts
+++ b/__tests__/transformers/preprocess-jsx-expressions.test.ts
@@ -465,6 +465,45 @@ describe('preprocessJSXExpressions', () => {
       });
     });
 
+    describe('export/import declarations', () => {
+      it('should not escape arrow-function body braces spanning a blank line', () => {
+        const content = 'export const Foo = () => {\n  const x = 1;\n\n  return <div>{x}</div>;\n};';
+        const result = preprocessJSXExpressions(content);
+
+        expect(result).toBe(content);
+        expect(() => mdxish(result)).not.toThrow();
+      });
+
+      it('should not escape `export function` body braces spanning a blank line', () => {
+        const content = 'export function Greeting() {\n\n  return <div>hi</div>;\n}';
+        const result = preprocessJSXExpressions(content);
+
+        expect(result).toBe(content);
+      });
+
+      it('should not escape an exported object literal spanning a blank line', () => {
+        const content = 'export const config = {\n  a: 1,\n\n  b: 2,\n};';
+        const result = preprocessJSXExpressions(content);
+
+        expect(result).toBe(content);
+      });
+
+      it('still escapes a stray prose brace after an export ends', () => {
+        const content = 'export const a = 1;\n\nText {\n\n}';
+        const result = preprocessJSXExpressions(content);
+
+        expect(result).toBe('export const a = 1;\n\nText \\{\n\n\\}');
+        expect(() => mdxish(result)).not.toThrow();
+      });
+
+      it('does not exempt prose that merely starts with "Export"', () => {
+        const content = 'Export this {\n\n} value';
+        const result = preprocessJSXExpressions(content);
+
+        expect(result).toBe('Export this \\{\n\n\\} value');
+      });
+    });
+
     describe('stress tests - complex real-world scenarios', () => {
       it('should handle API documentation with path parameters and blank lines', () => {
         const content = `GET /api/{version}/users

--- a/processor/transform/mdxish/preprocess-jsx-expressions.ts
+++ b/processor/transform/mdxish/preprocess-jsx-expressions.ts
@@ -53,6 +53,25 @@ function restoreHTMLElements(content: string, htmlElements: string[]): string {
   return content.replace(HTML_ELEM_PLACEHOLDER, (_m, idx) => htmlElements[parseInt(idx, 10)]);
 }
 
+const ESM_DECLARATION_START = /^(?:export|import)\b/;
+
+/**
+ * Whether a line begins a top-level `export`/`import` declaration. Its braces
+ * are valid JS owned by the mdxjsEsm tokenizer (which tolerates blank lines),
+ * so escaping them would corrupt the source and break acorn parsing.
+ */
+function startsEsmDeclaration(chars: string[], lineStart: number): boolean {
+  return ESM_DECLARATION_START.test(chars.slice(lineStart, lineStart + 7).join(''));
+}
+
+function isBlankLine(chars: string[], lineStart: number): boolean {
+  for (let i = lineStart; i < chars.length; i += 1) {
+    if (chars[i] === '\n') return true;
+    if (chars[i] !== ' ' && chars[i] !== '\t') return false;
+  }
+  return true;
+}
+
 /**
  * Escapes unbalanced and paragraph-spanning braces so MDX doesn't trip on them.
  */
@@ -69,10 +88,19 @@ function escapeProblematicBraces(content: string): string {
   const toEscape = new Set<number>();
   // Convert to array of Unicode code points so that emojis and multi-byte characters are correctly tracked
   const chars = Array.from(protectedContent);
-  const openStack: { hasBlankLine: boolean; isAttrExpr: boolean; pos: number }[] = [];
+  const openStack: { hasBlankLine: boolean; isAttrExpr: boolean; isEsmDeclaration: boolean; pos: number }[] = [];
+  // Whether the current top-level statement is an `export`/`import` declaration.
+  let insideEsmDeclaration = false;
 
   for (let i = 0; i < chars.length; i += 1) {
     const ch = chars[i];
+
+    // At a top-level (brace depth 0) line start, decide whether we're inside an
+    // ESM declaration. The flag persists across the declaration's own lines.
+    if (openStack.length === 0 && (i === 0 || chars[i - 1] === '\n')) {
+      if (startsEsmDeclaration(chars, i)) insideEsmDeclaration = true;
+      else if (isBlankLine(chars, i)) insideEsmDeclaration = false;
+    }
 
     // Track string delimiters inside expressions to ignore braces within them
     if (openStack.length > 0) {
@@ -125,11 +153,13 @@ function escapeProblematicBraces(content: string): string {
       if (!isAttrExpr && openStack.length > 0 && openStack[openStack.length - 1].isAttrExpr) {
         isAttrExpr = true;
       }
-      openStack.push({ pos: i, hasBlankLine: false, isAttrExpr });
+      openStack.push({ pos: i, hasBlankLine: false, isAttrExpr, isEsmDeclaration: insideEsmDeclaration });
       lastNewlinePos = -2;
     } else if (ch === '}') {
       if (openStack.length > 0) {
         const entry = openStack.pop()!;
+        // The declaration's braces are closed; later top-level braces are not ESM.
+        if (openStack.length === 0) insideEsmDeclaration = false;
         // Pure `{/* ... */}` comments are handled downstream by the jsxComment
         // tokenizer — escaping their braces would prevent it from running.
         const isPureJsxComment =
@@ -137,18 +167,23 @@ function escapeProblematicBraces(content: string): string {
           chars[entry.pos + 2] === '*' &&
           chars[i - 1] === '/' &&
           chars[i - 2] === '*';
-        if (entry.hasBlankLine && !isPureJsxComment && !entry.isAttrExpr) {
+        if (entry.hasBlankLine && !isPureJsxComment && !entry.isAttrExpr && !entry.isEsmDeclaration) {
           toEscape.add(entry.pos);
           toEscape.add(i);
         }
       } else {
         toEscape.add(i);
       }
+    } else if (ch === ';' && openStack.length === 0) {
+      // A top-level `;` ends the current statement, ESM or otherwise.
+      insideEsmDeclaration = false;
     }
   }
 
   // Anything still open is unbalanced.
-  openStack.forEach(entry => toEscape.add(entry.pos));
+  openStack.forEach(entry => {
+    if (!entry.isEsmDeclaration) toEscape.add(entry.pos);
+  });
 
   // Reconstruct the content with the escaped braces.
   const escapedContent = toEscape.size === 0 ? protectedContent : chars.map((ch, i) => (toEscape.has(i) ? `\\${ch}` : ch)).join('');


### PR DESCRIPTION
| 🎫 Resolve [RM-16918](https://linear.app/readme-io/issue/RM-16918/empty-lines-inside-function-throws-error) |
| :-----------------: |

## 🎯 What does this PR do?

There is an issue where declaring an `export` function/variable with an empty line inside its body throws `Could not parse import/exports with acorn` in the Mdxish pipeline (MDX handles it fine).

The root issue is the brace-balancing preprocessor (`escapeProblematicBraces`): it escapes any `{...}` pair that spans a blank line to protect markdown prose, but it had no carve-out for `export`/`import` blocks. So an export body's braces got rewritten to `\{ ... \}`, corrupting the JS before the `mdxjsEsm` tokenizer handed it to acorn.

The fix adds an ESM carve-out to that same scanner (reusing its existing string/brace state, mirroring the existing JSX-attribute and JSX-comment carve-outs): braces belonging to a top-level `export`/`import` declaration are left untouched so acorn receives valid JS.

## 🧪 QA tips

Paste each into an Mdxish doc — all should render without errors, and the ones starting with `export ... =>`/`function` should render the component output:

- [ ] Arrow component with a blank line in its body:

```mdx
export const Foo = () => {
  const x = "hello world";

  return <div>{x}</div>;
};

<Foo />
```

- [ ] `export function` with a blank line:

```mdx
export function Greeting() {

  return <div>Hey Ho</div>;
}

<Greeting />
```

- [ ] Multiple consecutive blank lines:

```mdx
export const Spaced = () => {
  const x = 1;



  return <div>{x}</div>;
};

<Spaced />
```

- [ ] Exported object value declared across a blank line:

```mdx
export const config = {
  greeting: "hi",

  name: "world",
};

{config.greeting} {config.name}
```

- [ ] Component with a blank-line body used inside a callout:

```mdx
export const Inner = () => {
  const label = "nested";

  return <strong>{label}</strong>;
};

> 👍 Heads up
>
> <Inner />
```

- [ ] Regression check — stray prose braces across a blank line still render literally (not treated as an expression):

```mdx
Text {

}
```

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
