### PR TITLE
fix(mdxish): escape stray `<` in table cells

### DIFF
--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -907,6 +907,83 @@ Just one line.
     });
   });
 
+  describe('given a stray < that does not begin a tag', () => {
+    const buildTable = (cell: string): string => `<Table>
+  <thead>
+    <tr><th>Col 1</th><th>_Col 2_</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>**Custom**</td>
+      <td>
+        ${cell}
+      </td>
+    </tr>
+  </tbody>
+</Table>`;
+
+    it('keeps a trailing < as literal text while still processing cell markdown', () => {
+      const hast = mdxish(buildTable('word <'));
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      // Sibling cell markdown must render — the symptom of the failed parse is
+      // that even unrelated cells lose their markdown processing.
+      const strongs = findAllElementsByTagName(tables[0], 'strong');
+      expect(strongs).toHaveLength(1);
+      expect(JSON.stringify(strongs[0])).toContain('Custom');
+
+      const cells = findAllElementsByTagName(tables[0], 'td');
+      expect(JSON.stringify(cells[1])).toContain('word <');
+    });
+
+    it('keeps a < followed by a digit (<1>) as literal text', () => {
+      const hast = mdxish(buildTable('a <1>'));
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      expect(findAllElementsByTagName(tables[0], 'strong')).toHaveLength(1);
+
+      const cells = findAllElementsByTagName(tables[0], 'td');
+      expect(JSON.stringify(cells[1])).toContain('a <1>');
+      // The `<1>` must not be interpreted as an element.
+      expect(findAllElementsByTagName(tables[0], '1')).toHaveLength(0);
+    });
+
+    it('handles a stray < condensed against surrounding markdown', () => {
+      const hast = mdxish(buildTable('see **bold** < and _more_'));
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      // Both the sibling cell bold and the in-cell bold/italic survive.
+      expect(findAllElementsByTagName(tables[0], 'strong').length).toBeGreaterThanOrEqual(2);
+      expect(findAllElementsByTagName(tables[0], 'em').length).toBeGreaterThanOrEqual(1);
+      expect(JSON.stringify(tables[0])).toContain('<');
+    });
+
+    it('does not touch a < inside inline code (masked region)', () => {
+      const hast = mdxish(buildTable('`a < b`'));
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const codes = findAllElementsByTagName(tables[0], 'code');
+      expect(codes).toHaveLength(1);
+      expect(JSON.stringify(codes[0])).toContain('a < b');
+      // No stray backslash should have been injected into the code span.
+      expect(JSON.stringify(codes[0])).not.toContain('\\\\');
+    });
+
+    it('still parses a genuine tag in the same cell (no over-escaping)', () => {
+      const hast = mdxish(buildTable('one < two <br/> three'));
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      // The real <br/> is preserved as an element while the stray < is literal.
+      expect(findAllElementsByTagName(tables[0], 'br')).toHaveLength(1);
+      expect(JSON.stringify(tables[0])).toContain('one <');
+    });
+  });
+
   describe('given asymmetric inline/flow JSX inside cells', () => {
     // mdxjs throws when a JSX element's opener has trailing text on its line
     // but its closer sits alone on its own line (or vice versa). Without

--- a/processor/transform/mdxish/tables/escape-stray-less-than.ts
+++ b/processor/transform/mdxish/tables/escape-stray-less-than.ts
@@ -1,0 +1,28 @@
+import { maskNonTagRegions } from './tag-walker';
+import { applyInserts, type Insert, type RepairResult } from './utils';
+
+// A `<` only starts a JSX/HTML construct when followed by a tag-name start
+// (letter, `_`, `$`), a closer `/`, a fragment `>`, or a comment/declaration
+// `!`. Anything else (whitespace, EOL, a digit, …) is a literal `<` that acorn
+// rejects with "before name, expected a character that can start a name".
+const STRAY_LESS_THAN_RE = /<(?![a-zA-Z_$/>!])/g;
+
+/**
+ * Escapes stray `<` characters that don't begin a valid tag so the strict mdxjs
+ * parse treats them as literal text instead of throwing (`word <`, `a <1>`).
+ *
+ * Runs against the masked source so `<` inside code spans, legacy `<<var>>`
+ * syntax, or already-escaped `\<` are left untouched.
+ */
+export const escapeStrayLessThan = (html: string): RepairResult => {
+  const masked = maskNonTagRegions(html);
+  const inserts: Insert[] = [];
+
+  STRAY_LESS_THAN_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = STRAY_LESS_THAN_RE.exec(masked)) !== null) {
+    inserts.push({ offset: match.index, text: '\\' });
+  }
+
+  return applyInserts(html, inserts);
+};

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -21,6 +21,7 @@ import codeTabsTransformer from '../../code-tabs';
 import { extractText } from '../../extract-text';
 import normalizeEmphasisAST from '../normalize-malformed-md-syntax';
 
+import { escapeStrayLessThan } from './escape-stray-less-than';
 import { normalizeTagSpacing } from './normalize-tag-spacing';
 import { remapPositionsToOriginal } from './remap-positions';
 import { repairExpressionEscapes } from './repair-expression-escapes';
@@ -364,11 +365,14 @@ const mdxishTables = (): Transform => tree => {
       //  - normalizeTagSpacing:      a line mixing text and an opening tag
       //                              (e.g. `text <div> \n <div> text`)
       //  - repairExpressionEscapes:  backslash escapes inside a `{…}` expression
+      //  - escapeStrayLessThan:      a `<` that doesn't begin a valid tag
+      //                              (e.g. `word <`, `a <1>`)
       // These repairs are created after seeing real customer content that has failed to parse
       const repairs: ((html: string) => RepairResult)[] = [
         repairUnclosedTags,
         normalizeTagSpacing,
         repairExpressionEscapes,
+        escapeStrayLessThan,
       ];
       // Stops at the first repair that yields a parseable tree
       repairs.some(repair => {


### PR DESCRIPTION
| 🎫 Resolve RM-16920 |
| :-----------------: |

## 🎯 What does this PR do?

In MDXish tables, a single `<` in a cell may cause the table's content to stop being parsed (cell markdown rendered as raw text). The cause is that the MDX parser used in the table transformer rejects a `<` that isn't followed by a valid tag-name character: A trailing `<`, or `<` before a non-letter like `<1>` — is invalid JSX, so the parse throws and the table falls back to raw HTML. 

**Fix**: escape those stray `<` before the strict parse so MDX treats them as literal text, add on to the table repairers we already have.

## 🧪 QA tips

These tables render broken on `next` and correctly on this branch (cell markdown processes and the `<` shows as literal text):

Trailing `<`:

```
<Table>
  <thead>
    <tr><th>Col 1</th><th>_Col 2_</th></tr>
  </thead>
  <tbody>
    <tr>
      <td>**Custom**</td>
      <td>
        word <
      </td>
    </tr>
  </tbody>
</Table>
```

`<` followed by a non-letter (`<1>`):

```
<Table>
  <thead>
    <tr><th>Col 1</th><th>_Col 2_</th></tr>
  </thead>
  <tbody>
    <tr>
      <td>**Custom**</td>
      <td>
        a <1>
      </td>
    </tr>
  </tbody>
</Table>
```

## 📸 Screenshot or Loom

**Before**:

<img width="559" height="317" alt="Screenshot 2026-07-07 at 4 54 11 pm" src="https://github.com/user-attachments/assets/242aa762-6c6c-46ff-bf04-eda29d0ffd72" />

**After**:

<img width="524" height="316" alt="Screenshot 2026-07-07 at 4 54 31 pm" src="https://github.com/user-attachments/assets/b7b22417-9466-4a0b-b877-d6490ae9bf1a" />
