### PR TITLE
fix(mdxish): restore correct end position for fully-consumed nested component blocks

### DIFF
--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -523,9 +523,6 @@ hello
       });
 
       it('position spans the full closing tag for a multi-line component inside a blockquote', () => {
-        // Regression test: positionEndingAtConsumed used the stripped value length to compute
-        // end.offset, but the original source has '> ' on every continuation line.
-        // This caused nodeToSource to slice too early, dropping the closing tag.
         const markdown = '> <Tag>\n>   body\n> </Tag>';
         const tree = parseWithPlugin(markdown);
 
@@ -536,8 +533,6 @@ hello
       });
 
       it('position spans the full closing tag for a multi-line component inside a list item', () => {
-        // Same regression: list-item indentation is stripped from the html value but
-        // present in the original source, causing the same off-by-N offset error.
         const markdown = '- <Tag>\n    body\n  </Tag>';
         const tree = parseWithPlugin(markdown);
 

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -521,6 +521,32 @@ hello
         const [tag] = tree.children;
         expect(markdown.slice(tag.position!.start.offset, tag.position!.end.offset)).toBe('<Tag attr={1}>**hi**</Tag>');
       });
+
+      it('position spans the full closing tag for a multi-line component inside a blockquote', () => {
+        // Regression test: positionEndingAtConsumed used the stripped value length to compute
+        // end.offset, but the original source has '> ' on every continuation line.
+        // This caused nodeToSource to slice too early, dropping the closing tag.
+        const markdown = '> <Tag>\n>   body\n> </Tag>';
+        const tree = parseWithPlugin(markdown);
+
+        const blockquote = tree.children[0] as Parent;
+        const tag = blockquote.children[0] as MdxJsxFlowElement;
+        expect(tag.type).toBe('mdxJsxFlowElement');
+        expect(markdown.slice(tag.position!.start.offset, tag.position!.end.offset)).toBe('<Tag>\n>   body\n> </Tag>');
+      });
+
+      it('position spans the full closing tag for a multi-line component inside a list item', () => {
+        // Same regression: list-item indentation is stripped from the html value but
+        // present in the original source, causing the same off-by-N offset error.
+        const markdown = '- <Tag>\n    body\n  </Tag>';
+        const tree = parseWithPlugin(markdown);
+
+        const list = tree.children[0] as Parent;
+        const listItem = list.children[0] as Parent;
+        const tag = listItem.children[0] as MdxJsxFlowElement;
+        expect(tag.type).toBe('mdxJsxFlowElement');
+        expect(markdown.slice(tag.position!.start.offset, tag.position!.end.offset)).toBe('<Tag>\n    body\n  </Tag>');
+      });
     });
   });
 

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -547,10 +547,6 @@ hello
       });
 
       it('position spans the full closing tag for a component with trailing sibling content inside a blockquote', () => {
-        // Regression: in the trailing-content path, positionEndingAtConsumed used the
-        // stripped value length to compute end.offset. Blockquote lines have '> ' prefixes
-        // in the source that are absent from the html node's value, causing the offset to
-        // be computed too early and the closing tag to appear truncated when sliced.
         const markdown = '> <Tag>\n>   body\n> </Tag>\n> trailing';
         const tree = parseWithPlugin(markdown);
 

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -2,6 +2,7 @@ import type { Code, Heading, Parent, Root } from 'mdast';
 
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
+import { VFile } from 'vfile';
 
 import { mdxComponentFromMarkdown } from '../../lib/mdast-util/mdx-component';
 import { mdxComponent } from '../../lib/micromark/mdx-component';
@@ -18,6 +19,8 @@ interface MdxJsxFlowElement extends Parent {
  * Helper to parse markdown and apply the component block plugins.
  * Includes the mdx-component micromark tokenizer to capture multi-line
  * components as single HTML nodes before the transformer runs.
+ * Passes a VFile so the transformer has access to the original source for
+ * source-aware position computation (needed for blockquote/list items).
  */
 const parseWithPlugin = (markdown: string): Root => {
   const processor = unified()
@@ -27,7 +30,7 @@ const parseWithPlugin = (markdown: string): Root => {
     .use(mdxishSelfClosingBlocks)
     .use(mdxishComponentBlocks);
   const tree = processor.parse(markdown);
-  processor.runSync(tree);
+  processor.runSync(tree, new VFile({ value: markdown }));
   return tree as Root;
 };
 
@@ -534,6 +537,32 @@ hello
 
       it('position spans the full closing tag for a multi-line component inside a list item', () => {
         const markdown = '- <Tag>\n    body\n  </Tag>';
+        const tree = parseWithPlugin(markdown);
+
+        const list = tree.children[0] as Parent;
+        const listItem = list.children[0] as Parent;
+        const tag = listItem.children[0] as MdxJsxFlowElement;
+        expect(tag.type).toBe('mdxJsxFlowElement');
+        expect(markdown.slice(tag.position!.start.offset, tag.position!.end.offset)).toBe('<Tag>\n    body\n  </Tag>');
+      });
+
+      it('position spans the full closing tag for a component with trailing sibling content inside a blockquote', () => {
+        // Regression: in the trailing-content path, positionEndingAtConsumed used the
+        // stripped value length to compute end.offset. Blockquote lines have '> ' prefixes
+        // in the source that are absent from the html node's value, causing the offset to
+        // be computed too early and the closing tag to appear truncated when sliced.
+        const markdown = '> <Tag>\n>   body\n> </Tag>\n> trailing';
+        const tree = parseWithPlugin(markdown);
+
+        const blockquote = tree.children[0] as Parent;
+        const tag = blockquote.children[0] as MdxJsxFlowElement;
+        expect(tag.type).toBe('mdxJsxFlowElement');
+        expect(markdown.slice(tag.position!.start.offset, tag.position!.end.offset)).toBe('<Tag>\n>   body\n> </Tag>');
+      });
+
+      it('position spans the full closing tag for a component with trailing sibling content inside a list item', () => {
+        // Same regression for list items: indentation is stripped from the html value.
+        const markdown = '- <Tag>\n    body\n  </Tag>\n- trailing';
         const tree = parseWithPlugin(markdown);
 
         const list = tree.children[0] as Parent;

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -222,12 +222,19 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
         attributes,
         children: parsedChildren,
         startPosition: node.position,
-        // End at the closing tag, not at trailing content re-parsed as siblings below.
-        endPosition: positionEndingAtConsumed(
-          node.position,
-          value,
-          leadingWhitespace + openingTagEnd + closingTagIndex + closingTagStr.length,
-        ),
+        // When trailing content follows the closing tag, compute the end position precisely
+        // within the html node's value so the component doesn't claim that content.
+        // When the entire html node is consumed, use the original node position directly:
+        // positionEndingAtConsumed would compute the wrong end.offset for nodes inside
+        // blockquotes/list items where the html value has '> '/space prefixes stripped
+        // but the original source does not, causing nodeToSource to slice too early.
+        endPosition: contentAfterClose
+          ? positionEndingAtConsumed(
+              node.position,
+              value,
+              leadingWhitespace + openingTagEnd + closingTagIndex + closingTagStr.length,
+            )
+          : node.position,
       });
       substituteNodeWithMdxNode(parent, index, componentNode);
 

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -88,6 +88,25 @@ const positionEndingAtConsumed = (nodePosition: Node['position'], value: string,
 };
 
 /**
+ * Build a position ending right after the last occurrence of `closingTag` within
+ * this node's span in the original source. Used in the trailing-content path so
+ * the offset is computed against the real source bytes (including blockquote/list
+ * prefixes that were stripped from the html node's value).
+ */
+const positionEndingAtClosingTagInSource = (
+  nodePosition: Node['position'],
+  closingTag: string,
+  source: string,
+): Node['position'] => {
+  if (!nodePosition?.start || !nodePosition.end) return nodePosition;
+  const nodeSource = source.slice(nodePosition.start.offset, nodePosition.end.offset);
+  const closingTagOffset = nodeSource.lastIndexOf(closingTag);
+  if (closingTagOffset === -1) return nodePosition;
+  const consumed = nodeSource.slice(0, closingTagOffset + closingTag.length);
+  return { start: nodePosition.start, end: pointAfter(nodePosition.start, consumed) };
+};
+
+/**
  * Create an MdxJsxFlowElement node from component data.
  */
 const createComponentNode = ({ tag, attributes, children, startPosition, endPosition }: ComponentNodeOptions): MdxJsxFlowElement => ({
@@ -132,9 +151,10 @@ const substituteNodeWithMdxNode = (parent: Parent, index: number, mdxNode: MdxJs
  * The opening tag, content, and closing tag are all captured in one HTML node
  * (guaranteed by the mdx-component tokenizer).
  */
-const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opts = {}) => tree => {
+const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opts = {}) => (tree, file) => {
   const stack: Parent[] = [tree];
   const safeMode = !!opts.safeMode;
+  const source: string | null = file?.value ? String(file.value) : null;
   const parseOpts: ParseAttributesOptions = { preserveExpressionsAsText: safeMode };
 
   const processChildNode = (parent: Parent, index: number) => {
@@ -224,16 +244,18 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
         startPosition: node.position,
         // When trailing content follows the closing tag, compute the end position precisely
         // within the html node's value so the component doesn't claim that content.
-        // When the entire html node is consumed, use the original node position directly:
-        // positionEndingAtConsumed would compute the wrong end.offset for nodes inside
-        // blockquotes/list items where the html value has '> '/space prefixes stripped
-        // but the original source does not, causing nodeToSource to slice too early.
+        // Prefer source-based positioning when the original source is available: the html
+        // node's value has '> '/space prefixes stripped for blockquotes/list items, so
+        // positionEndingAtConsumed would undercount source offsets. When the entire node
+        // is consumed, use the original node position directly.
         endPosition: contentAfterClose
-          ? positionEndingAtConsumed(
-              node.position,
-              value,
-              leadingWhitespace + openingTagEnd + closingTagIndex + closingTagStr.length,
-            )
+          ? source
+            ? positionEndingAtClosingTagInSource(node.position, closingTagStr, source)
+            : positionEndingAtConsumed(
+                node.position,
+                value,
+                leadingWhitespace + openingTagEnd + closingTagIndex + closingTagStr.length,
+              )
           : node.position,
       });
       substituteNodeWithMdxNode(parent, index, componentNode);


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

Fixes a regression introduced by #1519. This regression is [causing test failures for the monorepo update](https://github.com/readmeio/readme/actions/runs/28380935385/job/84086968506?pr=19434).

`positionEndingAtConsumed` computes `end.offset` as `start.offset + value.length`, where `value` is the html node's string content **after remark strips blockquote/list-item prefix characters** (`> `, leading spaces, etc.). Inside the original source those prefixes are still present on every continuation line, so the computed offset is too small — `nodeToSource` slices the original source too early and the closing tag of any multi-line JSX block is dropped.

The fix is narrow: `positionEndingAtConsumed` is only needed when there is trailing content **after** the closing tag (the case #1519 targeted). When the entire html node is consumed, the original `node.position` is already correct and should be used directly.

**Before:** `<Cards>\n  <Card />\n` (closing tag dropped)  
**After:** `<Cards>\n  <Card />\n</Cards>`

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ]

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
