### PR TITLE
fix(mdxish): preserve blank-line paragraph breaks inside table cells

### DIFF
--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -120,9 +120,9 @@ describe('mdxish tables transformation', () => {
                         type: 'mdxJsxFlowElement',
                         name: 'td',
                         children: [
-                          { type: 'text', value: 'Line 1' },
-                          { type: 'text', value: 'Line 3' },
-                          { type: 'text', value: 'Line 5' },
+                          { type: 'paragraph', children: [{ type: 'text', value: 'Line 1' }] },
+                          { type: 'paragraph', children: [{ type: 'text', value: 'Line 3' }] },
+                          { type: 'paragraph', children: [{ type: 'text', value: 'Line 5' }] },
                         ],
                       },
                     ],
@@ -133,6 +133,154 @@ describe('mdxish tables transformation', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('given blank-line-separated paragraphs in a header-less table cell', () => {
+    // A <tbody>-only table can't become an mdast table (no header row), so it
+    // stays JSX — paragraphs inside cells must survive that path
+    it('keeps the paragraphs as separate mdast nodes', () => {
+      const md = `<table><tbody><tr><td>
+First paragraph.
+
+Second paragraph.
+</td></tr></tbody></table>`;
+      const ast = astProcessor(md);
+
+      expect(ast).toMatchObject({
+        type: 'root',
+        children: [
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'table',
+            children: [
+              {
+                type: 'mdxJsxFlowElement',
+                name: 'tbody',
+                children: [
+                  {
+                    type: 'mdxJsxFlowElement',
+                    name: 'tr',
+                    children: [
+                      {
+                        type: 'mdxJsxFlowElement',
+                        name: 'td',
+                        children: [
+                          { type: 'paragraph', children: [{ type: 'text', value: 'First paragraph.' }] },
+                          { type: 'paragraph', children: [{ type: 'text', value: 'Second paragraph.' }] },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('renders the paragraphs as separate <p> elements', () => {
+      const md = `<table><tbody><tr><td>
+First paragraph.
+
+Second paragraph.
+</td></tr></tbody></table>`;
+      const html = toHtml(mdxish(md));
+
+      expect(html).toContain('<td><p>First paragraph.</p><p>Second paragraph.</p></td>');
+    });
+
+    it('renders separate <p> elements when the content is condensed against the tags', () => {
+      const md = `<table><tbody><tr><td>First paragraph.
+
+Second paragraph.</td></tr></tbody></table>`;
+      const html = toHtml(mdxish(md));
+
+      expect(html).toContain('<p>First paragraph.</p>');
+      expect(html).toContain('<p>Second paragraph.</p>');
+    });
+
+    it('treats multiple blank lines and indentation as a single paragraph break', () => {
+      const md = `<table>
+  <tbody>
+    <tr>
+      <td>
+        First paragraph.
+
+
+
+        Second paragraph.
+      </td>
+    </tr>
+  </tbody>
+</table>`;
+      const html = toHtml(mdxish(md));
+
+      expect(html).toContain('<td><p>First paragraph.</p><p>Second paragraph.</p></td>');
+    });
+
+    it('still parses markdown syntax inside each paragraph', () => {
+      const md = `<table><tbody><tr><td>
+**First** paragraph.
+
+_Second_ paragraph.
+</td></tr></tbody></table>`;
+      const html = toHtml(mdxish(md));
+
+      expect(html).toContain('<p><strong>First</strong> paragraph.</p>');
+      expect(html).toContain('<p><em>Second</em> paragraph.</p>');
+    });
+
+    it('preserves paragraphs in a JSX <Table> kept as JSX by structural attributes', () => {
+      const md = `<Table>
+  <thead>
+    <tr><th class="head">Header</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        First paragraph.
+
+        Second paragraph.
+      </td>
+    </tr>
+  </tbody>
+</Table>`;
+      const html = toHtml(mdxish(md));
+
+      expect(html).toContain('<td><p>First paragraph.</p><p>Second paragraph.</p></td>');
+    });
+
+    it('keeps paragraphs separate from a sibling list in the same cell', () => {
+      const md = `<table><tbody><tr><td>
+First paragraph.
+
+- item one
+- item two
+
+Second paragraph.
+</td></tr></tbody></table>`;
+      const hast = mdxish(md);
+      const cells = findAllElementsByTagName(hast, 'td');
+      expect(cells).toHaveLength(1);
+
+      const lists = findAllElementsByTagName(cells[0], 'ul');
+      expect(lists).toHaveLength(1);
+      expect(findAllElementsByTagName(lists[0], 'li')).toHaveLength(2);
+
+      const html = toHtml(cells[0]);
+      expect(html).toContain('First paragraph.');
+      expect(html).toContain('Second paragraph.');
+    });
+
+    it('still unwraps a sole paragraph in a header-less cell (no stray <p>)', () => {
+      const md = `<table><tbody><tr><td>
+Just one line.
+</td></tr></tbody></table>`;
+      const html = toHtml(mdxish(md));
+
+      expect(html).toContain('<td>Just one line.</td>');
     });
   });
 

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -25,7 +25,7 @@ import { normalizeTagSpacing } from './normalize-tag-spacing';
 import { remapPositionsToOriginal } from './remap-positions';
 import { repairExpressionEscapes } from './repair-expression-escapes';
 import { repairUnclosedTags } from './repair-unclosed-tags';
-import { tableTags, unwrapSoleParagraph, type Insert, type RepairResult } from './utils';
+import { tableTags, unwrapParagraphNodes, unwrapSoleParagraph, type Insert, type RepairResult } from './utils';
 
 interface MdxJsxTableCell extends Omit<MdxJsxFlowElement, 'name'> {
   name: 'td' | 'th';
@@ -214,23 +214,22 @@ const processTableNode = (
     // same line as content becomes mdxJsxTextElement inside a paragraph).
     // Unwrap these so <td>/<th> sit directly under <tr>, and strip
     // whitespace-only text nodes to avoid rendering empty <p>/<br>.
-    const cleanChildren = (children: Node[]): Node[] =>
-      children
-        .flatMap(child => {
-          if (child.type === 'paragraph' && 'children' in child && Array.isArray(child.children)) {
-            return child.children as Node[];
-          }
-          return [child];
-        })
-        .filter(
-          child =>
-            !(child.type === 'text' && 'value' in child && typeof child.value === 'string' && !child.value.trim()),
-        );
+    const removeWhitespaceOnlyTextNodes = (children: Node[]): Node[] =>
+      children.filter(
+        child =>
+          !(child.type === 'text' && 'value' in child && typeof child.value === 'string' && !child.value.trim()),
+      );
 
     visit(node as Node, isMDXElement, (el: MdxJsxFlowElement | MdxJsxTextElement) => {
-      if ('children' in el && Array.isArray(el.children)) {
-        el.children = cleanChildren(el.children as Node[]) as typeof el.children;
-      }
+      if (!('children' in el) || !Array.isArray(el.children)) return;
+
+      // Filtering transformers
+      // A cell only unwraps a sole paragraph: multiple paragraphs are real
+      // blank-line-separated content that must stay separated
+      const unwrapped = isTableCell(el)
+        ? unwrapSoleParagraph(el.children as Node[])
+        : unwrapParagraphNodes(el.children as Node[]);
+      el.children = removeWhitespaceOnlyTextNodes(unwrapped) as typeof el.children;
     });
 
     (parent.children as ((typeof parent.children)[number] | MdxJsxFlowElement | MdxJsxTextElement)[])[index] = {

--- a/processor/transform/mdxish/tables/utils.ts
+++ b/processor/transform/mdxish/tables/utils.ts
@@ -25,6 +25,19 @@ export const tableTags = new Set([
 ]);
 
 /**
+ * Replaces every paragraph node with its inline children. Used where paragraphs
+ * are parser artifacts (remarkMdx wrapping inline JSX), not real content.
+ */
+export const unwrapParagraphNodes = (children: Node[]): Node[] => {
+  return children.flatMap(child => {
+    if (child.type === 'paragraph' && 'children' in child && Array.isArray(child.children)) {
+      return child.children as Node[];
+    }
+    return [child];
+  });
+};
+
+/**
  * If the cell has exactly one paragraph child, unwrap it so its inline children sit
  * directly under the cell (matches GFM table cell shape and avoids stray `<p>` wrappers).
  *
@@ -35,12 +48,7 @@ export const unwrapSoleParagraph = (children: Node[]): Node[] => {
   const paragraphCount = children.filter(c => c.type === 'paragraph').length;
   if (paragraphCount !== 1) return children;
 
-  return children.flatMap(child => {
-    if (child.type === 'paragraph' && 'children' in child && Array.isArray(child.children)) {
-      return child.children as Node[];
-    }
-    return [child];
-  });
+  return unwrapParagraphNodes(children);
 };
 
 /**


### PR DESCRIPTION
| 🎫 Resolve CX-3654 |
| :-----------------: |

## 🎯 What does this PR do?

There was a reported mdxish rendering issue where blank-line-separated lines inside a table cell collapse onto a single line, whereas they should have been separated to different paragraphs:

<img width="1331" height="509" alt="Screenshot 2026-07-06 at 8 27 22 pm" src="https://github.com/user-attachments/assets/cd8b35a6-c4c4-433c-8f75-b839a99501e4" />

The cause of this was in the table transformer, when a table is parsed as JSX, the transformer unconditionally unwrapped **every** paragraph inside the table to strip remarkMdx's parser-artifact `<p>` wrappers, but it ended up merging real multi-paragraph cell content.

**Fix**: We should have limit the unwrapping based on the parent tag. Table cells (`td` and `th`) now go through `unwrapSoleParagraph` (a lone wrapper still unwraps, multiple paragraphs stay separate), and only structural containers (`table`/`tbody`/`tr`/…) keep unwrapping unconditionally since only them actually requires it.

Tested with more edge-case examples: condensed formats, extra blank lines/indentation, markdown inside paragraphs, JSX `<Table>` with attributes, paragraphs next to lists, and sole-paragraph cells (still no stray `<p>`).

## 🧪 QA tips

- [ ] The original repro renders as two separate paragraphs inside the cell:

  ```
  <table><tbody><tr><td>
  First paragraph.

  Second paragraph.
  </td></tr></tbody></table>
  ```

- [ ] Markdown still renders inside each paragraph:

  ```
  <table><tbody><tr><td>
  **First** paragraph.

  _Second_ paragraph.
  </td></tr></tbody></table>
  ```

- [ ] A JSX `<Table>` kept as JSX (attributes on cells) also preserves the break:

  ```
  <Table>
    <thead>
      <tr><th class="head">Header</th></tr>
    </thead>
    <tbody>
      <tr>
        <td>
          First paragraph.

          Second paragraph.
        </td>
      </tr>
    </tbody>
  </Table>
  ```

- [ ] Single-line cells are unchanged — no extra `<p>` wrapper:

  ```
  <table><tbody><tr><td>
  Just one line.
  </td></tr></tbody></table>
  ```
