### PR TITLE
fix: keep TOC auto-scroll local to the TOC scroller so it can't cancel page scroll

### DIFF
--- a/__tests__/components/TableOfContents.test.jsx
+++ b/__tests__/components/TableOfContents.test.jsx
@@ -236,6 +236,89 @@ describe('Table of Contents', () => {
       expect(newLink.classList.contains('active')).toBe(true);
     });
 
+    describe('active link auto-scroll', () => {
+      it('scrolls the TOC-local scroll container when the active link is out of view, without scrollIntoView', async () => {
+        // The TOC has its own scroll area (separate from the content scroller).
+        const tocScrollContainer = document.createElement('div');
+        Object.defineProperties(tocScrollContainer, {
+          scrollTop: { value: 100, writable: true },
+          clientHeight: { value: 200, writable: true },
+          scrollHeight: { value: 600, writable: true },
+        });
+        tocScrollContainer.style.overflow = 'auto';
+        tocScrollContainer.scrollTo = vi.fn();
+        tocScrollContainer.getBoundingClientRect = () => ({ top: 0, bottom: 200, height: 200 });
+        document.body.appendChild(tocScrollContainer);
+
+        const { container } = render(
+          <TableOfContents>
+            <a href="#heading-1">Heading 1</a>
+            <a href="#heading-2">Heading 2</a>
+            <a href="#heading-3">Heading 3</a>
+          </TableOfContents>,
+          { container: tocScrollContainer },
+        );
+
+        await act(async () => {});
+
+        // The link for heading-2 sits below the TOC scroller's viewport.
+        const secondLink = [...container.querySelectorAll('a')].find(a => a.hash === '#heading-2');
+        secondLink.getBoundingClientRect = () => ({ top: 250, bottom: 270, height: 20 });
+        secondLink.scrollIntoView = vi.fn();
+
+        act(() => {
+          observerCallback([{ target: document.getElementById('heading-2'), isIntersecting: true }]);
+        });
+
+        // Scrolled just far enough to reveal the link (block: 'nearest' semantics),
+        // on the TOC's own scroller only.
+        expect(tocScrollContainer.scrollTo).toHaveBeenCalledWith({ top: 100 + (270 - 200), behavior: 'smooth' });
+        // scrollIntoView walks every scrollable ancestor and cancels in-flight
+        // smooth scrolls on the page's content scroller (CX-3667) — it must not be used.
+        expect(secondLink.scrollIntoView).not.toHaveBeenCalled();
+
+        tocScrollContainer.remove();
+      });
+
+      it('never scrolls a container that holds the page content (CX-3667)', async () => {
+        // No TOC-local scroll area: the TOC lives directly inside the content
+        // scroller, so the link's nearest scrollable ancestor is the same
+        // scroller the page animates during navigation. Auto-scrolling it would
+        // cancel the hub's scroll-to-top reset.
+        scrollContainer.scrollTo = vi.fn();
+        scrollContainer.getBoundingClientRect = () => ({ top: 0, bottom: 800, height: 800 });
+
+        // Render into a plain wrapper inside the content scroller (rendering
+        // straight into scrollContainer would wipe the headings from the DOM).
+        const wrapper = document.createElement('div');
+        scrollContainer.appendChild(wrapper);
+
+        const { container } = render(
+          <TableOfContents>
+            <a href="#heading-1">Heading 1</a>
+            <a href="#heading-2">Heading 2</a>
+            <a href="#heading-3">Heading 3</a>
+          </TableOfContents>,
+          { container: wrapper },
+        );
+
+        await act(async () => {});
+
+        // Even with the active link far out of view, the shared scroller stays put.
+        const secondLink = [...container.querySelectorAll('a')].find(a => a.hash === '#heading-2');
+        secondLink.getBoundingClientRect = () => ({ top: 5000, bottom: 5020, height: 20 });
+        secondLink.scrollIntoView = vi.fn();
+
+        act(() => {
+          observerCallback([{ target: document.getElementById('heading-2'), isIntersecting: true }]);
+        });
+
+        expect(secondLink.classList.contains('active')).toBe(true);
+        expect(scrollContainer.scrollTo).not.toHaveBeenCalled();
+        expect(secondLink.scrollIntoView).not.toHaveBeenCalled();
+      });
+    });
+
     it('should work when hrefs contain query params (frame preview mode)', async () => {
       // In frame preview mode, links may include query params before the hash,
       // e.g. href="?isFramePreview=true#heading-1" instead of "#heading-1".

--- a/components/TableOfContents/index.tsx
+++ b/components/TableOfContents/index.tsx
@@ -83,6 +83,34 @@ function useScrollHighlight(navRef: React.RefObject<HTMLElement | null>) {
         && scrollParent.scrollTop + scrollParent.clientHeight >= scrollParent.scrollHeight - SCROLL_BOTTOM_TOLERANCE;
     };
 
+    /**
+     * Keeps the active link visible within the TOC's own scroll container —
+     * the same result as `scrollIntoView({ block: 'nearest' })`, but scoped to
+     * a single scroller. `scrollIntoView` adjusts *every* scrollable ancestor,
+     * and starting a scroll on the page's content scroller cancels any
+     * in-flight smooth scroll there — e.g. the hub's scroll-to-top reset when
+     * navigating between pages (CX-3667).
+     */
+    const scrollLinkIntoView = (link: HTMLAnchorElement) => {
+      const tocScroller = getScrollParent(link);
+      // Without a TOC-local scroll area, the link's nearest scrollable
+      // ancestor is the window (`getScrollParent`'s fallback) or the scroller
+      // holding the page content — never auto-scroll those just to reveal a
+      // TOC link.
+      if (!(tocScroller instanceof HTMLElement) || tocScroller.contains(headings[0])) return;
+
+      const scrollerRect = tocScroller.getBoundingClientRect();
+      const linkRect = link.getBoundingClientRect();
+      if (linkRect.top < scrollerRect.top) {
+        tocScroller.scrollTo?.({ top: tocScroller.scrollTop + (linkRect.top - scrollerRect.top), behavior: 'smooth' });
+      } else if (linkRect.bottom > scrollerRect.bottom) {
+        tocScroller.scrollTo?.({
+          top: tocScroller.scrollTop + (linkRect.bottom - scrollerRect.bottom),
+          behavior: 'smooth',
+        });
+      }
+    };
+
     const activate = (id: string | null) => {
       if (id === activeId) return;
       if (activeId) linkMap.get(activeId)?.forEach(a => a.classList.remove('active'));
@@ -100,7 +128,7 @@ function useScrollHighlight(navRef: React.RefObject<HTMLElement | null>) {
           nav.style.setProperty('--ToC-border-active-height', `${linkRect.height}px`);
           nav.style.setProperty('--ToC-border-active-top', `${linkRect.top - navRect.top}px`);
 
-          link.scrollIntoView?.({ block: 'nearest', behavior: 'smooth' });
+          scrollLinkIntoView(link);
         }
       }
     };

--- a/components/TableOfContents/index.tsx
+++ b/components/TableOfContents/index.tsx
@@ -91,7 +91,7 @@ function useScrollHighlight(navRef: React.RefObject<HTMLElement | null>) {
      * in-flight smooth scroll there — e.g. the hub's scroll-to-top reset when
      * navigating between pages (CX-3667).
      */
-    const scrollLinkIntoView = (link: HTMLAnchorElement) => {
+    const scrollTOCLinkIntoView = (link: HTMLAnchorElement) => {
       const tocScroller = getScrollParent(link);
       // Without a TOC-local scroll area, the link's nearest scrollable
       // ancestor is the window (`getScrollParent`'s fallback) or the scroller
@@ -128,7 +128,7 @@ function useScrollHighlight(navRef: React.RefObject<HTMLElement | null>) {
           nav.style.setProperty('--ToC-border-active-height', `${linkRect.height}px`);
           nav.style.setProperty('--ToC-border-active-top', `${linkRect.top - navRect.top}px`);
 
-          scrollLinkIntoView(link);
+          scrollTOCLinkIntoView(link);
         }
       }
     };


### PR DESCRIPTION
| 🎫 Resolve CX-3667 |
| :-----------------: |

## 🎯 What does this PR do?

Fixes a regression introduced by #1503 (v14.10.0) that broke the docs hub's scroll-to-top reset when navigating to a cached sidebar sub-link (CX-3667, Enterprise-reported).

- #1503 made the TOC keep its active link visible via `link.scrollIntoView({ block: 'nearest', behavior: 'smooth' })`. `scrollIntoView` adjusts **every scrollable ancestor**, and starting a scroll on the page's content scroller cancels any in-flight smooth scroll there. In the hub, the reader clicks a cached sub-link → `ScrollTop` starts a smooth scroll to top → the new page's TOC activates its first heading ~40ms later → its `scrollIntoView` cancels the reset, leaving the reader stranded mid-page. Verified with an instrumented browser against production: with this call in place the content freezes at the old offset; with it removed the reset completes (798 → 0).
- This PR replaces `scrollIntoView` with `scrollLinkIntoView`: the same `block: 'nearest'` behavior, but computed manually and applied **only to the TOC's own scroll container**. If the link's nearest scrollable ancestor is the window or a scroller that also holds the page content (i.e. the TOC has no scroll area of its own), it does nothing — so it can never interfere with page-level scrolling.
- What #1503 fixed (CX-3452 — long TOCs with their own scroll area tracking the active item) still works: the TOC-local scroller is scrolled just far enough to reveal the link.

## 🧪 QA tips

- On a docs hub page: visit a sidebar child page, go back to its parent, scroll down, then click the child sub-link again (so it's served from cache). The page should land at the top — before this fix it kept the old scroll position.
- On a long page whose TOC overflows its own scroll area: scroll through the content and confirm the TOC still auto-scrolls to keep the active item visible (the #1503 behavior).
- Unit tests cover both: TOC-local scroller gets the exact block-nearest offset with `scrollIntoView` never called, and a scroller containing page content is never touched.
- E2E: simulated this exact implementation on production docs.readme.com — cached sub-link click scrolls 798 → 247 → 33 → 0.

## 📸 Screenshot or Loom

N/A — behavioral scroll fix; see QA steps. Repro/verification scripts documented in readmeio/readme#19561 (which this supersedes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)