### PR TITLE
fix(mdxish): component sharing a line with trailing text duplicates the trailing content

### DIFF
--- a/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
+++ b/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
@@ -50,6 +50,34 @@ describe('mdxishAstProcessor', () => {
     });
   });
 
+  describe('component node positions', () => {
+    // A component sharing a line with trailing content is tokenized as one html
+    // node; the node's position must end at its own closing tag, else downstream
+    // position-based source slicing over-reads and duplicates the trailing text.
+    it('ends a component node position at its closing tag when trailing content follows on the same line', () => {
+      const md =
+        '<button className="pill" style={{ backgroundColor: "#ffc107" }}>PrPr</button> ***service-explorer***: Message brokers are now surfaced as entities.';
+      const { processor, parserReadyContent } = mdxishAstProcessor(md, { newEditorTypes: true });
+      const mdast = processor.runSync(processor.parse(parserReadyContent));
+
+      // Offset 77 is the end of `</button>`; the trailing text is a separate sibling.
+      expect(mdast).toMatchObject({
+        type: 'root',
+        children: [
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'button',
+            position: {
+              start: { line: 1, column: 1, offset: 0 },
+              end: { line: 1, column: 78, offset: 77 },
+            },
+          },
+          { type: 'paragraph' },
+        ],
+      });
+    });
+  });
+
   it('should return a unified processor and parser-ready content for simple text', () => {
     const md = 'Rafe is **cool**!';
     const { processor, parserReadyContent } = mdxishAstProcessor(md);

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -469,6 +469,59 @@ hello
         ]);
       });
     });
+
+    // The whole line is tokenized into one html node when a component shares its
+    // line with trailing content. The component node's position must end at its
+    // own tag so position-based source slicing downstream doesn't over-read.
+    describe('case 4: component position ends at its tag when trailing content follows', () => {
+      it('ends a block component at its closing tag', () => {
+        const markdown = '<Tag>body</Tag> trailing text here';
+        const tree = parseWithPlugin(markdown);
+
+        expect(tree.children).toMatchObject([
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'Tag',
+            position: { start: { offset: 0 }, end: { offset: 15 } },
+          },
+          { type: 'paragraph' },
+        ]);
+        const [tag] = tree.children;
+        expect(markdown.slice(tag.position!.start.offset, tag.position!.end.offset)).toBe('<Tag>body</Tag>');
+      });
+
+      it('ends a self-closing component at its tag', () => {
+        const markdown = '<Tag attr={1} /> trailing text here';
+        const tree = parseWithPlugin(markdown);
+
+        expect(tree.children).toMatchObject([
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'Tag',
+            position: { start: { offset: 0 }, end: { offset: 16 } },
+          },
+          { type: 'paragraph' },
+        ]);
+        const [tag] = tree.children;
+        expect(markdown.slice(tag.position!.start.offset, tag.position!.end.offset)).toBe('<Tag attr={1} />');
+      });
+
+      it('ends a component with an expression attribute and inline body at its closing tag', () => {
+        const markdown = '<Tag attr={1}>**hi**</Tag> more **text** here';
+        const tree = parseWithPlugin(markdown);
+
+        expect(tree.children).toMatchObject([
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'Tag',
+            position: { start: { offset: 0 }, end: { offset: 26 } },
+          },
+          { type: 'paragraph' },
+        ]);
+        const [tag] = tree.children;
+        expect(markdown.slice(tag.position!.start.offset, tag.position!.end.offset)).toBe('<Tag attr={1}>**hi**</Tag>');
+      });
+    });
   });
 
   describe('Anchor component (inline, excluded)', () => {

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -63,6 +63,29 @@ interface ComponentNodeOptions {
   tag: string;
 }
 
+type Point = NonNullable<Node['position']>['start'];
+
+/**
+ * Advance a point by the substring of source consumed from it.
+ */
+const pointAfter = (start: Point, consumed: string): Point => {
+  const newlineIndex = consumed.lastIndexOf('\n');
+  const newlineCount = newlineIndex === -1 ? 0 : consumed.split('\n').length - 1;
+  return {
+    line: start.line + newlineCount,
+    column: newlineCount === 0 ? start.column + consumed.length : consumed.length - newlineIndex,
+    offset: start.offset + consumed.length,
+  };
+};
+
+/**
+ * Build a position ending at `consumedLength` into the html node's value, so the
+ * component doesn't claim trailing content the tokenizer swallowed into one node.
+ */
+const positionEndingAtConsumed = (nodePosition: Node['position'], value: string, consumedLength: number): Node['position'] => {
+  if (!nodePosition?.start) return nodePosition;
+  return { start: nodePosition.start, end: pointAfter(nodePosition.start, value.slice(0, consumedLength)) };
+};
 
 /**
  * Create an MdxJsxFlowElement node from component data.

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -63,6 +63,7 @@ interface ComponentNodeOptions {
   tag: string;
 }
 
+
 /**
  * Create an MdxJsxFlowElement node from component data.
  */
@@ -125,10 +126,17 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
     const value = (node as { value?: string }).value;
     if (node.type !== 'html' || typeof value !== 'string') return;
 
-    const parsed = parseTag(value.trim(), parseOpts);
+    const trimmed = value.trim();
+    const parsed = parseTag(trimmed, parseOpts);
     if (!parsed) return;
 
     const { tag, attributes, selfClosing, contentAfterTag = '' } = parsed;
+
+    // Offset of `trimmed` within the (possibly whitespace-padded) html node value,
+    // so consumed-length math maps back onto the node's real source offsets.
+    const leadingWhitespace = value.length - value.trimStart().length;
+    // Index right after the opening tag's `>` within `trimmed`.
+    const openingTagEnd = trimmed.length - contentAfterTag.length;
 
     // Skip tags that have dedicated transformers
     if (GENERIC_MDX_COMPONENT_EXCLUDED_TAGS.has(tag)) return;
@@ -156,6 +164,8 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
         attributes,
         children: [],
         startPosition: node.position,
+        // End at the self-closing tag, not at any trailing content.
+        endPosition: positionEndingAtConsumed(node.position, value, leadingWhitespace + openingTagEnd),
       });
       substituteNodeWithMdxNode(parent, index, componentNode);
 
@@ -189,6 +199,12 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
         attributes,
         children: parsedChildren,
         startPosition: node.position,
+        // End at the closing tag, not at trailing content re-parsed as siblings below.
+        endPosition: positionEndingAtConsumed(
+          node.position,
+          value,
+          leadingWhitespace + openingTagEnd + closingTagIndex + closingTagStr.length,
+        ),
       });
       substituteNodeWithMdxNode(parent, index, componentNode);
 


### PR DESCRIPTION
| 🎫 Resolve CX-3535 |
| :-----------------: |

## 🎯 What does this PR do?

- **Observed bug:** when a component shares a line with trailing text (e.g. a `<button>` followed by markdown), the text after the component gets duplicated — it renders both inside the component and again as a new paragraph in the Mdxish editor.
- **What's wrong:** the `mdx-component` tokenizer swallows the whole line into one `html` node. `mdxishMdxComponentBlocks` correctly splits the trailing text into a sibling, but it gave the component node the *whole* html node's `position` (end of line) instead of the end of its own tag. Downstream position-based source slicing then over-reads and grabs the trailing text too.
- **The fix:** compute an accurate `position.end` for the component node so it ends at its own closing (or self-closing) tag, not at the swallowed trailing content. Applies to both the self-closing and self-contained-block cases.

## 🧪 QA tips

- [ ] Locally link this branch into the `readme` repo (build `dist` and link `@readme/markdown`), then paste the example below into the Mdxish editor.
- [ ] Confirm the text after the `<button>` appears **once** (a single paragraph), not duplicated.

```
<button className="pill" style={{ backgroundColor: "#ffc107" }}>PrPr</button> ***service-explorer***: Message brokers are now surfaced as entities in the catalog list and on the service maps in APM.
```

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
