### PR TITLE
feat(mdxish): support library imports in declarations

### DIFF
--- a/__tests__/lib/mdxish/exports.test.ts
+++ b/__tests__/lib/mdxish/exports.test.ts
@@ -244,6 +244,105 @@ isEven(4) = {isEven(4)}.`;
     });
   });
 
+  describe('library imports', () => {
+    it('resolves a named React import used inside an exported component (RM-16919)', () => {
+      const md = `import { useState } from 'react';
+
+export const Counter = () => {
+  const [count, setCount] = useState(0);
+  return (
+    <div>
+      <button onClick={() => setCount(count + 1)}>Add</button>
+      <p>{count}</p>
+    </div>
+  );
+};
+
+<Counter />`;
+      const html = renderToHtml(md);
+      expect(html).toContain('<button>Add</button>');
+      expect(html).toContain('<p>0</p>');
+    });
+
+    it('resolves a default React import', () => {
+      const md = `import React from 'react';
+
+export const Boxed = () => React.createElement('span', null, 'boxed');
+
+<Boxed />`;
+      expect(renderToHtml(md)).toContain('<span>boxed</span>');
+    });
+
+    it('resolves a namespace React import', () => {
+      const md = `import * as ReactLib from 'react';
+
+export const Boxed = () => ReactLib.createElement('span', null, 'ns');
+
+<Boxed />`;
+      expect(renderToHtml(md)).toContain('<span>ns</span>');
+    });
+
+    it('resolves an aliased named import', () => {
+      const md = `import { useState as useLocalState } from 'react';
+
+export const Counter = () => {
+  const [count] = useLocalState(7);
+  return <p>{count}</p>;
+};
+
+<Counter />`;
+      expect(renderToHtml(md)).toContain('<p>7</p>');
+    });
+
+    it('removes the import declaration from the rendered output', () => {
+      const md = `import { useState } from 'react';
+
+export const foo = "hello";
+
+Value: {foo}.`;
+      const html = mix(md);
+      expect(html).not.toContain('import {');
+      expect(html).toContain('Value: hello.');
+    });
+
+    it('keeps import bindings across multiple exports', () => {
+      const md = `import { useState, useMemo } from 'react';
+
+export const useSeed = () => useState(1);
+export const Doubler = () => {
+  const doubled = useMemo(() => 2 * 2, []);
+  return <p>{doubled}</p>;
+};
+
+<Doubler />`;
+      expect(renderToHtml(md)).toContain('<p>4</p>');
+    });
+
+    it('tolerates a condensed single-line import + export', () => {
+      const md = "import { useState } from 'react';export const Counter = () => { const [n] = useState(3); return <em>{n}</em>; };\n\n<Counter />";
+      expect(renderToHtml(md)).toContain('<em>3</em>');
+    });
+
+    it('warns and skips an unsupported library without breaking the rest of the doc', () => {
+      const md = `import { clamp } from 'lodash';
+
+export const greeting = "hi";
+
+{greeting}`;
+      const html = mix(md);
+      expect(html).not.toContain('import {');
+      expect(html).toContain('hi');
+    });
+
+    it('does not resolve imports in safeMode and keeps them as literal text', () => {
+      const md = `import { useState } from 'react';
+
+Plain text.`;
+      const html = mix(md, { safeMode: true });
+      expect(html).toContain("import { useState } from 'react';");
+    });
+  });
+
   describe('class declarations', () => {
     it('exposes class declarations as values', () => {
       const md = `export class MyClass {

--- a/processor/transform/mdxish/evaluate-exports.ts
+++ b/processor/transform/mdxish/evaluate-exports.ts
@@ -1,4 +1,4 @@
-import type { Declaration, Pattern, Program } from 'estree';
+import type { Declaration, ImportDeclaration, Pattern, Program } from 'estree';
 import type { Root } from 'mdast';
 import type { MdxjsEsm } from 'mdast-util-mdx';
 import type { Plugin } from 'unified';
@@ -10,6 +10,8 @@ import React from 'react';
 import { visit } from 'unist-util-visit';
 
 import { evaluate, isMDXEsm } from '../../utils';
+
+import { collectImportValues } from './resolve-esm-imports';
 
 export type MdxishScope = Record<string, unknown>;
 
@@ -73,6 +75,7 @@ const collectExportNames = (declaration: Declaration): string[] => {
 const evaluateExports: Plugin<[], Root> = () => (tree: Root, file: VFile) => {
   const programBody: Declaration[] = [];
   const exportNames: string[] = [];
+  const importDeclarations: ImportDeclaration[] = [];
   const nodesToRemove: { index: number; parent: Root }[] = [];
 
   visit(tree, isMDXEsm, (node: MdxjsEsm, index, parent) => {
@@ -88,6 +91,11 @@ const evaluateExports: Plugin<[], Root> = () => (tree: Root, file: VFile) => {
     // handled the same as a named export — the inner declaration carries the
     // binding name
     estreeBody.forEach(statement => {
+      if (statement.type === 'ImportDeclaration') {
+        importDeclarations.push(statement);
+        return;
+      }
+
       let declaration: Declaration | null = null;
       if (statement.type === 'ExportNamedDeclaration' && statement.declaration) {
         declaration = statement.declaration;
@@ -120,11 +128,14 @@ const evaluateExports: Plugin<[], Root> = () => (tree: Root, file: VFile) => {
     buildJsx(program, { runtime: 'classic', pragma: 'React.createElement', pragmaFrag: 'React.Fragment' });
     const { value: source } = toJs(program);
 
+    // Make sure import values are available in the scope
+    const importValues = collectImportValues(importDeclarations);
+
     // Evaluate and build on the expression source
     // Use react to compile JSX codes
     const evaluatedExports = evaluate(
       `(() => { ${source}\nreturn { ${exportNames.join(', ')} }; })()`,
-      { React },
+      { React, ...importValues },
     ) as Record<string, unknown>;
 
     Object.assign(scope, evaluatedExports);

--- a/processor/transform/mdxish/resolve-esm-imports.ts
+++ b/processor/transform/mdxish/resolve-esm-imports.ts
@@ -1,0 +1,62 @@
+import type { ImportDeclaration } from 'estree';
+
+import React from 'react';
+
+// Maps library names to their module package
+export type ModuleRegistry = Record<string, unknown>;
+
+// We provide React as a default module so that components can use hooks
+// and it's a common use case. Add other common libraries here.
+export const defaultModuleRegistry: ModuleRegistry = { react: React };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+// Get the value of a named export from a module
+const getModuleExport = (module: unknown, importedName: string): unknown =>
+  isRecord(module) && importedName in module ? module[importedName] : undefined;
+
+/**
+ * Turn `import` declarations into a flat map of binding → value.
+ * 
+ * A "binding" is a mapping of a local name to the value of it in the module exports
+ * Example: `import { useState } from 'react'` yields `{ useState: React.useState }`.
+ * 
+ * Unsupported specifiers are skipped with a warning rather than throwing, so a
+ * single unknown import can't break the rest of the document.
+ */
+export const collectImportValues = (
+  importDeclarations: ImportDeclaration[],
+  registry: ModuleRegistry = defaultModuleRegistry,
+): Record<string, unknown> => {
+  const importValues: Record<string, unknown> = {};
+
+  importDeclarations.forEach(declaration => {
+    const libraryName = declaration.source.value;
+    if (typeof libraryName !== 'string') return;
+
+    if (!(libraryName in registry)) {
+      // eslint-disable-next-line no-console
+      console.warn(`[WARNING] Cannot resolve import "${libraryName}"; it is not a supported library.`);
+      return;
+    }
+
+    const module = registry[libraryName];
+
+    declaration.specifiers.forEach(spec => {
+      // Default (`import React`) and namespace (`import * as React`) both bind
+      // the whole module under the local name.
+      if (spec.type === 'ImportDefaultSpecifier' || spec.type === 'ImportNamespaceSpecifier') {
+        importValues[spec.local.name] = module;
+      } else if (spec.type === 'ImportSpecifier') {
+        // Named imports (e.g. `import { useState } from 'react'`, useState is the import name)
+        const importName = spec.imported.type === 'Identifier' ? spec.imported.name : spec.imported.value;
+        if (typeof importName === 'string') {
+          importValues[spec.local.name] = getModuleExport(module, importName);
+        }
+      }
+    });
+  });
+
+  return importValues;
+};


### PR DESCRIPTION
| 🎫 Resolve [RM-16919](https://linear.app/readme-io/issue/RM-16919/support-importing-libraries) |
| :-----------------: |

## 🎯 What does this PR do?

Lets in-document declarations use `import` statements. Previously an imported name (e.g. React hooks) was dropped, so using it threw `<name> is not defined`. `import` declarations now resolve against a module registry (React by default) and their values are injected into the evaluation scope.

Not in scope but can be revisited:
- No path to pass in imports to the engine yet
- Currently the default available module is only "React" as that's what is was in MDX & the most commonly used one. We can consider extending this. Hence, only React imports work for now

## 🧪 QA tips

Try these in an MDXish doc — each should render without a "not defined" error:

Named import (the reported case):
```mdx
import { useState } from 'react';

export const Counter = () => {
  const [count, setCount] = useState(0);
  return (
    <div>
      <button onClick={() => setCount(count + 1)}>Add</button>
      <p>{count}</p>
    </div>
  );
};

<Counter />
```

Default / namespace / aliased imports:
```mdx
import React from 'react';
import * as ReactLib from 'react';
import { useState as useLocalState } from 'react';

export const A = () => React.createElement('span', null, 'a');
export const B = () => ReactLib.createElement('span', null, 'b');
export const C = () => { const [n] = useLocalState(7); return <em>{n}</em>; };

<A /> <B /> <C />
```

Unsupported library - warns and skips, rest of the doc still renders:
```mdx
import { clamp } from 'lodash';

export const greeting = "hi";

{greeting}
```

## 📸 Screenshot or Loom

https://github.com/user-attachments/assets/94036dca-a46c-4ea8-a246-0ae56b3a2ad7
