### PR TITLE
fix(mdxish): ensure inline html tags with expressions stay inline

### DIFF
--- a/__tests__/lib/mdxish/components.test.ts
+++ b/__tests__/lib/mdxish/components.test.ts
@@ -5,6 +5,7 @@ import React from 'react';
 import { visit } from 'unist-util-visit';
 
 import { mdxish, compile, run } from '../../../lib';
+import { findElementByTagName } from '../../helpers';
 
 describe('end-to-end tests in the mdxish pipeline for various types and variations of MDX components', () => {
   // Create & compile example component
@@ -348,5 +349,57 @@ labore et dolore magna aliqua.`,
       }
     });
     expect(exampleComponentNode).toBeUndefined();
+  });
+
+  describe('inline components with expression attributes', () => {
+    it('should concatenate expression attributes', () => {
+      const md = "<Anchor label=\"Merchant Sign-Up API Documentation\" target=\"_blank\" href={'https://' + 'www.example.com' + '/reference/sign-up-api'}>Link</Anchor>";
+      const tree = mdxish(md, { newEditorTypes: true });
+      const anchor = findElementByTagName(tree, 'Anchor');
+      expect(anchor).toMatchObject({
+        type: 'element',
+        tagName: 'Anchor',
+        properties: {
+          label: 'Merchant Sign-Up API Documentation',
+          target: '_blank',
+          href: 'https://www.example.com/reference/sign-up-api',
+        },
+        children: [{ type: 'text', value: 'Link' }],
+      });
+    });
+
+    it('should render an Anchor whose href is a concatenation expression', () => {
+      const md =
+        "<Anchor label=\"Docs\" target=\"_blank\" href={'https://' + user.docsUrl + '/x'}>Docs</Anchor>.";
+      const tree = mdxish(md, { newEditorTypes: true });
+      const anchor = findElementByTagName(tree, 'Anchor');
+      expect(anchor).toMatchObject({
+        type: 'element',
+        tagName: 'Anchor',
+        properties: {
+          label: 'Docs',
+          target: '_blank',
+          href: "'https://' + user.docsUrl + '/x'",
+        },
+        children: [{ type: 'text', value: 'Docs' }],
+      });
+    });
+
+    it('should keep trailing text after the closing tag as a sibling', () => {
+      const md = "Start <Anchor href={'a' + 'b'}>Link</Anchor> done.";
+      const tree = mdxish(md, { newEditorTypes: true });
+      const paragraph = tree.children[0] as Element;
+      const [start, anchor, trailing] = paragraph.children;
+      expect(start).toMatchObject({ type: 'text', value: 'Start ' });
+      expect(anchor).toMatchObject({
+        type: 'element',
+        tagName: 'Anchor',
+        properties: {
+          href: 'ab',
+        },
+        children: [{ type: 'text', value: 'Link' }],
+      });
+      expect(trailing).toMatchObject({ type: 'text', value: ' done.' });
+    });
   });
 });

--- a/__tests__/lib/mdxish/mdxish.test.ts
+++ b/__tests__/lib/mdxish/mdxish.test.ts
@@ -594,4 +594,63 @@ describe('html tags rendering', () => {
       children: [{ type: 'text', value: 'Example' }],
     });
   });
+
+  describe('keeps a non-block level lowercase HTML tags inline', () => {
+    const childTagNames = (parent: Element) =>
+      parent.children.filter((c): c is Element => c.type === 'element').map(c => c.tagName);
+
+    const expectSingleParagraph = (tree: Root): Element => {
+      const paragraphs = tree.children.filter((c): c is Element => c.type === 'element' && c.tagName === 'p');
+      expect(paragraphs).toHaveLength(1);
+      return paragraphs[0];
+    };
+
+    it('keeps a paired icon tag inline with a trailing link', () => {
+      const md =
+        '<i class="fa fa-check fa-lg" style={{ color: "#ff9f3a" }}></i> <a href="https://example.com">3-D Secure</a>';
+      expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
+    });
+
+    it('keeps a self-closing icon tag inline with a trailing link', () => {
+      const md = '<i class="fa fa-check" style={{ color: "red" }}/> <a href="https://example.com">link</a>';
+      expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
+    });
+
+    it('keeps an icon tag inline with trailing plain text', () => {
+      const md = '<i class="fa fa-check" style={{ color: "red" }}></i> done';
+      const paragraph = expectSingleParagraph(mdxish(md));
+      expect(childTagNames(paragraph)).toStrictEqual(['i']);
+      const trailing = paragraph.children.at(-1);
+      expect(trailing).toMatchObject({ type: 'text', value: ' done' });
+    });
+
+    it('keeps the icon inline despite condensed/tab whitespace before the link', () => {
+      const md = '<i style={{ color: "red" }}></i>\t \t<a href="https://example.com">link</a>';
+      expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
+    });
+
+    it('keeps the icon inline inside a list item', () => {
+      const md = '- <i style={{ color: "red" }}></i> <a href="https://example.com">link</a>';
+      const listItem = findElementByTagName(mdxish(md), 'li');
+      expect(listItem).toBeDefined();
+      expect(childTagNames(listItem!)).toStrictEqual(['i', 'a']);
+    });
+
+    it('leaves a standalone icon (no trailing content) as its own block', () => {
+      const md = '<i class="fa fa-check" style={{ color: "red" }}></i>';
+      const paragraphs = mdxish(md).children.filter((c): c is Element => c.type === 'element' && c.tagName === 'p');
+      expect(paragraphs).toHaveLength(0);
+      expect(findElementByTagName(mdxish(md), 'i')).toBeDefined();
+    });
+
+    // Block-level HTML tags (CommonMark html-block type 6) stay flow even with
+    // trailing content, so a `<div>` isn't invalidly nested inside a paragraph.
+    it('keeps a block-level tag as its own block with trailing content as a sibling', () => {
+      const md = '<div style={{ color: "red" }}>box</div> trailing';
+      const tree = mdxish(md);
+      expect(findElementByTagName(tree, 'div')).toBeDefined();
+      const topLevel = tree.children.filter((c): c is Element => c.type === 'element').map(c => c.tagName);
+      expect(topLevel).toStrictEqual(['div', 'p']);
+    });
+  });
 });

--- a/__tests__/lib/mdxish/mdxish.test.ts
+++ b/__tests__/lib/mdxish/mdxish.test.ts
@@ -556,7 +556,7 @@ b
 });
 
 describe('html tags rendering', () => {
-  describe('given various attribute formats', () => {
+  describe('various tag attribute formats', () => {
     const expectedAnchor = {
       type: 'element',
       tagName: 'a',
@@ -595,7 +595,7 @@ describe('html tags rendering', () => {
     });
   });
 
-  describe('keeps a non-block level lowercase HTML tags inline', () => {
+  describe('inline-ness vs block-ness of html tags', () => {
     const childTagNames = (parent: Element) =>
       parent.children.filter((c): c is Element => c.type === 'element').map(c => c.tagName);
 
@@ -605,42 +605,44 @@ describe('html tags rendering', () => {
       return paragraphs[0];
     };
 
-    it('keeps a paired icon tag inline with a trailing link', () => {
-      const md =
-        '<i class="fa fa-check fa-lg" style={{ color: "#ff9f3a" }}></i> <a href="https://example.com">3-D Secure</a>';
-      expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
-    });
-
-    it('keeps a self-closing icon tag inline with a trailing link', () => {
-      const md = '<i class="fa fa-check" style={{ color: "red" }}/> <a href="https://example.com">link</a>';
-      expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
-    });
-
-    it('keeps an icon tag inline with trailing plain text', () => {
-      const md = '<i class="fa fa-check" style={{ color: "red" }}></i> done';
-      const paragraph = expectSingleParagraph(mdxish(md));
-      expect(childTagNames(paragraph)).toStrictEqual(['i']);
-      const trailing = paragraph.children.at(-1);
-      expect(trailing).toMatchObject({ type: 'text', value: ' done' });
-    });
-
-    it('keeps the icon inline despite condensed/tab whitespace before the link', () => {
-      const md = '<i style={{ color: "red" }}></i>\t \t<a href="https://example.com">link</a>';
-      expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
-    });
-
-    it('keeps the icon inline inside a list item', () => {
-      const md = '- <i style={{ color: "red" }}></i> <a href="https://example.com">link</a>';
-      const listItem = findElementByTagName(mdxish(md), 'li');
-      expect(listItem).toBeDefined();
-      expect(childTagNames(listItem!)).toStrictEqual(['i', 'a']);
-    });
-
-    it('leaves a standalone icon (no trailing content) as its own block', () => {
-      const md = '<i class="fa fa-check" style={{ color: "red" }}></i>';
-      const paragraphs = mdxish(md).children.filter((c): c is Element => c.type === 'element' && c.tagName === 'p');
-      expect(paragraphs).toHaveLength(0);
-      expect(findElementByTagName(mdxish(md), 'i')).toBeDefined();
+    describe('icon tag', () => {
+      it('keeps a paired icon tag inline with a trailing link', () => {
+        const md =
+          '<i class="fa fa-check fa-lg" style={{ color: "#ff9f3a" }}></i> <a href="https://example.com">3-D Secure</a>';
+        expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
+      });
+  
+      it('keeps a self-closing icon tag inline with a trailing link', () => {
+        const md = '<i class="fa fa-check" style={{ color: "red" }}/> <a href="https://example.com">link</a>';
+        expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
+      });
+  
+      it('keeps an icon tag inline with trailing plain text', () => {
+        const md = '<i class="fa fa-check" style={{ color: "red" }}></i> done';
+        const paragraph = expectSingleParagraph(mdxish(md));
+        expect(childTagNames(paragraph)).toStrictEqual(['i']);
+        const trailing = paragraph.children.at(-1);
+        expect(trailing).toMatchObject({ type: 'text', value: ' done' });
+      });
+  
+      it('keeps the icon inline despite condensed/tab whitespace before the link', () => {
+        const md = '<i style={{ color: "red" }}></i>\t \t<a href="https://example.com">link</a>';
+        expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
+      });
+  
+      it('keeps the icon inline inside a list item', () => {
+        const md = '- <i style={{ color: "red" }}></i> <a href="https://example.com">link</a>';
+        const listItem = findElementByTagName(mdxish(md), 'li');
+        expect(listItem).toBeDefined();
+        expect(childTagNames(listItem!)).toStrictEqual(['i', 'a']);
+      });
+  
+      it('leaves a standalone icon (no trailing content) as its own block', () => {
+        const md = '<i class="fa fa-check" style={{ color: "red" }}></i>';
+        const paragraphs = mdxish(md).children.filter((c): c is Element => c.type === 'element' && c.tagName === 'p');
+        expect(paragraphs).toHaveLength(0);
+        expect(findElementByTagName(mdxish(md), 'i')).toBeDefined();
+      });
     });
 
     // Block-level HTML tags (CommonMark html-block type 6) stay flow even with
@@ -652,57 +654,14 @@ describe('html tags rendering', () => {
       const topLevel = tree.children.filter((c): c is Element => c.type === 'element').map(c => c.tagName);
       expect(topLevel).toStrictEqual(['div', 'p']);
     });
-  });
-  
-  describe('inline components with expression attributes', () => {
-    it('should concatenate expression attributes', () => {
-      const md = "<Anchor label=\"Merchant Sign-Up API Documentation\" target=\"_blank\" href={'https://' + 'www.example.com' + '/reference/sign-up-api'}>Link</Anchor>";
-      const tree = mdxish(md, { newEditorTypes: true });
-      const anchor = findElementByTagName(tree, 'Anchor');
-      expect(anchor).toMatchObject({
-        type: 'element',
-        tagName: 'Anchor',
-        properties: {
-          label: 'Merchant Sign-Up API Documentation',
-          target: '_blank',
-          href: 'https://www.example.com/reference/sign-up-api',
-        },
-        children: [{ type: 'text', value: 'Link' }],
-      });
-    });
 
-    it('should render an Anchor whose href is a concatenation expression', () => {
-      const md =
-        "<Anchor label=\"Docs\" target=\"_blank\" href={'https://' + user.docsUrl + '/x'}>Docs</Anchor>.";
-      const tree = mdxish(md, { newEditorTypes: true });
-      const anchor = findElementByTagName(tree, 'Anchor');
-      expect(anchor).toMatchObject({
-        type: 'element',
-        tagName: 'Anchor',
-        properties: {
-          label: 'Docs',
-          target: '_blank',
-          href: "'https://' + user.docsUrl + '/x'",
-        },
-        children: [{ type: 'text', value: 'Docs' }],
-      });
-    });
-
-    it('should keep trailing text after the closing tag as a sibling', () => {
-      const md = "Start <Anchor href={'a' + 'b'}>Link</Anchor> done.";
-      const tree = mdxish(md, { newEditorTypes: true });
-      const paragraph = tree.children[0] as Element;
-      const [start, anchor, trailing] = paragraph.children;
-      expect(start).toMatchObject({ type: 'text', value: 'Start ' });
-      expect(anchor).toMatchObject({
-        type: 'element',
-        tagName: 'Anchor',
-        properties: {
-          href: 'ab',
-        },
-        children: [{ type: 'text', value: 'Link' }],
-      });
-      expect(trailing).toMatchObject({ type: 'text', value: ' done.' });
+    // Raw-content tags (e.g. <pre>) also stay flow
+    it('keeps a raw-content tag as its own block with trailing content as a sibling', () => {
+      const md = '<pre data={{ a: 1 }}>code</pre> trailing';
+      const tree = mdxish(md);
+      expect(findElementByTagName(tree, 'pre')).toBeDefined();
+      const topLevel = tree.children.filter((c): c is Element => c.type === 'element').map(c => c.tagName);
+      expect(topLevel).toStrictEqual(['pre', 'p']);
     });
   });
 });

--- a/__tests__/lib/mdxish/mdxish.test.ts
+++ b/__tests__/lib/mdxish/mdxish.test.ts
@@ -596,7 +596,7 @@ describe('html tags rendering', () => {
   });
 
   describe('inline-ness vs block-ness of html tags', () => {
-    const childTagNames = (parent: Element) =>
+    const elementNames = (parent: Element | Root) =>
       parent.children.filter((c): c is Element => c.type === 'element').map(c => c.tagName);
 
     const expectSingleParagraph = (tree: Root): Element => {
@@ -609,59 +609,49 @@ describe('html tags rendering', () => {
       it('keeps a paired icon tag inline with a trailing link', () => {
         const md =
           '<i class="fa fa-check fa-lg" style={{ color: "#ff9f3a" }}></i> <a href="https://example.com">3-D Secure</a>';
-        expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
+        expect(elementNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
       });
-  
+
       it('keeps a self-closing icon tag inline with a trailing link', () => {
         const md = '<i class="fa fa-check" style={{ color: "red" }}/> <a href="https://example.com">link</a>';
-        expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
+        expect(elementNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
       });
-  
+
       it('keeps an icon tag inline with trailing plain text', () => {
         const md = '<i class="fa fa-check" style={{ color: "red" }}></i> done';
         const paragraph = expectSingleParagraph(mdxish(md));
-        expect(childTagNames(paragraph)).toStrictEqual(['i']);
+        expect(elementNames(paragraph)).toStrictEqual(['i']);
         const trailing = paragraph.children.at(-1);
         expect(trailing).toMatchObject({ type: 'text', value: ' done' });
       });
-  
+
       it('keeps the icon inline despite condensed/tab whitespace before the link', () => {
         const md = '<i style={{ color: "red" }}></i>\t \t<a href="https://example.com">link</a>';
-        expect(childTagNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
+        expect(elementNames(expectSingleParagraph(mdxish(md)))).toStrictEqual(['i', 'a']);
       });
-  
+
       it('keeps the icon inline inside a list item', () => {
         const md = '- <i style={{ color: "red" }}></i> <a href="https://example.com">link</a>';
         const listItem = findElementByTagName(mdxish(md), 'li');
         expect(listItem).toBeDefined();
-        expect(childTagNames(listItem!)).toStrictEqual(['i', 'a']);
+        expect(elementNames(listItem!)).toStrictEqual(['i', 'a']);
       });
-  
+
       it('leaves a standalone icon (no trailing content) as its own block', () => {
         const md = '<i class="fa fa-check" style={{ color: "red" }}></i>';
-        const paragraphs = mdxish(md).children.filter((c): c is Element => c.type === 'element' && c.tagName === 'p');
-        expect(paragraphs).toHaveLength(0);
-        expect(findElementByTagName(mdxish(md), 'i')).toBeDefined();
+        expect(elementNames(mdxish(md))).toStrictEqual(['i']);
       });
     });
 
     // Block-level HTML tags (CommonMark html-block type 6) stay flow even with
     // trailing content, so a `<div>` isn't invalidly nested inside a paragraph.
     it('keeps a block-level tag as its own block with trailing content as a sibling', () => {
-      const md = '<div style={{ color: "red" }}>box</div> trailing';
-      const tree = mdxish(md);
-      expect(findElementByTagName(tree, 'div')).toBeDefined();
-      const topLevel = tree.children.filter((c): c is Element => c.type === 'element').map(c => c.tagName);
-      expect(topLevel).toStrictEqual(['div', 'p']);
+      expect(elementNames(mdxish('<div style={{ color: "red" }}>box</div> trailing'))).toStrictEqual(['div', 'p']);
     });
 
-    // Raw-content tags (e.g. <pre>) also stay flow
+    // Raw-content tags (CommonMark html-block type 1, e.g. <pre>) also stay flow.
     it('keeps a raw-content tag as its own block with trailing content as a sibling', () => {
-      const md = '<pre data={{ a: 1 }}>code</pre> trailing';
-      const tree = mdxish(md);
-      expect(findElementByTagName(tree, 'pre')).toBeDefined();
-      const topLevel = tree.children.filter((c): c is Element => c.type === 'element').map(c => c.tagName);
-      expect(topLevel).toStrictEqual(['pre', 'p']);
+      expect(elementNames(mdxish('<pre data={{ a: 1 }}>code</pre> trailing'))).toStrictEqual(['pre', 'p']);
     });
   });
 });

--- a/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
+++ b/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
@@ -51,25 +51,44 @@ describe('mdxishAstProcessor', () => {
   });
 
   describe('component node positions', () => {
-    // A component sharing a line with trailing content is tokenized as one html
-    // node; the node's position must end at its own closing tag, else downstream
-    // position-based source slicing over-reads and duplicates the trailing text.
-    it('ends a component node position at its closing tag when trailing content follows on the same line', () => {
+    it('keeps a lowercase tag inline with trailing content on the same line', () => {
       const md =
         '<button className="pill" style={{ backgroundColor: "#ffc107" }}>PrPr</button> ***service-explorer***: Message brokers are now surfaced as entities.';
       const { processor, parserReadyContent } = mdxishAstProcessor(md, { newEditorTypes: true });
       const mdast = processor.runSync(processor.parse(parserReadyContent));
 
-      // Offset 77 is the end of `</button>`; the trailing text is a separate sibling.
+      expect(mdast).toMatchObject({
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              { type: 'mdxJsxTextElement', name: 'button' },
+              { type: 'text', value: ' ' },
+              { type: 'emphasis' },
+              { type: 'text', value: ': Message brokers are now surfaced as entities.' },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('ends a component node position at its closing tag when trailing content follows on the same line', () => {
+      const md =
+        '<Component attr={1+1}>PrPr</Component> ***service-explorer***: Message brokers are now surfaced as entities.';
+      const { processor, parserReadyContent } = mdxishAstProcessor(md, { newEditorTypes: true });
+      const mdast = processor.runSync(processor.parse(parserReadyContent));
+
+      // Offset 38 is the end of `</Component>`; the trailing text is a separate sibling.
       expect(mdast).toMatchObject({
         type: 'root',
         children: [
           {
             type: 'mdxJsxFlowElement',
-            name: 'button',
+            name: 'Component',
             position: {
               start: { line: 1, column: 1, offset: 0 },
-              end: { line: 1, column: 78, offset: 77 },
+              end: { line: 1, column: 39, offset: 38 },
             },
           },
           { type: 'paragraph' },

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -2,7 +2,7 @@
 import type { Code, Construct, Effects, Extension, Resolver, State, TokenizeContext } from 'micromark-util-types';
 
 import { markdownLineEnding, markdownSpace } from 'micromark-util-character';
-import { htmlBlockNames } from 'micromark-util-html-tag-name';
+import { htmlBlockNames, htmlRawNames } from 'micromark-util-html-tag-name';
 import { codes, types } from 'micromark-util-symbol';
 
 import { INLINE_COMPONENT_TAGS, TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
@@ -14,10 +14,11 @@ declare module 'micromark-util-types' {
   }
 }
 
-// CommonMark html-block type-6 tags (e.g. div, section, table): block-level, so
-// they stay flow even with trailing content. Other lowercase tags (i, span, …)
-// follow the type-7 rule and only stay flow when nothing trails the close tag.
-const htmlBlockTagNames = new Set(htmlBlockNames);
+// Raw tags (type-1: pre/script/style/textarea) and block tags (type-6: div,
+// section, …) always start a block, so they stay flow even with trailing
+// content. Other lowercase tags (i, span, …) follow the type-7 rule and only
+// stay flow when nothing trails the close tag.
+const htmlFlowTagNames = new Set([...htmlRawNames, ...htmlBlockNames]);
 
 const nonLazyContinuationStart: Construct = {
   tokenize: tokenizeNonLazyContinuationStart,
@@ -768,10 +769,10 @@ function createTokenize(mode: 'flow' | 'text') {
         effects.exit('mdxComponent');
         return ok(code);
       }
-      // A single-line non-block lowercase tag with content trailing its close is
-      // inline (html-flow type-7), so `<i …></i> <a>…</a>` stays on one line
-      // instead of splitting into separate blocks. Block tags (div, …) stay flow.
-      if (isLowercaseTag && !sawLineEnding && !htmlBlockTagNames.has(tagName)) {
+      // A single-line type-7 lowercase tag with content trailing its close is
+      // inline, so `<i …></i> <a>…</a>` stays on one line instead of splitting
+      // into separate blocks. Raw/block tags (pre, div, …) stay flow.
+      if (isLowercaseTag && !sawLineEnding && !htmlFlowTagNames.has(tagName)) {
         return afterCloseInlineCandidate(code);
       }
       if (code === null || markdownLineEnding(code)) {

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import type { Code, Construct, Effects, Extension, Resolver, State, TokenizeContext } from 'micromark-util-types';
 
-import { markdownLineEnding } from 'micromark-util-character';
+import { markdownLineEnding, markdownSpace } from 'micromark-util-character';
+import { htmlBlockNames } from 'micromark-util-html-tag-name';
 import { codes, types } from 'micromark-util-symbol';
 
 import { TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
@@ -12,6 +13,11 @@ declare module 'micromark-util-types' {
     mdxComponentData: 'mdxComponentData';
   }
 }
+
+// CommonMark html-block type-6 tags (e.g. div, section, table): block-level, so
+// they stay flow even with trailing content. Other lowercase tags (i, span, …)
+// follow the type-7 rule and only stay flow when nothing trails the close tag.
+const htmlBlockTagNames = new Set(htmlBlockNames);
 
 const nonLazyContinuationStart: Construct = {
   tokenize: tokenizeNonLazyContinuationStart,
@@ -87,6 +93,10 @@ function createTokenize(mode: 'flow' | 'text') {
     let fenceLength = 0;
     let fenceCloseLength = 0;
     let atLineStart = false;
+
+    // True once this construct consumes any line ending; lets `afterClose`
+    // treat only single-line lowercase tags as inline candidates.
+    let sawLineEnding = false;
 
     // Bail when the opener line has unmatched tag-like tokens in its body.
     // `<Foo>_<Bar>.csv` leaves opens > closes; matched shapes like
@@ -413,6 +423,7 @@ function createTokenize(mode: 'flow' | 'text') {
     }
 
     function openTagContinuationNonLazy(code: Code): State | undefined {
+      sawLineEnding = true;
       effects.enter(types.lineEnding);
       effects.consume(code);
       effects.exit(types.lineEnding);
@@ -553,6 +564,7 @@ function createTokenize(mode: 'flow' | 'text') {
     }
 
     function fencedCodeContinuationNonLazy(code: Code): State | undefined {
+      sawLineEnding = true;
       effects.enter(types.lineEnding);
       effects.consume(code);
       effects.exit(types.lineEnding);
@@ -741,6 +753,12 @@ function createTokenize(mode: 'flow' | 'text') {
         effects.exit('mdxComponent');
         return ok(code);
       }
+      // A single-line non-block lowercase tag with content trailing its close is
+      // inline (html-flow type-7), so `<i …></i> <a>…</a>` stays on one line
+      // instead of splitting into separate blocks. Block tags (div, …) stay flow.
+      if (isLowercaseTag && !sawLineEnding && !htmlBlockTagNames.has(tagName)) {
+        return afterCloseInlineCandidate(code);
+      }
       if (code === null || markdownLineEnding(code)) {
         effects.exit('mdxComponentData');
         effects.exit('mdxComponent');
@@ -752,6 +770,21 @@ function createTokenize(mode: 'flow' | 'text') {
       return afterClose;
     }
 
+    // Whitespace-only to the line ending keeps the flow block; any other
+    // trailing char means inline content, so refuse and let inline parsing run.
+    function afterCloseInlineCandidate(code: Code): State | undefined {
+      if (code === null || markdownLineEnding(code)) {
+        effects.exit('mdxComponentData');
+        effects.exit('mdxComponent');
+        return ok(code);
+      }
+      if (markdownSpace(code)) {
+        effects.consume(code);
+        return afterCloseInlineCandidate;
+      }
+      return nok(code);
+    }
+
     // ── Body continuation (line endings) ───────────────────────────────────
 
     function bodyContinuationStart(code: Code): State | undefined {
@@ -759,6 +792,7 @@ function createTokenize(mode: 'flow' | 'text') {
     }
 
     function bodyContinuationNonLazy(code: Code): State | undefined {
+      sawLineEnding = true;
       effects.enter(types.lineEnding);
       effects.consume(code);
       effects.exit(types.lineEnding);


### PR DESCRIPTION
| 🎫 Resolve CX-3624 |
| :-----------------: |

## 🎯 What does this PR do?

In MDXish, there is a reported bug where the text after an icon tag `<i>` does not render in the same line as it, the icon is at the start of the line (if it's inside a line, it would be correctly inline)
```md
<i class="fa fa-check fa-lg" style={{ color: "#ff9f3a" }}></i> <a href="https://x.com">3-D Secure</a>
```
MDX vs MDXish:

<img width="863" height="243" alt="Screenshot 2026-06-30 at 2 04 11 pm" src="https://github.com/user-attachments/assets/f133cca4-1d25-4aac-89d4-a465874aa8bf" />

The issue is with the MDX tokenizer. Currently it treats a line-leading lowercase tag carrying a `{…}` JSX attribute (e.g. `style={{…}}`) as a block, and captures the rest of the line as separate block siblings, so the icon becomes its own block:

```html
<i ...></i>
<p><a href="https://x.com">3-D Secure</a></p>
```

In reality, certain lowercase HTML tags such as icon are always inline, so the tokenizer should have been aware of that. The fix makes a single-line non-block lowercase tag with inline content trailing its end tag fall through to inline parsing (mirrors CommonMark html-flow type-7). We also distinct block-level HTML tags so it stays flow (excluded via `htmlBlockNames`), so a `<div>` isn't invalidly nested in a `<p>`:

## 🧪 QA tips

- [ ] Paste the reported snippet into an MDXish doc — icon and link render on the same line.
- [ ] `npx vitest run __tests__/lib/mdxish/mdxish.test.ts __tests__/lib/mdxish/mdxishAstProcessor.test.ts`

More snippets to paste — inline tags should stay on one line, block tags should remain their own block:

```md
<!-- self-closing icon + link → one line -->
<i class="fa fa-check" style={{ color: "red" }}/> <a href="https://x.com">link</a>
```

```md
<!-- inline tag + trailing text → one line -->
<span style={{ color: "red" }}>Status</span>: all good
```

```md
<!-- inside a list item → icon + link stay inline -->
- <i style={{ color: "red" }}></i> <a href="https://x.com">link</a>
```

```md
<!-- block tag stays its own block, trailing text becomes a separate paragraph -->
<div style={{ color: "red" }}>box</div> trailing
```

```md
<!-- standalone icon (nothing trailing) stays its own block -->
<i class="fa fa-check" style={{ color: "red" }}></i>
```

## 📸 Screenshot or Loom

Now content after icon stays inline:

<img width="787" height="268" alt="Screenshot 2026-06-30 at 2 19 05 pm" src="https://github.com/user-attachments/assets/99c41ece-4be0-47aa-b07c-b50f1c6fcdad" />

