### PR TITLE
fix: defer mermaid download until a diagram is present

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "vitest",
     "test.ui": "vitest --ui",
     "test.browser": "jest",
-    "verify-exports": "node scripts/verify-render-diff.cjs && node scripts/verify-render-fixture.cjs",
+    "verify-exports": "node scripts/verify-render-diff.cjs && node scripts/verify-render-fixture.cjs && node scripts/verify-lazy-mermaid.cjs",
     "watch": "webpack --watch --progress --mode development"
   },
   "dependencies": {

--- a/scripts/verify-lazy-mermaid.cjs
+++ b/scripts/verify-lazy-mermaid.cjs
@@ -1,0 +1,26 @@
+/* eslint-disable no-console -- CLI script: console output is the deliberate UX */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+// --- Lazy-mermaid guard: browser bundle must not load mermaid eagerly ---
+const bundlePath = process.env.VERIFY_LAZY_MERMAID_BUNDLE_PATH || path.join(__dirname, '..', 'dist', 'main.js');
+const bundle = fs.readFileSync(bundlePath, 'utf-8');
+
+assert(
+  !bundle.includes('require("mermaid")'),
+  `eager-load violation: require("mermaid") found in ${bundlePath} — mermaid is being loaded eagerly via the UMD factory`,
+);
+
+assert(
+  bundle.includes('import("mermaid")'),
+  `missing lazy import: import("mermaid") not found in ${bundlePath} — mermaid is either bundled or externalized eagerly`,
+);
+
+assert(
+  !bundle.includes('mermaidAPI'),
+  `bundling violation: mermaid library code found in ${bundlePath} — the mermaid external is not being applied`,
+);
+
+console.log(`lazy-mermaid guard: PASS — ${bundlePath} defers mermaid via import()`);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,7 +91,10 @@ const browserConfig = merge(getConfig({ target: 'web' }), {
     '@readme/variable': '@readme/variable',
     '@tippyjs/react': '@tippyjs/react',
     acorn: 'acorn',
-    mermaid: 'mermaid',
+    // 'import' (not a plain umd external) keeps import('mermaid') lazy in
+    // dist/main.js, so consumers only download mermaid when a diagram renders.
+    // Guarded by scripts/verify-lazy-mermaid.cjs.
+    mermaid: 'import mermaid',
     react: {
       amd: 'react',
       commonjs: 'react',
@@ -110,6 +113,10 @@ const browserConfig = merge(getConfig({ target: 'web' }), {
   output: {
     library: {
       type: 'umd',
+    },
+    // Required for the 'import mermaid' external
+    environment: {
+      dynamicImport: true,
     },
   },
   resolve: {


### PR DESCRIPTION
| 🎫 Resolve RM-17134 |
| :-----------------: |

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

- Consumers were downloading the mermaid library on every page, regardless of whether a diagram was present
- This was never intended to be the case, but the existing external meant the published dist/main.js began with `module.exports = factory(..., require("mermaid"), ...)` which forcibly loads mermaid anyway
- This fix ensures it only gets downloaded when truly needed, and adds a regression test to prevent it from occurring in the future

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- e2e tested: Before the fix, you would be able to search for `mermaidAPI` in the main.js on every page load. After this fix, you cannot find it. Also verified that mermaid diagrams rendered correctly

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
