### PR TITLE
fix: dont animate toc on init

### DIFF
--- a/components/TableOfContents/index.tsx
+++ b/components/TableOfContents/index.tsx
@@ -171,10 +171,19 @@ function useScrollHighlight(navRef: React.RefObject<HTMLElement | null>) {
     }) || headings[0];
     activate(initialHeading.id);
 
+    // Snap the active indicator to its initial position without animating, then
+    // enable transitions so only subsequent scroll updates animate. The forced
+    // reflow (reading layout) commits the snapped position as the transition
+    // baseline — otherwise enabling the transition in the same style recalc would
+    // animate it in from height 0 every time the TOC (re)mounts.
+    nav.getBoundingClientRect();
+    nav.dataset.tocReady = 'true';
+
     return () => {
       observer.disconnect();
       scrollTarget.removeEventListener('scroll', onScroll);
       nav.removeEventListener('click', onClick);
+      delete nav.dataset.tocReady;
     };
   }, [navRef, tocKey]);
 }

--- a/components/TableOfContents/style.scss
+++ b/components/TableOfContents/style.scss
@@ -19,22 +19,28 @@
       position: absolute;
       left: 0;
       top: 0;
-      transition:
-        height var(--transition-slow),
-        top var(--transition-slow);
-      transition-timing-function: var(--transition-timing);
       width: 0.154em; // 2px
     }
 
     &::before {
       background-color: var(--ToC-border-color);
       height: 100%;
+      transition: height var(--transition-slow);
+      transition-timing-function: var(--transition-timing);
     }
 
     &::after {
       background-color: var(--ToC-border-active-color);
       height: var(--ToC-border-active-height);
       top: var(--ToC-border-active-top);
+    }
+
+    // to avoid animating on page page
+    &[data-toc-ready]::after {
+      transition:
+        height var(--transition-slow),
+        top var(--transition-slow);
+      transition-timing-function: var(--transition-timing);
     }
 
     .active {


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

Right now the table of contents animates on page load:

https://github.com/user-attachments/assets/7b9f1ef5-797f-4c0c-8c65-cf906759466e


This PR prevents the initial transition when the page loads.


## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ]

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
