### PR TITLE
fix: correct exports map ordering

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -35,6 +35,7 @@ export {
   stripComments,
   tags,
 } from './lib';
+export type { MdxishOpts, RenderMdxishOpts, RunOpts } from './lib';
 export { default as Owlmoji } from './lib/owlmoji';
 export { Components, utils };
 export { tailwindCompiler } from './utils/tailwind-compiler';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,6 +17,7 @@ export { default as plain } from './plain';
 export { default as renderMdxish } from './renderMdxish';
 export type { RenderMdxishOpts } from './renderMdxish';
 export { default as run } from './run';
+export type { RunOpts } from './run';
 export { default as tags } from './tags';
 export { default as mdxishTags } from './mdxishTags';
 export { default as stripComments } from './stripComments';

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "browser": "./dist/main.js",
       "node": "./dist/main.node.js",
+      "browser": "./dist/main.js",
       "default": "./dist/main.node.js"
     },
     "./render-diff": {


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## Context

1. In https://github.com/readmeio/markdown/pull/1489 we added an exports map to support new regression test exports

    https://github.com/readmeio/markdown/blob/928b36eae181a1bdbcdee6c3b45f0fa8b5580813/package.json#L9-L26

     But the map listed "browser" first. Some tools (like Jest, when testing React components) ask for *both* "browser" and "node" at once so Jest kept receiving the browser file when it needs the node file.
     
 2. This caused these test failures in the monorepo https://github.com/readmeio/readme/actions/runs/28407377427/job/84174978249?pr=19434
 
 3. [We added this fix](https://github.com/readmeio/readme/pull/19434/changes/05dee11eaff6eb146b042dea084ecf4587a663da) which forces jest to use the node file. But a simpler fix is to just re-order the entries in the @readme/markdown package
     
## 🎯 What does this PR do?
- Fix the ordering of entries so we can clean up the monorepo bandaid
- Export some types so we can use them correctly in the monorepo

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ]

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
