### PR TITLE
fix(mdxish): inline Anchor/Glossary with expression attrs render as plain text

### DIFF
--- a/__tests__/lib/mdxish/mdxish.test.ts
+++ b/__tests__/lib/mdxish/mdxish.test.ts
@@ -612,7 +612,6 @@ describe('html tags rendering', () => {
       });
     });
 
-
     it('should render an Anchor whose href is a concatenation expression', () => {
       const md =
         "<Anchor label=\"Docs\" target=\"_blank\" href={'https://' + user.docsUrl + '/x'}>Docs</Anchor>.";

--- a/__tests__/lib/mdxish/mdxish.test.ts
+++ b/__tests__/lib/mdxish/mdxish.test.ts
@@ -596,8 +596,23 @@ describe('html tags rendering', () => {
   });
 
   describe('inline components with expression attributes', () => {
-    // Regression: spaces/quotes inside `href={...}` made CommonMark reject the
-    // tag, so the whole <Anchor> leaked as literal text and swallowed `</Anchor>`.
+    it('should concatenate expression attributes', () => {
+      const md = "<Anchor label=\"Merchant Sign-Up API Documentation\" target=\"_blank\" href={'https://' + 'www.example.com' + '/reference/sign-up-api'}>Link</Anchor>";
+      const tree = mdxish(md, { newEditorTypes: true });
+      const anchor = findElementByTagName(tree, 'Anchor');
+      expect(anchor).toMatchObject({
+        type: 'element',
+        tagName: 'Anchor',
+        properties: {
+          label: 'Merchant Sign-Up API Documentation',
+          target: '_blank',
+          href: 'https://www.example.com/reference/sign-up-api',
+        },
+        children: [{ type: 'text', value: 'Link' }],
+      });
+    });
+
+
     it('should render an Anchor whose href is a concatenation expression', () => {
       const md =
         "<Anchor label=\"Docs\" target=\"_blank\" href={'https://' + user.docsUrl + '/x'}>Docs</Anchor>.";
@@ -616,11 +631,19 @@ describe('html tags rendering', () => {
     });
 
     it('should keep trailing text after the closing tag as a sibling', () => {
-      const md = "<Anchor href={'a' + 'b'}>Link</Anchor> done.";
+      const md = "Start <Anchor href={'a' + 'b'}>Link</Anchor> done.";
       const tree = mdxish(md, { newEditorTypes: true });
       const paragraph = tree.children[0] as Element;
-      const [anchor, trailing] = paragraph.children;
-      expect((anchor as Element).tagName).toBe('Anchor');
+      const [start, anchor, trailing] = paragraph.children;
+      expect(start).toMatchObject({ type: 'text', value: 'Start ' });
+      expect(anchor).toMatchObject({
+        type: 'element',
+        tagName: 'Anchor',
+        properties: {
+          href: 'ab',
+        },
+        children: [{ type: 'text', value: 'Link' }],
+      });
       expect(trailing).toMatchObject({ type: 'text', value: ' done.' });
     });
   });

--- a/__tests__/lib/mdxish/mdxish.test.ts
+++ b/__tests__/lib/mdxish/mdxish.test.ts
@@ -594,4 +594,34 @@ describe('html tags rendering', () => {
       children: [{ type: 'text', value: 'Example' }],
     });
   });
+
+  describe('inline components with expression attributes', () => {
+    // Regression: spaces/quotes inside `href={...}` made CommonMark reject the
+    // tag, so the whole <Anchor> leaked as literal text and swallowed `</Anchor>`.
+    it('should render an Anchor whose href is a concatenation expression', () => {
+      const md =
+        "<Anchor label=\"Docs\" target=\"_blank\" href={'https://' + user.docsUrl + '/x'}>Docs</Anchor>.";
+      const tree = mdxish(md, { newEditorTypes: true });
+      const anchor = findElementByTagName(tree, 'Anchor');
+      expect(anchor).toMatchObject({
+        type: 'element',
+        tagName: 'Anchor',
+        properties: {
+          label: 'Docs',
+          target: '_blank',
+          href: "'https://' + user.docsUrl + '/x'",
+        },
+        children: [{ type: 'text', value: 'Docs' }],
+      });
+    });
+
+    it('should keep trailing text after the closing tag as a sibling', () => {
+      const md = "<Anchor href={'a' + 'b'}>Link</Anchor> done.";
+      const tree = mdxish(md, { newEditorTypes: true });
+      const paragraph = tree.children[0] as Element;
+      const [anchor, trailing] = paragraph.children;
+      expect((anchor as Element).tagName).toBe('Anchor');
+      expect(trailing).toMatchObject({ type: 'text', value: ' done.' });
+    });
+  });
 });

--- a/__tests__/transformers/mdx-inline-html.test.ts
+++ b/__tests__/transformers/mdx-inline-html.test.ts
@@ -56,6 +56,48 @@ describe('inline HTML with expression attributes transformation to MDX text', ()
     expect(collectNodes<MdxJsxTextElement>(tree, 'mdxJsxTextElement')).toHaveLength(0);
   });
 
+  it('promotes inline Anchor with a concatenation-expression attr to mdxJsxTextElement', () => {
+    // Quotes/spaces inside the braces make CommonMark reject the tag as inline
+    // HTML, so the mdxComponent text tokenizer must claim it instead.
+    const tree = parse("<Anchor target=\"_blank\" href={'https://' + user.docsUrl + '/x'}>Docs</Anchor>.");
+    const [inline] = collectNodes<MdxJsxTextElement>(tree, 'mdxJsxTextElement');
+    expect(inline).toMatchObject({
+      type: 'mdxJsxTextElement',
+      name: 'Anchor',
+      attributes: [
+        { type: 'mdxJsxAttribute', name: 'target', value: '_blank' },
+        {
+          type: 'mdxJsxAttribute',
+          name: 'href',
+          value: { type: 'mdxJsxAttributeValueExpression', value: "'https://' + user.docsUrl + '/x'" },
+        },
+      ],
+      children: [{ type: 'text', value: 'Docs' }],
+    });
+  });
+
+  it('promotes inline Glossary with a template-literal expression attr', () => {
+    // eslint-disable-next-line no-template-curly-in-string
+    const tree = parse('<Glossary term={`a${b}c`}>word</Glossary>');
+    const [inline] = collectNodes<MdxJsxTextElement>(tree, 'mdxJsxTextElement');
+    expect(inline).toMatchObject({
+      type: 'mdxJsxTextElement',
+      name: 'Glossary',
+      attributes: [
+        // eslint-disable-next-line no-template-curly-in-string
+        { type: 'mdxJsxAttribute', name: 'term', value: { type: 'mdxJsxAttributeValueExpression', value: '`a${b}c`' } },
+      ],
+      children: [{ type: 'text', value: 'word' }],
+    });
+  });
+
+  it('leaves inline Anchor without expression attrs for the CommonMark path', () => {
+    // Plain `<Anchor href="x">` stays an html node so the existing inline-mdx
+    // merge path (and rehype-raw) handle it — the tokenizer must not claim it.
+    const tree = parse('<Anchor href="https://example.com">Link</Anchor>');
+    expect(collectNodes<MdxJsxTextElement>(tree, 'mdxJsxTextElement')).toHaveLength(0);
+  });
+
   it('does not touch inline PascalCase components — mdxishComponentBlocks owns them', () => {
     // PascalCase is flow-level by design; it becomes `mdxJsxFlowElement` via
     // the block transformer even when authored inline, so the inline pass

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -56,11 +56,12 @@ const mdxComponentTextConstruct: Construct = {
  * lowercase HTML tags that carry at least one `{…}` attribute expression.
  * Multi-line, concrete, `afterClose` consumes the rest of the line.
  *
- * **Text** — runs inside paragraphs / inline context. Claims *only* lowercase
- * tags with brace attributes (PascalCase is intentionally flow-only, matching
- * how ReadMe's custom components are authored). Aborts on line endings (inline
- * constructs don't span lines) and exits immediately after `</tag>` so the
- * paragraph's inline parser picks up the trailing text.
+ * **Text** — runs inside paragraphs / inline context. Claims lowercase tags and
+ * inline PascalCase components (`INLINE_COMPONENT_TAGS` — Anchor, Glossary), both
+ * gated on at least one `{…}` brace attribute. All other PascalCase stays
+ * flow-only, matching how ReadMe's custom components are authored. Aborts on line
+ * endings (inline constructs don't span lines) and exits immediately after
+ * `</tag>` so the paragraph's inline parser picks up the trailing text.
  */
 function createTokenize(mode: 'flow' | 'text') {
   const isFlow = mode === 'flow';
@@ -73,8 +74,9 @@ function createTokenize(mode: 'flow' | 'text') {
     let closingTagName = '';
     // For lowercase tags we only want to claim the block if it uses JSX
     // attribute expression syntax (`attr={...}`). Plain HTML should fall
-    // through to CommonMark html-flow. Uppercase tags are always claimed
-    // (flow only — PascalCase is not accepted in text mode).
+    // through to CommonMark html-flow. Flow mode claims any PascalCase block
+    // component; text mode claims only inline PascalCase components
+    // (INLINE_COMPONENT_TAGS — Anchor, Glossary), also brace-gated.
     let isLowercaseTag = false;
     let sawBraceAttr = false;
 
@@ -312,14 +314,17 @@ function createTokenize(mode: 'flow' | 'text') {
         return tagNameRest;
       }
 
-      // Tag name complete — check exclusions. Text mode is the only path that
-      // claims inline PascalCase components (Anchor, Glossary), so it bypasses
-      // the dedicated-tokenizer exclusion for those; every other case honors it.
-      if (!isFlow && !isLowercaseTag) {
-        if (!INLINE_COMPONENT_TAGS.has(tagName)) return nok(code);
-      } else if (TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS.has(tagName)) {
-        return nok(code);
-      }
+      // Tag name complete — decide whether this tokenizer claims the tag.
+      // Three cases: lowercase tags are always candidates (brace-gated later in
+      // `afterOpenTagName`); flow-mode PascalCase claims any block component
+      // except those with a dedicated tokenizer; text-mode PascalCase claims
+      // only inline components (Anchor, Glossary).
+      const claimable = isLowercaseTag
+        ? true
+        : isFlow
+          ? !TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS.has(tagName)
+          : INLINE_COMPONENT_TAGS.has(tagName);
+      if (!claimable) return nok(code);
 
       depth = 1;
       return afterOpenTagName(code);
@@ -330,6 +335,11 @@ function createTokenize(mode: 'flow' | 'text') {
     function afterOpenTagName(code: Code): State | undefined {
       if (code === null) return nok(code);
 
+      // Everything except a flow-mode PascalCase block component must carry a
+      // `{…}` brace attribute to be claimed; plain HTML falls through to
+      // CommonMark.
+      const requiresBraceAttr = isLowercaseTag || !isFlow;
+
       if (markdownLineEnding(code)) {
         if (!isFlow) return nok(code);
         effects.exit('mdxComponentData');
@@ -338,14 +348,14 @@ function createTokenize(mode: 'flow' | 'text') {
 
       // Self-closing />
       if (code === codes.slash) {
-        if ((isLowercaseTag || !isFlow) && !sawBraceAttr) return nok(code);
+        if (requiresBraceAttr && !sawBraceAttr) return nok(code);
         effects.consume(code);
         return selfCloseGt;
       }
 
       // End of opening tag
       if (code === codes.greaterThan) {
-        if ((isLowercaseTag || !isFlow) && !sawBraceAttr) return nok(code);
+        if (requiresBraceAttr && !sawBraceAttr) return nok(code);
         effects.consume(code);
         onOpenerLine = isFlow;
         return body;
@@ -843,12 +853,13 @@ function tokenizeNonLazyContinuationStart(this: TokenizeContext, effects: Effect
  * self-closing `<Component />`). Prevents CommonMark from fragmenting them
  * across multiple HTML / paragraph nodes.
  *
- * **Text (inline)** — registers only for lowercase tags with brace attrs
- * (e.g. `Start <a href={url}>here</a> end`). Picks them up during inline
- * parsing so they render inline inside their paragraph, then are rewritten
- * to `mdxJsxTextElement` by the `components/inline-html` transformer.
- * PascalCase is intentionally flow-only; ReadMe's custom components are
- * authored as block-level elements.
+ * **Text (inline)** — registers for lowercase tags and inline PascalCase
+ * components (Anchor, Glossary) that carry brace attrs (e.g.
+ * `Start <a href={url}>here</a> end`, `<Anchor href={url}>x</Anchor>`). Picks
+ * them up during inline parsing so they render inline inside their paragraph,
+ * then are rewritten to `mdxJsxTextElement` by the `components/inline-html`
+ * transformer. All other PascalCase is flow-only; ReadMe's custom components
+ * are authored as block-level elements.
  *
  * Excludes tags handled by dedicated tokenizers: Table, HTMLBlock, Glossary,
  * Anchor.

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -4,7 +4,7 @@ import type { Code, Construct, Effects, Extension, Resolver, State, TokenizeCont
 import { markdownLineEnding } from 'micromark-util-character';
 import { codes, types } from 'micromark-util-symbol';
 
-import { TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
+import { INLINE_COMPONENT_TAGS, TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
 
 declare module 'micromark-util-types' {
   interface TokenTypeMap {
@@ -275,12 +275,13 @@ function createTokenize(mode: 'flow' | 'text') {
     // ── Tag name parsing ───────────────────────────────────────────────────
 
     function tagNameFirst(code: Code): State | undefined {
-      // Uppercase A-Z → PascalCase MDX component. Flow-only — PascalCase
-      // components are block elements in ReadMe's authoring model.
+      // Uppercase A-Z → PascalCase MDX component. Flow mode claims block
+      // components; text mode only claims inline components (Anchor, Glossary),
+      // which is enforced once the full name is known in `tagNameRest`.
       if (code !== null && code >= codes.uppercaseA && code <= codes.uppercaseZ) {
-        if (!isFlow) return nok(code);
         tagName = String.fromCharCode(code);
         isLowercaseTag = false;
+        sawBraceAttr = false;
         effects.consume(code);
         return tagNameRest;
       }
@@ -311,8 +312,12 @@ function createTokenize(mode: 'flow' | 'text') {
         return tagNameRest;
       }
 
-      // Tag name complete — check exclusions
-      if (TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS.has(tagName)) {
+      // Tag name complete — check exclusions. Text mode is the only path that
+      // claims inline PascalCase components (Anchor, Glossary), so it bypasses
+      // the dedicated-tokenizer exclusion for those; every other case honors it.
+      if (!isFlow && !isLowercaseTag) {
+        if (!INLINE_COMPONENT_TAGS.has(tagName)) return nok(code);
+      } else if (TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS.has(tagName)) {
         return nok(code);
       }
 
@@ -333,14 +338,14 @@ function createTokenize(mode: 'flow' | 'text') {
 
       // Self-closing />
       if (code === codes.slash) {
-        if (isLowercaseTag && !sawBraceAttr) return nok(code);
+        if ((isLowercaseTag || !isFlow) && !sawBraceAttr) return nok(code);
         effects.consume(code);
         return selfCloseGt;
       }
 
       // End of opening tag
       if (code === codes.greaterThan) {
-        if (isLowercaseTag && !sawBraceAttr) return nok(code);
+        if ((isLowercaseTag || !isFlow) && !sawBraceAttr) return nok(code);
         effects.consume(code);
         onOpenerLine = isFlow;
         return body;

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
       },
       {
         "path": "dist/main.node.js",
-        "maxSize": "950KB"
+        "maxSize": "955KB"
       }
     ]
   },

--- a/processor/transform/mdxish/components/inline-html.ts
+++ b/processor/transform/mdxish/components/inline-html.ts
@@ -25,12 +25,12 @@ const parsePhrasingChildren = (value: string, safeMode: boolean): PhrasingConten
 };
 
 /**
- * Attempt to promote a lowercase inline `html` node to an
- * `mdxJsxTextElement`. Scope is deliberately narrow: only lowercase tags
- * carrying `{…}` attribute expressions (what the `mdxComponent` text
- * tokenizer claims). PascalCase components — even when inline — stay with
- * `mdxishComponentBlocks` so they remain `mdxJsxFlowElement`, matching
- * ReadMe's flow-level component authoring model.
+ * Attempt to promote an inline `html` node to an `mdxJsxTextElement`. Scope
+ * mirrors what the `mdxComponent` text tokenizer claims: lowercase tags and
+ * inline PascalCase components (`INLINE_COMPONENT_TAGS` — Anchor, Glossary),
+ * both carrying `{…}` attribute expressions. All other PascalCase components
+ * stay with `mdxishComponentBlocks` so they remain `mdxJsxFlowElement`,
+ * matching ReadMe's flow-level component authoring model.
  *
  * Returns the original node unchanged when it doesn't qualify.
  */
@@ -69,14 +69,15 @@ const promoteInlineHtml = (node: Html, parseOpts: ParseAttributesOptions, safeMo
  * Runs after `mdxishComponentBlocks`, which skips paragraph-parented html
  * nodes and leaves them for this pass. Two producers put html nodes inside
  * paragraphs:
- *   1. The `mdxComponent` text tokenizer, for lowercase tags with `{…}`
- *      attribute expressions (e.g. `<a href={url}>here</a>`).
+ *   1. The `mdxComponent` text tokenizer, for lowercase tags and inline
+ *      PascalCase components (Anchor, Glossary) with `{…}` attribute
+ *      expressions (e.g. `<a href={url}>here</a>`, `<Anchor href={url}>x</Anchor>`).
  *   2. CommonMark's built-in html-text tokenizer, for PascalCase components
  *      (e.g. a single html node for self-closing `<C />`).
  *
- * Eligibility mirrors `mdxishComponentBlocks`: lowercase tags only promote
- * when they carry an expression attribute; plain inline HTML like
- * `<a href="x">` stays as an html node for rehype-raw.
+ * Eligibility mirrors `mdxishComponentBlocks`: a tag only promotes when it
+ * carries an expression attribute and isn't a non-inline PascalCase component;
+ * plain inline HTML like `<a href="x">` stays as an html node for rehype-raw.
  */
 const mdxishInlineMdxHtmlBlocks: Plugin<[{ safeMode?: boolean }?], Root> = (opts = {}) => tree => {
   const safeMode = !!opts.safeMode;

--- a/processor/transform/mdxish/components/inline-html.ts
+++ b/processor/transform/mdxish/components/inline-html.ts
@@ -3,7 +3,7 @@ import type { Plugin } from 'unified';
 
 import { visit } from 'unist-util-visit';
 
-import { GENERIC_MDX_COMPONENT_EXCLUDED_TAGS } from '../../../../lib/constants';
+import { INLINE_COMPONENT_TAGS } from '../../../../lib/constants';
 import { type ParseAttributesOptions, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
 
 import { getInlineMdProcessor, hasExpressionAttr, isPascalCase, toMdxJsxTextElement } from './utils';
@@ -40,12 +40,11 @@ const promoteInlineHtml = (node: Html, parseOpts: ParseAttributesOptions, safeMo
 
   const { tag, attributes, selfClosing, contentAfterTag = '' } = parsed;
 
-  // PascalCase stays flow-level; handled by mdxishComponentBlocks.
-  if (isPascalCase(tag)) return node;
-
-  // Dedicated tokenizers (Table, HTMLBlock, Glossary, Anchor) handle their
-  // own tags — don't hijack them here.
-  if (GENERIC_MDX_COMPONENT_EXCLUDED_TAGS.has(tag)) return node;
+  // Non-inline PascalCase stays flow-level (handled by mdxishComponentBlocks)
+  // and dedicated tokenizers (Table, HTMLBlock) own their tags. Inline
+  // components (Anchor, Glossary) with expression attrs are promoted here —
+  // the text tokenizer captures them as a single html node.
+  if (isPascalCase(tag) && !INLINE_COMPONENT_TAGS.has(tag)) return node;
 
   // Plain inline HTML (no expressions) stays as an html node so rehype-raw
   // parses it with parse5 as normal.


### PR DESCRIPTION
| 🎫 Resolve [CX-3591](https://linear.app/readme-io/issue/CX-3591/incorrect-anchor-rendering-in-mdx-ish) |
| :-----------------: |

## 🎯 What does this PR do?

There was a reported bug where `<Anchor>` tags were breaking not rendering as links. The root cause of the reported Anchor was it contained complex expression in an attribute: `href={'https://' + user.docsUrl + '/reference/sign-up-api'}`, which the raw anchor HTML can't render.

The fix is to now let the mdx tokenizer to now claim inline PascalCase components in text mode (Anchor & Glossary) and pass it on the relatively newly created MDX inline HTML transformer path (processor/transform/mdxish/components/inline-html.ts), which parses them into `mdxJsxTextElement` so they render correctly.

## 🧪 QA tips

- [ ] Inline `Anchor` with a concatenation-expression `href` renders as a link (the original repro):

  ```md
  <Anchor target="_blank" href={'https://' + 'www.google.com' + '/reference/sign-up-api'}>Content</Anchor>.
  ```

- [ ] Inline `Glossary` with a template-literal expression attr renders:

  ```md
  <Glossary term={`a${b}c`}>word</Glossary>
  ```

- [ ] Plain inline `Anchor` (no expression attrs) still renders via the existing CommonMark path:

  ```md
  <Anchor href="https://example.com">Link</Anchor>
  ```

## 📸 Screenshot or Loom

Old mdxish editor vs fixed mdxish vs legacy editor (correct baseline):

https://github.com/user-attachments/assets/2255ffd3-01b0-4324-a4d4-5ad791007e3e
