### PR TITLE
fix(mdxish): render tables with tag-crossing emphasis and multiple per-cell defects

### DIFF
--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -1147,12 +1147,12 @@ Trailing paragraph then\`C\`<li>last</li></ul>
 <tbody>
 <tr>
 <td>
-The last day to be considered in the performance report snapshot. It cannot be the current date.  <br />**_Note:_**  _<ul><li>The reports encompass data until the end of the day (23:59:59 hrs ET) for this particular date_ </li><li>_If report data is not available for the requested end date, the request will fail, and the response will contain endDate until which the performance report is available_</li></ul>
+Hello  <br />**_Note:_**  _<ul><li>Random words_ </li><li>_Random words 2_</li></ul>
 </td>
 <td>
-Possible values: \`CAMPAIGN\`, \`CAMPAIGN_GROUP\`<ul><li>When \`reportType\` is set to \`campaign\`, \`lineItem\`,  \`sku\`,  or \`newBuyer\`, the default value of \`scope\` = \`CAMPAIGN\`</li><li>When \`reportType\` is set to \`creative\`, \`tactic\`, or \`bid\`: \`scope\` = \`CAMPAIGN_GROUP\` is not supported and will return an error.</li><li></li>
+Possible values: \`SENTINEL\`, \`RANDOM\`<ul><li>A list item</li><li></li>
 
-When \`scope\` = \`CAMPAIGN_GROUP\`, the \`campaign\`, \`lineItem\`, \`sku\`, \`newBuyer\` reports will have 2 additional fields: \`campaignGroupId\` and  \`campaignGroupName\`<li>If \`scope\` isn't defined in the request, it will be set to \`CAMPAIGN\` by default.</li></ul>
+When \`scope\` = \`SENTINEL_GROUP\`, the \`SENTINEL\`, reports will have 2 additional fields: \`SENTINELGroupId\` and  \`SENTINELGroupName\`<li>If \`scope\` isn't defined in the request, it will be set to \`SENTINEL\` by default.</li></ul>
 </td>
 </tr>
 </tbody>
@@ -1162,8 +1162,8 @@ When \`scope\` = \`CAMPAIGN_GROUP\`, the \`campaign\`, \`lineItem\`, \`sku\`, \`
       expect(html).toContain('<table');
       expect(html).toContain('<strong><em>Note:</em></strong>');
       expect(html).not.toContain('**_Note');
-      expect(html).toContain('<code>CAMPAIGN</code>');
-      expect(html).not.toContain('`CAMPAIGN`');
+      expect(html).toContain('<code>SENTINEL</code>');
+      expect(html).not.toContain('`SENTINEL`');
     });
   });
 

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -984,6 +984,189 @@ Just one line.
     });
   });
 
+  describe('given emphasis that crosses an HTML tag boundary inside a cell', () => {
+    it('escapes an underscore that opens outside a list and closes inside it', () => {
+      // `_` opens before `<ul>` (tag depth N) but closes inside `<li>` (depth
+      // N+2), which makes mdxjs throw and drop the whole table's markdown.
+      const doc = `<Table>
+<tbody>
+<tr>
+<td>**bold**</td>
+<td>_<ul><li>crossing underscore_</li></ul></td>
+</tr>
+</tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      // Sibling cell markdown must still render; the crossing `_` degrades to
+      // a literal underscore rather than breaking the table.
+      const strongs = findAllElementsByTagName(tables[0], 'strong');
+      expect(strongs).toHaveLength(1);
+      expect(JSON.stringify(strongs[0])).toContain('bold');
+
+      expect(findAllElementsByTagName(tables[0], 'ul')).toHaveLength(1);
+      const items = findAllElementsByTagName(tables[0], 'li');
+      expect(items).toHaveLength(1);
+      expect(JSON.stringify(items[0])).toContain('crossing underscore_');
+      expect(findAllElementsByTagName(items[0], 'em')).toHaveLength(0);
+    });
+
+    it('keeps well-formed emphasis inside a deeper tag while escaping the crossing one', () => {
+      const doc = `<Table>
+<tbody>
+<tr>
+<td>**heading**</td>
+<td>**_Note:_**  _<ul><li>opener escaped_ </li><li>_kept italic_</li></ul></td>
+</tr>
+</tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      // `**_Note:_**` and the balanced `_kept italic_` inside the second <li>
+      // are well-formed and must render; only the crossing `_` is escaped.
+      const html = toHtml(tables[0]);
+      expect(html).toContain('<strong><em>Note:</em></strong>');
+      expect(html).toContain('<li><em>kept italic</em></li>');
+      expect(html).toContain('opener escaped_');
+      expect(html).not.toContain('**_Note');
+    });
+
+    it('escapes a crossing bold (**) run the same way as underscores', () => {
+      const doc = `<Table>
+<tbody>
+<tr>
+<td>ok</td>
+<td>**<ul><li>bold crosses**</li></ul></td>
+</tr>
+</tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const items = findAllElementsByTagName(tables[0], 'li');
+      expect(items).toHaveLength(1);
+      expect(JSON.stringify(items[0])).toContain('bold crosses**');
+      expect(findAllElementsByTagName(items[0], 'strong')).toHaveLength(0);
+    });
+
+    it('does not touch snake_case or emphasis contained within a single tag', () => {
+      const doc = `<Table>
+<tbody>
+<tr>
+<td>**keep**</td>
+<td><ul><li>uses snake_case_name and _real italic_ here</li></ul></td>
+</tr>
+</tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      // Emphasis fully inside the <li> is well-formed, so it renders and the
+      // intraword underscores stay literal — no repair needed here.
+      const items = findAllElementsByTagName(tables[0], 'li');
+      expect(items).toHaveLength(1);
+      const emphasis = findAllElementsByTagName(items[0], 'em');
+      expect(emphasis).toHaveLength(1);
+      expect(JSON.stringify(emphasis[0])).toContain('real italic');
+      expect(JSON.stringify(items[0])).toContain('snake_case_name');
+    });
+
+    it('leaves an underscore inside inline code untouched (masked region)', () => {
+      const doc = `<Table>
+<tbody>
+<tr>
+<td>**keep**</td>
+<td>\`_<ul>_\` and text</td>
+</tr>
+</tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const codes = findAllElementsByTagName(tables[0], 'code');
+      expect(codes).toHaveLength(1);
+      expect(JSON.stringify(codes[0])).toContain('_<ul>_');
+      expect(JSON.stringify(codes[0])).not.toContain('\\\\');
+    });
+  });
+
+  describe('given independent parse defects in different cells (chained repairs)', () => {
+    it('fixes crossing emphasis in one cell and a blank-line-split <ul> in another', () => {
+      // Each cell fails mdxjs for a different reason: cell 1 has emphasis that
+      // crosses a tag boundary (escapeCrossingEmphasis) and cell 2 has a `<ul>`
+      // that spans a blank line / paragraph break (normalizeTagSpacing). Neither
+      // repair fixes both alone — they have to stack for the table to parse.
+      const doc = `<Table>
+<tbody>
+<tr>
+<td>
+Intro.  _<ul><li>crossing underscore_</li></ul>
+</td>
+<td>
+Values: \`A\`, \`B\`<ul><li>first</li><li></li>
+
+Trailing paragraph then\`C\`<li>last</li></ul>
+</td>
+</tr>
+</tbody>
+</Table>`;
+
+      const hast = mdxish(doc);
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+
+      const cells = findAllElementsByTagName(tables[0], 'td');
+      expect(cells).toHaveLength(2);
+
+      // Cell 1: crossing `_` degraded to literal, list still rendered.
+      expect(JSON.stringify(cells[0])).toContain('crossing underscore_');
+      // Cell 2: inline code parsed rather than left as raw backticks.
+      const codes = findAllElementsByTagName(tables[0], 'code');
+      expect(codes.length).toBeGreaterThanOrEqual(3);
+      const html = toHtml(tables[0]);
+      expect(html).toContain('<code>A</code>');
+      expect(html).not.toContain('`A`');
+      // Both cells' lists survive the two-cell layout.
+      expect(findAllElementsByTagName(tables[0], 'ul')).toHaveLength(2);
+    });
+
+    it('renders the reported two-cell table without leaking literal markdown', () => {
+      const doc = `<Table>
+<tbody>
+<tr>
+<td>
+The last day to be considered in the performance report snapshot. It cannot be the current date.  <br />**_Note:_**  _<ul><li>The reports encompass data until the end of the day (23:59:59 hrs ET) for this particular date_ </li><li>_If report data is not available for the requested end date, the request will fail, and the response will contain endDate until which the performance report is available_</li></ul>
+</td>
+<td>
+Possible values: \`CAMPAIGN\`, \`CAMPAIGN_GROUP\`<ul><li>When \`reportType\` is set to \`campaign\`, \`lineItem\`,  \`sku\`,  or \`newBuyer\`, the default value of \`scope\` = \`CAMPAIGN\`</li><li>When \`reportType\` is set to \`creative\`, \`tactic\`, or \`bid\`: \`scope\` = \`CAMPAIGN_GROUP\` is not supported and will return an error.</li><li></li>
+
+When \`scope\` = \`CAMPAIGN_GROUP\`, the \`campaign\`, \`lineItem\`, \`sku\`, \`newBuyer\` reports will have 2 additional fields: \`campaignGroupId\` and  \`campaignGroupName\`<li>If \`scope\` isn't defined in the request, it will be set to \`CAMPAIGN\` by default.</li></ul>
+</td>
+</tr>
+</tbody>
+</Table>`;
+
+      const html = toHtml(mdxish(doc));
+      expect(html).toContain('<table');
+      expect(html).toContain('<strong><em>Note:</em></strong>');
+      expect(html).not.toContain('**_Note');
+      expect(html).toContain('<code>CAMPAIGN</code>');
+      expect(html).not.toContain('`CAMPAIGN`');
+    });
+  });
+
   describe('given asymmetric inline/flow JSX inside cells', () => {
     // mdxjs throws when a JSX element's opener has trailing text on its line
     // but its closer sits alone on its own line (or vice versa). Without

--- a/processor/transform/mdxish/tables/escape-crossing-emphasis.ts
+++ b/processor/transform/mdxish/tables/escape-crossing-emphasis.ts
@@ -9,8 +9,7 @@ const isWhitespace = (ch: string | undefined): boolean => ch === undefined || /\
 // ASCII punctuation, per the CommonMark flanking definition. String bounds
 // (undefined) count as whitespace, not punctuation.
 const isPunctuation = (ch: string | undefined): boolean => {
-  if (ch === undefined) return false;
-  const code = ch.charCodeAt(0);
+  const code = ch?.charCodeAt(0) ?? -1;
   return (
     (code >= 33 && code <= 47) ||
     (code >= 58 && code <= 64) ||
@@ -25,14 +24,13 @@ interface Flanking {
 }
 
 /**
- * Decide whether a delimiter run can open and/or close emphasis, following
- * CommonMark's left/right-flanking rules. `_` additionally can't open/close
- * intraword, which is what keeps `snake_case` from being treated as emphasis.
+ * Whether a delimiter run can open and/or close emphasis, per CommonMark's
+ * left/right-flanking rules. The extra `_` conditions forbid intraword
+ * emphasis, which keeps `snake_case` from being treated as a delimiter.
  */
 const analyzeFlanking = (source: string, char: string, start: number, end: number): Flanking => {
-  const before = start > 0 ? source[start - 1] : undefined;
-  const after = end < source.length ? source[end] : undefined;
-
+  const before = source[start - 1];
+  const after = source[end];
   const leftFlanking =
     !isWhitespace(after) && (!isPunctuation(after) || isWhitespace(before) || isPunctuation(before));
   const rightFlanking =
@@ -47,54 +45,45 @@ const analyzeFlanking = (source: string, char: string, start: number, end: numbe
   return { canOpen: leftFlanking, canClose: rightFlanking };
 };
 
-interface TagOpenEvent {
-  kind: 'tagOpen';
-  offset: number;
-}
-interface TagCloseEvent {
-  kind: 'tagClose';
-  offset: number;
-}
-interface EmphasisEvent {
-  char: string;
-  flanking: Flanking;
-  kind: 'emphasis';
-  length: number;
-  offset: number;
-}
-type WalkEvent = EmphasisEvent | TagCloseEvent | TagOpenEvent;
+type WalkEvent =
+  | { char: string; flanking: Flanking; kind: 'emphasis'; length: number; offset: number }
+  | { kind: 'tagClose'; offset: number }
+  | { kind: 'tagOpen'; offset: number };
 
-// At a shared offset, an opener must sort before an emphasis run before a closer
-// so a self-closing tag's open/close bracket the run rather than swallow it.
-const eventPriority = (event: WalkEvent): number =>
-  event.kind === 'tagOpen' ? 0 : event.kind === 'emphasis' ? 1 : 2;
+/**
+ * Collect HTML tag boundaries (via htmlparser2) and emphasis delimiter runs
+ * (via regex over the masked source, so code spans and escaped `<` are skipped)
+ * into one list ordered by position. At a shared offset a tag opener sorts
+ * before a closer, so a self-closing tag brackets rather than swallows a run.
+ */
+const collectEvents = (html: string): WalkEvent[] => {
+  const masked = maskNonTagRegions(html);
+  const events: WalkEvent[] = [];
 
-const collectTagEvents = (source: string): (TagCloseEvent | TagOpenEvent)[] => {
-  const events: (TagCloseEvent | TagOpenEvent)[] = [];
-  walkTags(source, {
+  walkTags(html, {
     onOpen: ({ start }) => events.push({ kind: 'tagOpen', offset: start }),
     onClose: ({ start }) => events.push({ kind: 'tagClose', offset: start }),
   });
-  return events;
-};
 
-const collectEmphasisEvents = (masked: string, source: string): EmphasisEvent[] => {
-  const events: EmphasisEvent[] = [];
   EMPHASIS_RUN_RE.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = EMPHASIS_RUN_RE.exec(masked)) !== null) {
+    const [run, char] = match;
     const start = match.index;
-    // Leave already-escaped delimiters alone.
     // eslint-disable-next-line no-continue
-    if (source[start - 1] === '\\') continue;
-    const char = match[1];
-    const length = match[0].length;
-    events.push({ kind: 'emphasis', offset: start, char, length, flanking: analyzeFlanking(source, char, start, start + length) });
+    if (html[start - 1] === '\\') continue; // already escaped
+    events.push({ kind: 'emphasis', offset: start, char, length: run.length, flanking: analyzeFlanking(html, char, start, start + run.length) });
   }
-  return events;
+
+  return events.sort((a, b) => a.offset - b.offset || (a.kind === 'tagClose' ? 1 : 0) - (b.kind === 'tagClose' ? 1 : 0));
 };
 
-type Frame = { char: string; kind: 'em'; length: number; offset: number } | { kind: 'tag' };
+interface OpenEmphasis {
+  char: string;
+  depth: number;
+  length: number;
+  offset: number;
+}
 
 /**
  * mdxjs rejects a table when a markdown emphasis run opens at one HTML
@@ -103,50 +92,44 @@ type Frame = { char: string; kind: 'em'; length: number; offset: number } | { ki
  * "Expected a closing tag for `<li>` before the end of `emphasis`" and the
  * whole `<Table>` fails to parse.
  *
- * This pass walks tags and emphasis delimiters together, keeping a stack of
- * open tags and open emphasis. A delimiter only matches an opener living in the
- * same tag context; any emphasis left dangling when its enclosing tag closes
- * (or at end of input), and any closer with no in-context opener, is escaped so
- * mdxjs treats it as literal text. Scoped to the malformed-retry path.
+ * We walk tags and emphasis together, tracking tag depth and a stack of open
+ * emphasis. A delimiter only closes an opener at the same depth; any emphasis
+ * still open when its enclosing tag closes (or at end of input), and any closer
+ * with no same-depth opener, is escaped so mdxjs treats it as literal text.
+ * Scoped to the malformed-retry path.
  */
 export const escapeCrossingEmphasis = (html: string): RepairResult => {
-  const masked = maskNonTagRegions(html);
-  const events: WalkEvent[] = [...collectTagEvents(html), ...collectEmphasisEvents(masked, html)].sort(
-    (a, b) => a.offset - b.offset || eventPriority(a) - eventPriority(b),
-  );
-
-  const stack: Frame[] = [];
+  const open: OpenEmphasis[] = [];
   const orphans: { length: number; offset: number }[] = [];
+  let depth = 0;
 
-  events.forEach(event => {
+  collectEvents(html).forEach(event => {
     if (event.kind === 'tagOpen') {
-      stack.push({ kind: 'tag' });
+      depth += 1;
       return;
     }
     if (event.kind === 'tagClose') {
-      // Unwind to the nearest open tag; emphasis opened inside it never closed
-      // within the tag, so it crosses the boundary.
-      while (stack.length > 0) {
-        const frame = stack.pop();
-        if (!frame || frame.kind === 'tag') break;
-        orphans.push({ offset: frame.offset, length: frame.length });
+      depth -= 1;
+      // Emphasis opened deeper than the surviving depth was inside the tag that
+      // just closed, so it crosses the boundary.
+      while (open.length > 0 && open[open.length - 1].depth > depth) {
+        const crossed = open.pop();
+        if (crossed) orphans.push(crossed);
       }
       return;
     }
 
-    const top = stack[stack.length - 1];
-    if (event.flanking.canClose && top?.kind === 'em' && top.char === event.char) {
-      stack.pop();
+    const top = open[open.length - 1];
+    if (event.flanking.canClose && top?.char === event.char && top.depth === depth) {
+      open.pop();
     } else if (event.flanking.canOpen) {
-      stack.push({ kind: 'em', char: event.char, offset: event.offset, length: event.length });
+      open.push({ char: event.char, depth, offset: event.offset, length: event.length });
     } else if (event.flanking.canClose) {
       orphans.push({ offset: event.offset, length: event.length });
     }
   });
 
-  stack.forEach(frame => {
-    if (frame.kind === 'em') orphans.push({ offset: frame.offset, length: frame.length });
-  });
+  orphans.push(...open); // anything still open never closed
 
   const inserts: Insert[] = orphans.flatMap(({ offset, length }) =>
     Array.from({ length }, (_unused, i) => ({ offset: offset + i, text: '\\' })),

--- a/processor/transform/mdxish/tables/escape-crossing-emphasis.ts
+++ b/processor/transform/mdxish/tables/escape-crossing-emphasis.ts
@@ -1,0 +1,155 @@
+import { maskNonTagRegions, walkTags } from './tag-walker';
+import { applyInserts, type Insert, type RepairResult } from './utils';
+
+// Maximal run of a single emphasis delimiter (`_`, `*`, `**`, `***`, …).
+const EMPHASIS_RUN_RE = /([*_])\1*/g;
+
+const isWhitespace = (ch: string | undefined): boolean => ch === undefined || /\s/.test(ch);
+
+// ASCII punctuation, per the CommonMark flanking definition. String bounds
+// (undefined) count as whitespace, not punctuation.
+const isPunctuation = (ch: string | undefined): boolean => {
+  if (ch === undefined) return false;
+  const code = ch.charCodeAt(0);
+  return (
+    (code >= 33 && code <= 47) ||
+    (code >= 58 && code <= 64) ||
+    (code >= 91 && code <= 96) ||
+    (code >= 123 && code <= 126)
+  );
+};
+
+interface Flanking {
+  canClose: boolean;
+  canOpen: boolean;
+}
+
+/**
+ * Decide whether a delimiter run can open and/or close emphasis, following
+ * CommonMark's left/right-flanking rules. `_` additionally can't open/close
+ * intraword, which is what keeps `snake_case` from being treated as emphasis.
+ */
+const analyzeFlanking = (source: string, char: string, start: number, end: number): Flanking => {
+  const before = start > 0 ? source[start - 1] : undefined;
+  const after = end < source.length ? source[end] : undefined;
+
+  const leftFlanking =
+    !isWhitespace(after) && (!isPunctuation(after) || isWhitespace(before) || isPunctuation(before));
+  const rightFlanking =
+    !isWhitespace(before) && (!isPunctuation(before) || isWhitespace(after) || isPunctuation(after));
+
+  if (char === '_') {
+    return {
+      canOpen: leftFlanking && (!rightFlanking || isPunctuation(before)),
+      canClose: rightFlanking && (!leftFlanking || isPunctuation(after)),
+    };
+  }
+  return { canOpen: leftFlanking, canClose: rightFlanking };
+};
+
+interface TagOpenEvent {
+  kind: 'tagOpen';
+  offset: number;
+}
+interface TagCloseEvent {
+  kind: 'tagClose';
+  offset: number;
+}
+interface EmphasisEvent {
+  char: string;
+  flanking: Flanking;
+  kind: 'emphasis';
+  length: number;
+  offset: number;
+}
+type WalkEvent = EmphasisEvent | TagCloseEvent | TagOpenEvent;
+
+// At a shared offset, an opener must sort before an emphasis run before a closer
+// so a self-closing tag's open/close bracket the run rather than swallow it.
+const eventPriority = (event: WalkEvent): number =>
+  event.kind === 'tagOpen' ? 0 : event.kind === 'emphasis' ? 1 : 2;
+
+const collectTagEvents = (source: string): (TagCloseEvent | TagOpenEvent)[] => {
+  const events: (TagCloseEvent | TagOpenEvent)[] = [];
+  walkTags(source, {
+    onOpen: ({ start }) => events.push({ kind: 'tagOpen', offset: start }),
+    onClose: ({ start }) => events.push({ kind: 'tagClose', offset: start }),
+  });
+  return events;
+};
+
+const collectEmphasisEvents = (masked: string, source: string): EmphasisEvent[] => {
+  const events: EmphasisEvent[] = [];
+  EMPHASIS_RUN_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = EMPHASIS_RUN_RE.exec(masked)) !== null) {
+    const start = match.index;
+    // Leave already-escaped delimiters alone.
+    // eslint-disable-next-line no-continue
+    if (source[start - 1] === '\\') continue;
+    const char = match[1];
+    const length = match[0].length;
+    events.push({ kind: 'emphasis', offset: start, char, length, flanking: analyzeFlanking(source, char, start, start + length) });
+  }
+  return events;
+};
+
+type Frame = { char: string; kind: 'em'; length: number; offset: number } | { kind: 'tag' };
+
+/**
+ * mdxjs rejects a table when a markdown emphasis run opens at one HTML
+ * tag-nesting depth and closes at another — e.g. `_<ul><li>text_</li></ul>`,
+ * where the `_` opens outside the list but closes inside a `<li>`. It throws
+ * "Expected a closing tag for `<li>` before the end of `emphasis`" and the
+ * whole `<Table>` fails to parse.
+ *
+ * This pass walks tags and emphasis delimiters together, keeping a stack of
+ * open tags and open emphasis. A delimiter only matches an opener living in the
+ * same tag context; any emphasis left dangling when its enclosing tag closes
+ * (or at end of input), and any closer with no in-context opener, is escaped so
+ * mdxjs treats it as literal text. Scoped to the malformed-retry path.
+ */
+export const escapeCrossingEmphasis = (html: string): RepairResult => {
+  const masked = maskNonTagRegions(html);
+  const events: WalkEvent[] = [...collectTagEvents(html), ...collectEmphasisEvents(masked, html)].sort(
+    (a, b) => a.offset - b.offset || eventPriority(a) - eventPriority(b),
+  );
+
+  const stack: Frame[] = [];
+  const orphans: { length: number; offset: number }[] = [];
+
+  events.forEach(event => {
+    if (event.kind === 'tagOpen') {
+      stack.push({ kind: 'tag' });
+      return;
+    }
+    if (event.kind === 'tagClose') {
+      // Unwind to the nearest open tag; emphasis opened inside it never closed
+      // within the tag, so it crosses the boundary.
+      while (stack.length > 0) {
+        const frame = stack.pop();
+        if (!frame || frame.kind === 'tag') break;
+        orphans.push({ offset: frame.offset, length: frame.length });
+      }
+      return;
+    }
+
+    const top = stack[stack.length - 1];
+    if (event.flanking.canClose && top?.kind === 'em' && top.char === event.char) {
+      stack.pop();
+    } else if (event.flanking.canOpen) {
+      stack.push({ kind: 'em', char: event.char, offset: event.offset, length: event.length });
+    } else if (event.flanking.canClose) {
+      orphans.push({ offset: event.offset, length: event.length });
+    }
+  });
+
+  stack.forEach(frame => {
+    if (frame.kind === 'em') orphans.push({ offset: frame.offset, length: frame.length });
+  });
+
+  const inserts: Insert[] = orphans.flatMap(({ offset, length }) =>
+    Array.from({ length }, (_unused, i) => ({ offset: offset + i, text: '\\' })),
+  );
+  return applyInserts(html, inserts);
+};

--- a/processor/transform/mdxish/tables/escape-crossing-emphasis.ts
+++ b/processor/transform/mdxish/tables/escape-crossing-emphasis.ts
@@ -1,22 +1,16 @@
+import { unicodePunctuation, unicodeWhitespace } from 'micromark-util-character';
+
 import { maskNonTagRegions, walkTags } from './tag-walker';
 import { applyInserts, type Insert, type RepairResult } from './utils';
 
 // Maximal run of a single emphasis delimiter (`_`, `*`, `**`, `***`, …).
 const EMPHASIS_RUN_RE = /([*_])\1*/g;
 
-const isWhitespace = (ch: string | undefined): boolean => ch === undefined || /\s/.test(ch);
+// String bounds (undefined) count as whitespace, not punctuation, per the
+// CommonMark flanking definition.
+const isWhitespace = (ch: string | undefined): boolean => ch === undefined || unicodeWhitespace(ch.charCodeAt(0));
 
-// ASCII punctuation, per the CommonMark flanking definition. String bounds
-// (undefined) count as whitespace, not punctuation.
-const isPunctuation = (ch: string | undefined): boolean => {
-  const code = ch?.charCodeAt(0) ?? -1;
-  return (
-    (code >= 33 && code <= 47) ||
-    (code >= 58 && code <= 64) ||
-    (code >= 91 && code <= 96) ||
-    (code >= 123 && code <= 126)
-  );
-};
+const isPunctuation = (ch: string | undefined): boolean => ch !== undefined && unicodePunctuation(ch.charCodeAt(0));
 
 interface Flanking {
   canClose: boolean;

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -64,6 +64,22 @@ const buildTableNodeProcessor = (withMdx: boolean) =>
 const tableNodeProcessor = buildTableNodeProcessor(true);
 const fallbackTableNodeProcessor = buildTableNodeProcessor(false);
 
+// Targeted repairs for tables mdxjs rejects, tried cumulatively (each runs on
+// the prior's output) since one table can carry independent per-cell defects.
+// Each was added after seeing real customer content fail to parse:
+//  - repairUnclosedTags:      unclosed/orphan HTML tags
+//  - normalizeTagSpacing:     a line mixing text and an opening tag
+//  - repairExpressionEscapes: backslash escapes inside a `{…}` expression
+//  - escapeStrayLessThan:     a `<` that doesn't begin a valid tag (`word <`)
+//  - escapeCrossingEmphasis:  emphasis opening/closing at different tag depths
+const tableRepairs: ((html: string) => RepairResult)[] = [
+  repairUnclosedTags,
+  normalizeTagSpacing,
+  repairExpressionEscapes,
+  escapeStrayLessThan,
+  escapeCrossingEmphasis,
+];
+
 /**
  * Parse the HTML node that contains the full table substring
  * into the table parts (headers, rows, cells).
@@ -110,9 +126,7 @@ const parseTableNode = (
  * Check if children are only text nodes that might contain markdown
  */
 const isTextOnly = (children: unknown[]): boolean => {
-  return children.every(
-    child => child && typeof child === 'object' && 'type' in child && child.type === 'text',
-  );
+  return children.every(child => child && typeof child === 'object' && 'type' in child && child.type === 'text');
 };
 
 /**
@@ -202,11 +216,7 @@ const processTableNode = (
   let hasStructuralAttributes = false;
   visit(node as Node, isMDXElement, (child: MdxJsxFlowElement | MdxJsxTextElement) => {
     if (child.name === 'thead') hasThead = true;
-    if (
-      tableTags.has(child.name) &&
-      Array.isArray(child.attributes) &&
-      child.attributes.length > 0
-    ) {
+    if (tableTags.has(child.name) && Array.isArray(child.attributes) && child.attributes.length > 0) {
       hasStructuralAttributes = true;
     }
   });
@@ -218,8 +228,7 @@ const processTableNode = (
     // whitespace-only text nodes to avoid rendering empty <p>/<br>.
     const removeWhitespaceOnlyTextNodes = (children: Node[]): Node[] =>
       children.filter(
-        child =>
-          !(child.type === 'text' && 'value' in child && typeof child.value === 'string' && !child.value.trim()),
+        child => !(child.type === 'text' && 'value' in child && typeof child.value === 'string' && !child.value.trim()),
       );
 
     visit(node as Node, isMDXElement, (el: MdxJsxFlowElement | MdxJsxTextElement) => {
@@ -338,6 +347,32 @@ const processTableNode = (
 };
 
 /**
+ * Apply `tableRepairs` cumulatively, re-parsing after every change and stopping
+ * once the accumulated result parses. Each layer's inserts are relative to the
+ * string that repair received, so they stay ordered for position remapping.
+ */
+const repairAndReparse = (node: Html): Root | undefined => {
+  let repairedValue = node.value;
+  const layers: Insert[][] = [];
+  let parsed: Root | undefined;
+
+  tableRepairs.some(repair => {
+    const { value, inserts } = repair(repairedValue);
+    if (value === repairedValue) return false;
+    repairedValue = value;
+    layers.push(inserts);
+    parsed = parseTableNode(
+      tableNodeProcessor,
+      { ...node, value: repairedValue },
+      { layers, originalSource: node.value },
+    );
+    return Boolean(parsed);
+  });
+
+  return parsed;
+};
+
+/**
  * Converts JSX Table elements to markdown table nodes and re-parses markdown in cells.
  *
  * The jsxTable micromark tokenizer captures `<Table>...</Table>` as a single html node,
@@ -354,52 +389,10 @@ const mdxishTables = (): Transform => tree => {
     if (typeof index !== 'number' || !parent || !('children' in parent)) return;
     if (!node.value.startsWith('<Table') && !node.value.startsWith('<table')) return;
 
-    // Main logic to transform table node to its parts
     // Because the processor uses remarkMdx, it is stricter in what it accepts
-    // and only accepts valid MDX syntax. in the table node.
-    // To get around that, we have some fallback logics after trying to repair the table content.
-    let parsed = parseTableNode(tableNodeProcessor, node);
-    if (!parsed) {
-      // Apply a sequence of targeted repairs cumulatively — each runs on the
-      // prior repair's output — and re-parse after every change, stopping once
-      // the accumulated result parses. Chaining matters because a single table
-      // can carry independent defects in different cells (e.g. crossing
-      // emphasis in one and a blank-line-split `<ul>` in another) that no single
-      // repair fixes on its own.
-      //  - repairUnclosedTags:       unclosed/orphan HTML tags
-      //  - normalizeTagSpacing:      a line mixing text and an opening tag
-      //                              (e.g. `text <div> \n <div> text`)
-      //  - repairExpressionEscapes:  backslash escapes inside a `{…}` expression
-      //  - escapeStrayLessThan:      a `<` that doesn't begin a valid tag
-      //                              (e.g. `word <`, `a <1>`)
-      //  - escapeCrossingEmphasis:   an emphasis run that opens and closes at
-      //                              different tag depths (e.g. `_<ul><li>x_`)
-      // These repairs are created after seeing real customer content that has failed to parse
-      const repairs: ((html: string) => RepairResult)[] = [
-        repairUnclosedTags,
-        normalizeTagSpacing,
-        repairExpressionEscapes,
-        escapeStrayLessThan,
-        escapeCrossingEmphasis,
-      ];
-
-      // Each layer's inserts are relative to the string that repair received, so
-      // we keep them ordered to remap parsed positions back to `node.value`.
-      let repairedValue = node.value;
-      const layers: Insert[][] = [];
-      repairs.some(repair => {
-        const { value, inserts } = repair(repairedValue);
-        if (value === repairedValue) return false;
-        repairedValue = value;
-        layers.push(inserts);
-        parsed = parseTableNode(
-          tableNodeProcessor,
-          { ...node, value: repairedValue },
-          { layers, originalSource: node.value },
-        );
-        return Boolean(parsed);
-      });
-    }
+    // and only accepts valid MDX syntax in the table node. To get around that,
+    // fall back to the cumulative repairs when the first parse fails.
+    const parsed = parseTableNode(tableNodeProcessor, node) ?? repairAndReparse(node);
 
     if (parsed) {
       // If the table is parsed successfully, we can now process it further

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -21,9 +21,10 @@ import codeTabsTransformer from '../../code-tabs';
 import { extractText } from '../../extract-text';
 import normalizeEmphasisAST from '../normalize-malformed-md-syntax';
 
+import { escapeCrossingEmphasis } from './escape-crossing-emphasis';
 import { escapeStrayLessThan } from './escape-stray-less-than';
 import { normalizeTagSpacing } from './normalize-tag-spacing';
-import { remapPositionsToOriginal } from './remap-positions';
+import { remapPositionsThroughLayers } from './remap-positions';
 import { repairExpressionEscapes } from './repair-expression-escapes';
 import { repairUnclosedTags } from './repair-unclosed-tags';
 import { tableTags, unwrapParagraphNodes, unwrapSoleParagraph, type Insert, type RepairResult } from './utils';
@@ -72,7 +73,7 @@ const fallbackTableNodeProcessor = buildTableNodeProcessor(false);
 const parseTableNode = (
   processor: typeof tableNodeProcessor,
   node: Html,
-  repair?: { inserts: Insert[]; originalSource: string },
+  repair?: { layers: Insert[][]; originalSource: string },
 ): Root | undefined => {
   let parsed: Root;
   try {
@@ -82,10 +83,10 @@ const parseTableNode = (
   }
 
   // If `node.value` was repaired before parsing, first remap positions back to
-  // the original (unrepaired) coordinates via the insert list — otherwise the
+  // the original (unrepaired) coordinates via the insert layers — otherwise the
   // shift would land on synthetic characters and be inaccurate
   if (repair) {
-    remapPositionsToOriginal(parsed as Node, repair.originalSource, repair.inserts);
+    remapPositionsThroughLayers(parsed as Node, repair.originalSource, repair.layers);
   }
 
   // The subparser produces positions relative to `node.value`; shift them by
@@ -359,27 +360,43 @@ const mdxishTables = (): Transform => tree => {
     // To get around that, we have some fallback logics after trying to repair the table content.
     let parsed = parseTableNode(tableNodeProcessor, node);
     if (!parsed) {
-      // Try a sequence of targeted repairs and re-parse
-      // after each, stopping at the first that yields a parseable tree:
+      // Apply a sequence of targeted repairs cumulatively — each runs on the
+      // prior repair's output — and re-parse after every change, stopping once
+      // the accumulated result parses. Chaining matters because a single table
+      // can carry independent defects in different cells (e.g. crossing
+      // emphasis in one and a blank-line-split `<ul>` in another) that no single
+      // repair fixes on its own.
       //  - repairUnclosedTags:       unclosed/orphan HTML tags
       //  - normalizeTagSpacing:      a line mixing text and an opening tag
       //                              (e.g. `text <div> \n <div> text`)
       //  - repairExpressionEscapes:  backslash escapes inside a `{…}` expression
       //  - escapeStrayLessThan:      a `<` that doesn't begin a valid tag
       //                              (e.g. `word <`, `a <1>`)
+      //  - escapeCrossingEmphasis:   an emphasis run that opens and closes at
+      //                              different tag depths (e.g. `_<ul><li>x_`)
       // These repairs are created after seeing real customer content that has failed to parse
       const repairs: ((html: string) => RepairResult)[] = [
         repairUnclosedTags,
         normalizeTagSpacing,
         repairExpressionEscapes,
         escapeStrayLessThan,
+        escapeCrossingEmphasis,
       ];
-      // Stops at the first repair that yields a parseable tree
+
+      // Each layer's inserts are relative to the string that repair received, so
+      // we keep them ordered to remap parsed positions back to `node.value`.
+      let repairedValue = node.value;
+      const layers: Insert[][] = [];
       repairs.some(repair => {
-        const { value, inserts } = repair(node.value);
-        if (value !== node.value) {
-          parsed = parseTableNode(tableNodeProcessor, { ...node, value }, { inserts, originalSource: node.value });
-        }
+        const { value, inserts } = repair(repairedValue);
+        if (value === repairedValue) return false;
+        repairedValue = value;
+        layers.push(inserts);
+        parsed = parseTableNode(
+          tableNodeProcessor,
+          { ...node, value: repairedValue },
+          { layers, originalSource: node.value },
+        );
         return Boolean(parsed);
       });
     }

--- a/processor/transform/mdxish/tables/remap-positions.ts
+++ b/processor/transform/mdxish/tables/remap-positions.ts
@@ -103,14 +103,6 @@ const remapWithMapper = (tree: Node, originalSource: string, mapOffset: (repaire
 };
 
 /**
- * Remap positions produced from a single-repair string back to the original.
- */
-export const remapPositionsToOriginal = (tree: Node, originalSource: string, inserts: Insert[]): void => {
-  if (inserts.length === 0) return;
-  remapWithMapper(tree, originalSource, buildOffsetMapper(inserts));
-};
-
-/**
  * Remap positions produced after a chain of repairs (each applied to the prior
  * one's output) back to the original source coordinates.
  */

--- a/processor/transform/mdxish/tables/remap-positions.ts
+++ b/processor/transform/mdxish/tables/remap-positions.ts
@@ -37,6 +37,21 @@ const buildOffsetMapper = (inserts: Insert[]): ((repaired: number) => number) =>
 };
 
 /**
+ * Compose the per-repair offset mappers into one that maps an offset in the
+ * fully-repaired string back to the original. `layers` are in application
+ * order; each maps its own output space to its input space, so we apply them
+ * last-repair-first to peel every edit back to the original coordinates.
+ */
+const composeOffsetMapper = (layers: Insert[][]): ((repaired: number) => number) => {
+  const mappers = layers.map(buildOffsetMapper);
+  return (repaired: number): number => {
+    let offset = repaired;
+    for (let i = mappers.length - 1; i >= 0; i -= 1) offset = mappers[i](offset);
+    return offset;
+  };
+};
+
+/**
  * Map an offset in `source` to its 1-based `{ line, column }`. `lineStarts`
  * is the precomputed array of offsets where each line begins.
  */
@@ -62,13 +77,11 @@ const computeLineStarts = (source: string): number[] => {
 
 /**
  * Walk `tree`, translating every node's position from the repaired source's
- * coordinate space back to the original source. Offsets are remapped via the
- * insert list; line/column are recomputed from the original source so they
- * remain accurate even if repairs introduced newlines.
+ * coordinate space back to the original source via `mapOffset`. Line/column
+ * are recomputed from the original source so they remain accurate even if
+ * repairs introduced newlines.
  */
-export const remapPositionsToOriginal = (tree: Node, originalSource: string, inserts: Insert[]): void => {
-  if (inserts.length === 0) return;
-  const mapOffset = buildOffsetMapper(inserts);
+const remapWithMapper = (tree: Node, originalSource: string, mapOffset: (repaired: number) => number): void => {
   const lineStarts = computeLineStarts(originalSource);
 
   visit(tree, child => {
@@ -87,4 +100,21 @@ export const remapPositionsToOriginal = (tree: Node, originalSource: string, ins
       child.position.end.column = column;
     }
   });
+};
+
+/**
+ * Remap positions produced from a single-repair string back to the original.
+ */
+export const remapPositionsToOriginal = (tree: Node, originalSource: string, inserts: Insert[]): void => {
+  if (inserts.length === 0) return;
+  remapWithMapper(tree, originalSource, buildOffsetMapper(inserts));
+};
+
+/**
+ * Remap positions produced after a chain of repairs (each applied to the prior
+ * one's output) back to the original source coordinates.
+ */
+export const remapPositionsThroughLayers = (tree: Node, originalSource: string, layers: Insert[][]): void => {
+  if (layers.length === 0) return;
+  remapWithMapper(tree, originalSource, composeOffsetMapper(layers));
 };


### PR DESCRIPTION
| 🎫 Resolve CX-3655 |
| :-----------------: |

## 🎯 What does this PR do?

A customer `<Table>` with markdown inside its cells rendered as literal text. It turned out the doc hit **two independent parse failures** that the strict mdxjs table parser rejected and the repair chain couldn't recover from:

1. **Emphasis crossing a tag boundary**: e.g. `_<ul><li>…date_`, where a `_` opens outside the list but closes inside a `<li>`. mdxjs throws *"Expected a closing tag for `<li>` before the end of `emphasis`"*. New `escapeCrossingEmphasis` repair escapes only the delimiters whose partner sits at a different tag depth, so those degrade to literal text while the rest of the cell still renders.

2. **Two cells, each broken differently**: one cell had the crossing emphasis above, the other a `<ul>` spanning a blank line (already handled by `normalizeTagSpacing`). Each repair ran on the *original* source independently, so no single one fixed both and the table stayed broken — oddly, either cell on its own rendered fine. The repair loop now applies repairs **cumulatively** (each runs on the previous one's output) so independent defects stack, with position remapping composed across the layers.

## 🧪 QA tips

Both should now render as a proper table with the markdown/HTML inside the cells processed (previously the whole table came through as literal text):

**Single cell — crossing emphasis**
```md
<Table>
<tbody>
<tr>
<td>**bold**</td>
<td>
The last day to be considered in the performance report snapshot. It cannot be the current date.  <br />**_Note:_**  _<ul><li>The reports encompass data until the end of the day (23:59:59 hrs ET) for this particular date_ </li><li>_If report data is not available for the requested end date, the request will fail, and the response will contain endDate until which the performance report is available_</li></ul>
</td>
</tr>
</tbody>
</Table>
```

**Two cells — independent defects (only broke when both were present)**
```md
<Table>
<tbody>
<tr>
<td>
The last day to be considered in the performance report snapshot. It cannot be the current date.  <br />**_Note:_**  _<ul><li>The reports encompass data until the end of the day (23:59:59 hrs ET) for this particular date_ </li><li>_If report data is not available for the requested end date, the request will fail, and the response will contain endDate until which the performance report is available_</li></ul>
</td>
<td>
Possible values: `CAMPAIGN`, `CAMPAIGN_GROUP`<ul><li>When `reportType` is set to `campaign`, `lineItem`,  `sku`,  or `newBuyer`, the default value of `scope` = `CAMPAIGN`</li><li>When `reportType` is set to `creative`, `tactic`, or `bid`: `scope` = `CAMPAIGN_GROUP` is not supported and will return an error.</li><li></li>

When `scope` = `CAMPAIGN_GROUP`, the `campaign`, `lineItem`, `sku`, `newBuyer` reports will have 2 additional fields: `campaignGroupId` and  `campaignGroupName`<li>If `scope` isn't defined in the request, it will be set to `CAMPAIGN` by default.</li></ul>
</td>
</tr>
</tbody>
</Table>
```

## 📸 Screenshot or Loom

The broken table working: 

<img width="516" height="734" alt="Screenshot 2026-07-09 at 5 57 02 pm" src="https://github.com/user-attachments/assets/b83c758e-e29f-420a-870d-11de388091e5" />

