### PR TITLE
fix: normalize youtube url in Embed

### DIFF
--- a/__tests__/components/Embed.test.tsx
+++ b/__tests__/components/Embed.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import React from 'react';
 
 import Embed from '../../components/Embed';
-import { normalizeYouTubeUrl } from '../../components/Embed/normalizeYouTubeUrl';
+import { normalizeYouTubeUrlToEmbedUrl } from '../../components/Embed/normalizeYouTubeUrl';
 
 import { renderingEngines } from './utils';
 
@@ -38,6 +38,30 @@ describe('Embed', () => {
       expect(iframe).toHaveAttribute('src', 'https://example.com/embed');
       expect(iframe).toHaveAttribute('title', 'Demo');
       expect(iframe).toHaveStyle({ height: '480px', width: '100%' });
+    });
+
+    it('normalizes a YouTube URL in the iframe path even without typeOfEmbed="youtube"', () => {
+      const { container } = render(
+        <Embed iframe title="Demo" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" />,
+      );
+
+      expect(container.querySelector('iframe')).toHaveAttribute('src', 'https://www.youtube.com/embed/dQw4w9WgXcQ');
+    });
+
+    it('normalizes a YouTube URL when typeOfEmbed is iframe', () => {
+      const { container } = render(
+        <Embed title="Demo" typeOfEmbed="iframe" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" />,
+      );
+
+      expect(container.querySelector('iframe')).toHaveAttribute('src', 'https://www.youtube.com/embed/dQw4w9WgXcQ');
+    });
+
+    it('leaves a non-YouTube URL untouched in the iframe path', () => {
+      const { container } = render(
+        <Embed iframe title="Demo" url="https://example.com/watch?v=dQw4w9WgXcQ" />,
+      );
+
+      expect(container.querySelector('iframe')).toHaveAttribute('src', 'https://example.com/watch?v=dQw4w9WgXcQ');
     });
 
     it('renders an iframe for iframe-derivable embed types without html', () => {
@@ -93,6 +117,14 @@ describe('Embed', () => {
         expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/dQw4w9WgXcQ');
       });
 
+      it.each(renderingEngines)('%s: renders an iframe for a shorts URL', (_label, renderContent) => {
+        const Content = renderContent(youtubeEmbed('https://www.youtube.com/shorts/dQw4w9WgXcQ'));
+        const { container } = render(<Content />);
+
+        const iframe = container.querySelector('iframe');
+        expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/dQw4w9WgXcQ');
+      });
+
       it.each(renderingEngines)('%s: renders an iframe for an embed URL', (_label, renderContent) => {
         const Content = renderContent(youtubeEmbed('https://www.youtube.com/embed/dQw4w9WgXcQ'));
         const { container } = render(<Content />);
@@ -102,13 +134,14 @@ describe('Embed', () => {
       });
     });
 
-    describe('normalizeYouTubeUrl', () => {
+    describe('normalizeYouTubeUrlToEmbedUrl', () => {
       it.each([
         ['watch URL', 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'https://www.youtube.com/embed/dQw4w9WgXcQ'],
         ['youtu.be short link', 'https://youtu.be/dQw4w9WgXcQ', 'https://www.youtube.com/embed/dQw4w9WgXcQ'],
+        ['shorts URL', 'https://www.youtube.com/shorts/dQw4w9WgXcQ', 'https://www.youtube.com/embed/dQw4w9WgXcQ'],
         ['already-embeddable URL', 'https://www.youtube.com/embed/dQw4w9WgXcQ', 'https://www.youtube.com/embed/dQw4w9WgXcQ'],
       ])('converts a %s', (_label, url, expected) => {
-        expect(normalizeYouTubeUrl(url)).toBe(expected);
+        expect(normalizeYouTubeUrlToEmbedUrl(url)).toBe(expected);
       });
     
       it.each([
@@ -116,7 +149,7 @@ describe('Embed', () => {
         ['YouTube URL with no video id', 'https://www.youtube.com/feed/subscriptions'],
         ['watch URL missing the v param', 'https://www.youtube.com/watch?list=RDdQw4w9WgXcQ'],
       ])('returns the %s unchanged', (_label, url) => {
-        expect(normalizeYouTubeUrl(url)).toBe(url);
+        expect(normalizeYouTubeUrlToEmbedUrl(url)).toBe(url);
       });
     
       describe('timestamps', () => {
@@ -128,11 +161,11 @@ describe('Embed', () => {
           ['hours, minutes, and seconds via t', watch('t=1h2m3s'), embed('3723')],
           ['integer seconds via start', watch('start=42'), embed('42')],
         ])('carries %s', (_label, url, expected) => {
-          expect(normalizeYouTubeUrl(url)).toBe(expected);
+          expect(normalizeYouTubeUrlToEmbedUrl(url)).toBe(expected);
         });
     
         it('prefers start over t when both are present', () => {
-          expect(normalizeYouTubeUrl(watch('start=42&t=596s'))).toBe(embed('42'));
+          expect(normalizeYouTubeUrlToEmbedUrl(watch('start=42&t=596s'))).toBe(embed('42'));
         });
     
         it.each([
@@ -140,7 +173,7 @@ describe('Embed', () => {
           ['a non-numeric timestamp', watch('t=abc')],
           ['no timestamp', 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'],
         ])('omits start for %s', (_label, url) => {
-          expect(normalizeYouTubeUrl(url)).toBe('https://www.youtube.com/embed/dQw4w9WgXcQ');
+          expect(normalizeYouTubeUrlToEmbedUrl(url)).toBe('https://www.youtube.com/embed/dQw4w9WgXcQ');
         });
       });
     });

--- a/__tests__/components/Embed.test.tsx
+++ b/__tests__/components/Embed.test.tsx
@@ -1,0 +1,148 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import Embed from '../../components/Embed';
+import { normalizeYouTubeUrl } from '../../components/Embed/normalizeYouTubeUrl';
+
+import { renderingEngines } from './utils';
+
+const youtubeEmbed = (url: string) => `<Embed title="" typeOfEmbed="youtube" url="${url}" />`;
+
+describe('Embed', () => {
+  describe('general component rendering', () => {
+    it('renders a link embed with title, image, and provider', () => {
+      const { container } = render(
+        <Embed
+          favicon="https://example.com/favicon.ico"
+          image="https://example.com/preview.jpg"
+          title="Example Article"
+          url="https://example.com/article"
+        />,
+      );
+
+      const link = container.querySelector('a.embed-link');
+      expect(link).toHaveAttribute('href', 'https://example.com/article');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(container.querySelector('.embed-title')).toHaveTextContent('Example Article');
+      expect(container.querySelector('.embed-img')).toHaveAttribute('src', 'https://example.com/preview.jpg');
+      expect(container.querySelector('.embed-provider')).toHaveTextContent('example.com');
+    });
+
+    it('renders an iframe when iframe is true', () => {
+      const { container } = render(
+        <Embed iframe title="Demo" url="https://example.com/embed" />,
+      );
+
+      const iframe = container.querySelector('iframe');
+      expect(iframe).toHaveAttribute('src', 'https://example.com/embed');
+      expect(iframe).toHaveAttribute('title', 'Demo');
+      expect(iframe).toHaveStyle({ height: '480px', width: '100%' });
+    });
+
+    it('renders an iframe for iframe-derivable embed types without html', () => {
+      const { container } = render(
+        <Embed title="" typeOfEmbed="pdf" url="https://example.com/doc.pdf" />,
+      );
+
+      expect(container.querySelector('iframe')).toHaveAttribute('src', 'https://example.com/doc.pdf');
+    });
+
+    it('renders provided html inside embed-media', () => {
+      const { container } = render(
+        <Embed html="<iframe title='Map'></iframe>" title="Map" url="https://example.com/map" />,
+      );
+
+      expect(container.querySelector('.embed-media iframe')).toHaveAttribute('title', 'Map');
+    });
+
+    it('renders a fallback view link when the title is @embed', () => {
+      const { container } = render(
+        <Embed title="@embed" url="https://gist.github.com/foo/abc123" />,
+      );
+
+      expect(container.querySelector('.embed-body-url')).toHaveTextContent('https://gist.github.com/foo/abc123');
+      expect(container.querySelector('.embed-title')).toBeNull();
+    });
+
+    it('renders a link for non-iframe-derivable embed types', () => {
+      const { container } = render(
+        <Embed title="" typeOfEmbed="github" url="https://gist.github.com/foo/abc123" />,
+      );
+
+      expect(container.querySelector('a.embed-link')).toHaveAttribute('href', 'https://gist.github.com/foo/abc123');
+      expect(container.querySelector('iframe')).toBeNull();
+    });
+  });
+
+  describe('YouTube', () => {
+    describe('embeds a youtube url', () => {
+      it.each(renderingEngines)('%s: renders an iframe for a watch URL', (_label, renderContent) => {
+        const Content = renderContent(youtubeEmbed('https://www.youtube.com/watch?v=dQw4w9WgXcQ'));
+        const { container } = render(<Content />);
+
+        const iframe = container.querySelector('iframe');
+        expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/dQw4w9WgXcQ');
+      });
+
+      it.each(renderingEngines)('%s: renders an iframe for a youtu.be short link', (_label, renderContent) => {
+        const Content = renderContent(youtubeEmbed('https://youtu.be/dQw4w9WgXcQ'));
+        const { container } = render(<Content />);
+
+        const iframe = container.querySelector('iframe');
+        expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/dQw4w9WgXcQ');
+      });
+
+      it.each(renderingEngines)('%s: renders an iframe for an embed URL', (_label, renderContent) => {
+        const Content = renderContent(youtubeEmbed('https://www.youtube.com/embed/dQw4w9WgXcQ'));
+        const { container } = render(<Content />);
+
+        const iframe = container.querySelector('iframe');
+        expect(iframe).toHaveAttribute('src', 'https://www.youtube.com/embed/dQw4w9WgXcQ');
+      });
+    });
+
+    describe('normalizeYouTubeUrl', () => {
+      it.each([
+        ['watch URL', 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', 'https://www.youtube.com/embed/dQw4w9WgXcQ'],
+        ['youtu.be short link', 'https://youtu.be/dQw4w9WgXcQ', 'https://www.youtube.com/embed/dQw4w9WgXcQ'],
+        ['already-embeddable URL', 'https://www.youtube.com/embed/dQw4w9WgXcQ', 'https://www.youtube.com/embed/dQw4w9WgXcQ'],
+      ])('converts a %s', (_label, url, expected) => {
+        expect(normalizeYouTubeUrl(url)).toBe(expected);
+      });
+    
+      it.each([
+        ['non-URL input', 'not a url'],
+        ['YouTube URL with no video id', 'https://www.youtube.com/feed/subscriptions'],
+        ['watch URL missing the v param', 'https://www.youtube.com/watch?list=RDdQw4w9WgXcQ'],
+      ])('returns the %s unchanged', (_label, url) => {
+        expect(normalizeYouTubeUrl(url)).toBe(url);
+      });
+    
+      describe('timestamps', () => {
+        const watch = (timestamp: string) => `https://www.youtube.com/watch?v=dQw4w9WgXcQ&${timestamp}`;
+        const embed = (start: string) => `https://www.youtube.com/embed/dQw4w9WgXcQ?start=${start}`;
+    
+        it.each([
+          ['plain seconds via t', watch('t=90'), embed('90')],
+          ['hours, minutes, and seconds via t', watch('t=1h2m3s'), embed('3723')],
+          ['integer seconds via start', watch('start=42'), embed('42')],
+        ])('carries %s', (_label, url, expected) => {
+          expect(normalizeYouTubeUrl(url)).toBe(expected);
+        });
+    
+        it('prefers start over t when both are present', () => {
+          expect(normalizeYouTubeUrl(watch('start=42&t=596s'))).toBe(embed('42'));
+        });
+    
+        it.each([
+          ['a zero timestamp', watch('t=0s')],
+          ['a non-numeric timestamp', watch('t=abc')],
+          ['no timestamp', 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'],
+        ])('omits start for %s', (_label, url) => {
+          expect(normalizeYouTubeUrl(url)).toBe('https://www.youtube.com/embed/dQw4w9WgXcQ');
+        });
+      });
+    });
+  });
+});

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -89,7 +89,7 @@ exports[`Render engine regressions tests > divergent (mdxish) 1`] = `
 exports[`Render engine regressions tests > embeds (mdx) 1`] = `
 "<h1 class="heading heading-1 header-scroll"><div class="heading-anchor anchor waypoint" id="embeds"></div><div class="heading-text">Embeds</div><a aria-label="Skip link to Embeds" class="heading-anchor-icon fa fa-regular fa-anchor" href="#embeds"></a></h1>
 <iframe src="https://example.com/embed" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe>
-<iframe src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe>
+<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe>
 <iframe src="https://example.com/doc.pdf" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe>
 <iframe src="https://jsfiddle.net/example" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe>"
 `;
@@ -97,7 +97,7 @@ exports[`Render engine regressions tests > embeds (mdx) 1`] = `
 exports[`Render engine regressions tests > embeds (mdxish) 1`] = `
 "<h1 class="heading heading-1 header-scroll"><div class="heading-anchor anchor waypoint" id="embeds"></div><div class="heading-text">Embeds</div><a aria-label="Skip link to Embeds" class="heading-anchor-icon fa fa-regular fa-anchor" href="#embeds"></a></h1>
 <div class="readme-tailwind"><iframe src="https://example.com/embed" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe></div>
-<div class="readme-tailwind"><iframe src="https://www.youtube.com/watch?v=dQw4w9WgXcQ" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe></div>
+<div class="readme-tailwind"><iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe></div>
 <div class="readme-tailwind"><iframe src="https://example.com/doc.pdf" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe></div>
 <div class="readme-tailwind"><iframe src="https://jsfiddle.net/example" style="border:none;display:flex;margin:auto;width:100%;height:480px"></iframe></div>"
 `;

--- a/components/Embed/index.tsx
+++ b/components/Embed/index.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 
-import { normalizeYouTubeUrl } from './normalizeYouTubeUrl';
+import { normalizeYouTubeUrlToEmbedUrl } from './normalizeYouTubeUrl';
 
 interface FaviconProps {
   alt?: string;
@@ -74,7 +74,7 @@ const Embed = ({
     !html && !explicitOptOut && url && typeOfEmbed && IFRAME_DERIVABLE_TYPES.has(typeOfEmbed);
 
   if (iframe || renderTypeAsIframe) {
-    const src = typeOfEmbed === 'youtube' ? normalizeYouTubeUrl(url) : url;
+    const src = normalizeYouTubeUrlToEmbedUrl(url);
     return <iframe {...spreadAttrs} src={src} style={iframeStyle} title={title} />;
   }
 

--- a/components/Embed/index.tsx
+++ b/components/Embed/index.tsx
@@ -2,6 +2,8 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
 
+import { normalizeYouTubeUrl } from './normalizeYouTubeUrl';
+
 interface FaviconProps {
   alt?: string;
   src: string;
@@ -72,7 +74,8 @@ const Embed = ({
     !html && !explicitOptOut && url && typeOfEmbed && IFRAME_DERIVABLE_TYPES.has(typeOfEmbed);
 
   if (iframe || renderTypeAsIframe) {
-    return <iframe {...spreadAttrs} src={url} style={iframeStyle} title={title} />;
+    const src = typeOfEmbed === 'youtube' ? normalizeYouTubeUrl(url) : url;
+    return <iframe {...spreadAttrs} src={src} style={iframeStyle} title={title} />;
   }
 
   if (!providerUrl && url)

--- a/components/Embed/normalizeYouTubeUrl.ts
+++ b/components/Embed/normalizeYouTubeUrl.ts
@@ -1,0 +1,38 @@
+// YouTube watch/share URLs (youtube.com/watch?v=ID, youtu.be/ID) set X-Frame-Options
+// and refuse to be framed. The player only allows embedding via youtube.com/embed/ID.
+const YOUTUBE_HOSTS = new Set(['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be', 'www.youtu.be']);
+
+// /embed/ accepts `start` (integer seconds), not the watch-page `t` value which may carry units (e.g. 596s, 1h2m3s).
+const toStartSeconds = (timestamp: string): string | null => {
+  const [, hours, minutes, seconds] = timestamp.match(/^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s?)?$/) ?? [];
+  const total = (Number(hours) || 0) * 3600 + (Number(minutes) || 0) * 60 + (Number(seconds) || 0);
+  return total > 0 ? String(total) : null;
+};
+
+const extractVideoId = (parsed: URL): string | null => {
+  if (parsed.hostname.endsWith('youtu.be')) return parsed.pathname.slice(1).split('/')[0] || null;
+  if (parsed.pathname.startsWith('/watch')) return parsed.searchParams.get('v');
+  return null;
+};
+
+export const normalizeYouTubeUrl = (url: string): string => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  if (!YOUTUBE_HOSTS.has(parsed.hostname)) return url;
+  if (parsed.pathname.startsWith('/embed/')) return url;
+
+  const videoId = extractVideoId(parsed);
+  if (!videoId) return url;
+
+  const embed = new URL(`https://www.youtube.com/embed/${videoId}`);
+  const timestamp = parsed.searchParams.get('start') || parsed.searchParams.get('t');
+  const start = timestamp ? toStartSeconds(timestamp) : null;
+  if (start) embed.searchParams.set('start', start);
+
+  return embed.toString();
+};

--- a/components/Embed/normalizeYouTubeUrl.ts
+++ b/components/Embed/normalizeYouTubeUrl.ts
@@ -1,6 +1,6 @@
 // YouTube watch/share URLs (youtube.com/watch?v=ID, youtu.be/ID) set X-Frame-Options
 // and refuse to be framed. The player only allows embedding via youtube.com/embed/ID.
-const YOUTUBE_HOSTS = new Set(['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be', 'www.youtu.be']);
+const YOUTUBE_HOSTS = new Set(['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be', 'www.youtu.be', 'm.youtu.be']);
 
 // /embed/ accepts `start` (integer seconds), not the watch-page `t` value which may carry units (e.g. 596s, 1h2m3s).
 const toStartSeconds = (timestamp: string): string | null => {
@@ -12,10 +12,13 @@ const toStartSeconds = (timestamp: string): string | null => {
 const extractVideoId = (parsed: URL): string | null => {
   if (parsed.hostname.endsWith('youtu.be')) return parsed.pathname.slice(1).split('/')[0] || null;
   if (parsed.pathname.startsWith('/watch')) return parsed.searchParams.get('v');
+  if (parsed.pathname.startsWith('/shorts/')) return parsed.pathname.slice('/shorts/'.length).split('/')[0] || null;
   return null;
 };
 
-export const normalizeYouTubeUrl = (url: string): string => {
+// Most youtube links we get from the browser are watch URLs, like https://www.youtube.com/watch?v=dQw4w9WgXcQ
+// These /watch URLs won't work in an iframe, so we need to convert them to the embed URL if iframe is used
+export const normalizeYouTubeUrlToEmbedUrl = (url: string): string => {
   let parsed: URL;
   try {
     parsed = new URL(url);


### PR DESCRIPTION
| 🎫 Resolve RM-17012 |
| :-----------------: |

## 🎯 What does this PR do?

YouTube watch/share URLs like `youtube.com/watch?v=dQw4w9WgXcQ` set `X-Frame-Options` and doesn't render on view if an `<iframe>` is used to render it, while our Embed component might use that. Since the watch/ URL is the most common form people use, it might be worth normalising them to embed links that works with iframe.

```md
<Embed title="" typeOfEmbed="youtube" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" />
<Embed title="" typeOfEmbed="youtube" url="https://youtu.be/dQw4w9WgXcQ" />
<Embed title="" typeOfEmbed="youtube" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=1h2m3s" />
```
The normalizer would convert them to `<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ">` (the last with `?start=3723`) which works. Already-embeddable and non-YouTube URLs pass through untouched.

## 🧪 QA tips

Paste these into a doc and verify each renders as noted.

- Normalized to /embed/ (iframe renders and plays):

```
  <Embed title="" typeOfEmbed="youtube" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" />
  <Embed title="" typeOfEmbed="youtube" url="https://youtu.be/dQw4w9WgXcQ" />
  <Embed title="" typeOfEmbed="youtube" url="https://m.youtu.be/dQw4w9WgXcQ" />
  <Embed title="" typeOfEmbed="youtube" url="https://www.youtube.com/shorts/dQw4w9WgXcQ" />
```

- Iframe path without typeOfEmbed="youtube" — still normalizes:

```
  <Embed title="" iframe url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" />
  <Embed title="" typeOfEmbed="iframe" url="https://www.youtube.com/watch?v=dQw4w9WgXcQ" />
```

- Pass through untouched (already embeddable):

```
  <Embed title="" typeOfEmbed="youtube" url="https://www.youtube.com/embed/dQw4w9WgXcQ" />
```

## 📸 Screenshot or Loom

Before:

<img width="1571" height="908" alt="Screenshot 2026-07-01 at 12 35 42 pm" src="https://github.com/user-attachments/assets/8ec3b5d2-011b-4bb4-aee1-d63d0034668b" />

After:

<img width="1568" height="835" alt="Screenshot 2026-07-01 at 12 36 06 pm" src="https://github.com/user-attachments/assets/ce912597-b313-47b7-8fbf-2f19e8fc7747" />
