### PR TITLE
feat: export `extractToc`

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -26,6 +26,7 @@ export {
   mdxishAstProcessor,
   mdxishMdastToMd,
   mdxishTags,
+  extractToc,
   migrate,
   mix,
   plain,

--- a/lib/extractToc.ts
+++ b/lib/extractToc.ts
@@ -1,0 +1,3 @@
+import { extractToc } from '../processor/plugin/toc';
+
+export default extractToc;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,7 +11,7 @@ export { default as mdx } from './mdx';
 export { default as mix } from './mix';
 export { default as mdxish, mdxishAstProcessor, mdxishMdastToMd } from './mdxish';
 export type { MdxishOpts } from './mdxish';
-export { extractToc } from '../processor/plugin/toc';
+export { default as extractToc } from './extractToc';
 export { default as migrate } from './migrate';
 export { default as plain } from './plain';
 export { default as renderMdxish } from './renderMdxish';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,7 @@ export { default as mdx } from './mdx';
 export { default as mix } from './mix';
 export { default as mdxish, mdxishAstProcessor, mdxishMdastToMd } from './mdxish';
 export type { MdxishOpts } from './mdxish';
+export { extractToc } from '../processor/plugin/toc';
 export { default as migrate } from './migrate';
 export { default as plain } from './plain';
 export { default as renderMdxish } from './renderMdxish';


### PR DESCRIPTION
| 🎫 Resolve RM-16323 |
| :-----------------: |

## 🎯 What does this PR do?

Exports `extractToc` so we can grab the anchors of a document without rendering the full page

Required for this PR: https://github.com/readmeio/gitto/pull/2381

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ]

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
