### PR TITLE
fix(mdxish): parse tables markdown when inside html tags

### DIFF
--- a/__tests__/processor/utils.test.ts
+++ b/__tests__/processor/utils.test.ts
@@ -1,4 +1,4 @@
-import { toAttributes } from '../../processor/utils';
+import { toAttributes, pointAfter } from '../../processor/utils';
 
 describe('toAttributes', () => {
   it('converts string values to string attributes', () => {
@@ -75,5 +75,38 @@ describe('toAttributes', () => {
 
     expect(attrs).toHaveLength(1);
     expect(attrs[0].name).toBe('name');
+  });
+});
+
+describe('pointAfter', () => {
+  it('returns the start point unchanged when nothing is consumed', () => {
+    const start = { line: 5, column: 3, offset: 40 };
+    expect(pointAfter(start, '')).toStrictEqual({ line: 5, column: 3, offset: 40 });
+  });
+
+  it('advances only the column and offset when the consumed run stays on the start line', () => {
+    const start = { line: 5, column: 3, offset: 40 };
+    expect(pointAfter(start, '0123')).toStrictEqual({ line: 5, column: 7, offset: 44 });
+  });
+
+  it('advances the line and resets the column relative to the last newline when the run crosses lines', () => {
+    const start = { line: 1, column: 1, offset: 0 };
+    // "ab\ncdef\nghi" ends on the 3rd line, 3 chars past its newline.
+    expect(pointAfter(start, 'ab\ncdef\nghi')).toStrictEqual({ line: 3, column: 4, offset: 11 });
+  });
+
+  it('places the column at 1 when the run ends right after a trailing newline', () => {
+    const start = { line: 1, column: 1, offset: 0 };
+    expect(pointAfter(start, 'ab\n')).toStrictEqual({ line: 2, column: 1, offset: 3 });
+  });
+
+  it('treats a missing start offset as 0', () => {
+    const start = { line: 2, column: 5 };
+    expect(pointAfter(start, 'xy')).toStrictEqual({ line: 2, column: 7, offset: 2 });
+  });
+
+  it('carries a non-zero start offset through unchanged in the same-line case', () => {
+    const start = { line: 1, column: 1, offset: 1000 };
+    expect(pointAfter(start, 'hello ')).toStrictEqual({ line: 1, column: 7, offset: 1006 });
   });
 });

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -1580,6 +1580,14 @@ the /{customer\\_id}/config/clients operation
       expect(splitHtmlWithNestedTables(htmlNode('<div>no table here</div>'))).toBeNull();
     });
 
+    it.each(['<tablewrapper>', '<TableOfContents>'])('splits a node beginning with the non-table tag %s', (prefixTag) => {
+      const closeTag = `</${prefixTag.slice(1, -1)}>`;
+      const value = `${prefixTag}${lowercaseTable}${closeTag}`;
+      const parts = splitHtmlWithNestedTables(htmlNode(value));
+
+      expect(parts?.map(p => p.value)).toStrictEqual([prefixTag, lowercaseTable, closeTag]);
+    });
+
     it.each([lowercaseTable, uppercaseTable])('splits a <div>-wrapped %s into wrapper-open, table, wrapper-close parts', (table) => {
       const value = `<div>\n${table}\n</div>`;
       const parts = splitHtmlWithNestedTables(htmlNode(value));

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -1600,5 +1600,15 @@ the /{customer\\_id}/config/clients operation
       expect(html).toContain('class="wrap"');
       expect(html).toContain('<strong>400</strong>');
     });
+
+    it('lifts every table when the wrapper holds more than one', () => {
+      const second = table.replace('**400**', '**500**').replace('`CODE`', '`OTHER`');
+      const html = toHtml(mdxish(`<div>\n${table}\n${second}\n</div>`));
+
+      expect(html).toContain('<strong>400</strong>');
+      expect(html).toContain('<code>CODE</code>');
+      expect(html).toContain('<strong>500</strong>');
+      expect(html).toContain('<code>OTHER</code>');
+    });
   });
 });

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -1,11 +1,17 @@
-import type { Root, Text } from 'mdast';
+import type { Html, Root, Text } from 'mdast';
 import type { MdxFlowExpression, MdxJsxTextElement } from 'mdast-util-mdx';
 
 import { toHtml } from 'hast-util-to-html';
 
 import { mdxish, mdxishAstProcessor } from '../../lib/mdxish';
-import { pointAt } from '../../processor/transform/mdxish/tables/mdxish-tables';
+import { splitHtmlWithNestedTables } from '../../processor/transform/mdxish/tables/utils';
 import { collectNodes, findAllElementsByTagName, parseMdxishWithSource, roundTripMdxish } from '../helpers';
+
+const htmlNode = (value: string, start?: { column: number; line: number; offset: number }): Html => ({
+  type: 'html',
+  value,
+  ...(start && { position: { start, end: start } }),
+});
 
 const astProcessor = (md: string): Root => {
   const { processor, parserReadyContent } = mdxishAstProcessor(md);
@@ -1558,46 +1564,71 @@ the /{customer\\_id}/config/clients operation
     });
   });
 
-  describe('pointAt', () => {
-    it('returns the base point unchanged when index is 0', () => {
-      const base = { line: 5, column: 3, offset: 40 };
-      expect(pointAt(base, 'anything', 0)).toStrictEqual({ line: 5, column: 3, offset: 40 });
+  describe('splitHtmlWithNestedTables', () => {
+    const lowercaseTable = '<table><tr><td>x</td></tr></table>';
+    const uppercaseTable = '<Table><tr><td>x</td></tr></Table>';
+    
+    it('returns null for a top-level lowercase <table>', () => {
+      expect(splitHtmlWithNestedTables(htmlNode(lowercaseTable))).toBeNull();
     });
 
-    it('advances only the column and offset when index stays on the base line', () => {
-      const base = { line: 5, column: 3, offset: 40 };
-      expect(pointAt(base, '0123456789', 4)).toStrictEqual({ line: 5, column: 7, offset: 44 });
+    it('returns null for a top-level <Table> component', () => {
+      expect(splitHtmlWithNestedTables(htmlNode(uppercaseTable))).toBeNull();
     });
 
-    it('advances the line and resets the column relative to the last newline when index crosses lines', () => {
-      const base = { line: 1, column: 1, offset: 0 };
-      // "ab\ncdef\nghij" — index 9 lands on 'h', the 2nd character of the 3rd line.
-      expect(pointAt(base, 'ab\ncdef\nghij', 9)).toStrictEqual({ line: 3, column: 2, offset: 9 });
+    it('returns null when the block holds no table at all', () => {
+      expect(splitHtmlWithNestedTables(htmlNode('<div>no table here</div>'))).toBeNull();
     });
 
-    it('places the column at 1 when index lands exactly on the first character after a newline', () => {
-      const base = { line: 1, column: 1, offset: 0 };
-      // "ab\ncdef" — index 3 lands on 'c', the 1st character of the 2nd line.
-      expect(pointAt(base, 'ab\ncdef', 3)).toStrictEqual({ line: 2, column: 1, offset: 3 });
+    it.each([lowercaseTable, uppercaseTable])('splits a <div>-wrapped %s into wrapper-open, table, wrapper-close parts', (table) => {
+      const value = `<div>\n${table}\n</div>`;
+      const parts = splitHtmlWithNestedTables(htmlNode(value));
+
+      expect(parts).toStrictEqual([
+        { type: 'html', value: '<div>\n' },
+        { type: 'html', value: table },
+        { type: 'html', value: '\n</div>' },
+      ]);
     });
 
-    it('treats a missing base offset as 0', () => {
-      const base = { line: 2, column: 5 };
-      expect(pointAt(base, 'xyz', 2)).toStrictEqual({ line: 2, column: 7, offset: 2 });
+    it.each([lowercaseTable, uppercaseTable])('lifts every table when the wrapper holds more than one', (table) => {
+      const value = `<div>\n${table}\n${table}\n</div>`;
+      const parts = splitHtmlWithNestedTables(htmlNode(value));
+
+      expect(parts?.map(p => p.value)).toStrictEqual([
+        '<div>\n',
+        table,
+        '\n',
+        table,
+        '\n</div>',
+      ]);
     });
 
-    it('carries a non-zero base offset through unchanged in the same-line case', () => {
-      const base = { line: 1, column: 1, offset: 1000 };
-      expect(pointAt(base, 'hello world', 6)).toStrictEqual({ line: 1, column: 7, offset: 1006 });
+    it('does not match a <table> masked inside a fenced code block', () => {
+      const value = '<div>\n\n```html\n<table><td>x</td></table>\n```\n\n</div>';
+      expect(splitHtmlWithNestedTables(htmlNode(value))).toBeNull();
+    });
+
+    it('leaves an implicitly-closed table whole so trailing content is not dropped', () => {
+      const value = '<div>\n<table><tr><td>x</td></tr>\n**important trailing content**\n</div>';
+      expect(splitHtmlWithNestedTables(htmlNode(value))).toBeNull();
+    });
+
+    it('carries source positions onto each split part', () => {
+      const value = '<div>\n<table><tr><td>x</td></tr></table>\n</div>';
+      const parts = splitHtmlWithNestedTables(htmlNode(value, { line: 3, column: 1, offset: 20 }));
+
+      const tablePart = parts?.find(p => p.value.startsWith('<table'));
+      // `<table>` sits on line 4, offset 6 into the value → offset 26 in the document.
+      expect(tablePart?.position?.start).toStrictEqual({ line: 4, column: 1, offset: 26 });
     });
   });
 
-  describe('given a <table> wrapped in a raw HTML block', () => {
+  describe('given a table wrapped in a raw HTML block', () => {
     // A wrapping `<div>` makes CommonMark html-flow / the mdxComponent plain-block
-    // claim swallow the whole block, so the nested table never reaches the table
-    // machinery and its cell markdown stays literal. The pre-pass lifts the table
-    // out so its cells parse and rehype-raw re-nests it inside the wrapper.
-    const table = `<table>
+    // claim swallow the whole HTML block. We need to extract them out so the 
+    // table transformer can process the table separately
+    const lowercaseTable = `<table>
 <thead>
 <tr>
 <th>Response Code</th>
@@ -1611,9 +1642,24 @@ the /{customer\\_id}/config/clients operation
 </tr>
 </tbody>
 </table>`;
+    const uppercaseTable = `<Table>
+<thead>
+<tr>
+<th>Response Code</th>
+<th>Error Code</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>**400**</td>
+<td>\`CODE\`</td>
+</tr>
+</tbody>
+</Table>`;
 
-    it('parses cell markdown and keeps the wrapper when a blank line follows the <div>', () => {
-      const html = toHtml(mdxish(`<div>\n\n${table}\n \n</div>`));
+    it.each([lowercaseTable, uppercaseTable])('parses cell markdown and keeps the wrapper when a blank line follows the <div>', (table) => {
+      const value = `<div>\n\n${table}\n \n</div>`;
+      const html = toHtml(mdxish(value));
 
       expect(html).toContain('<div>');
       expect(html).toContain('<strong>400</strong>');
@@ -1621,7 +1667,7 @@ the /{customer\\_id}/config/clients operation
       expect(html).not.toContain('**400**');
     });
 
-    it('parses cell markdown when the table is directly adjacent to the <div>', () => {
+    it.each([lowercaseTable, uppercaseTable])('parses cell markdown when the table is directly adjacent to the <div>', (table) => {
       const html = toHtml(mdxish(`<div>\n${table}\n</div>`));
 
       expect(html).toContain('<div>');
@@ -1629,15 +1675,15 @@ the /{customer\\_id}/config/clients operation
       expect(html).toContain('<code>CODE</code>');
     });
 
-    it('preserves attributes on the wrapping element', () => {
+    it.each([lowercaseTable, uppercaseTable])('preserves attributes on the wrapping element', (table) => {
       const html = toHtml(mdxish(`<div className="wrap">\n\n${table}\n\n</div>`));
 
       expect(html).toContain('class="wrap"');
       expect(html).toContain('<strong>400</strong>');
     });
 
-    it('lifts every table when the wrapper holds more than one', () => {
-      const second = table.replace('**400**', '**500**').replace('`CODE`', '`OTHER`');
+    it.each([lowercaseTable, uppercaseTable])('lifts every table when the wrapper holds more than one', (table) => {
+      const second = lowercaseTable.replace('**400**', '**500**').replace('`CODE`', '`OTHER`');
       const html = toHtml(mdxish(`<div>\n${table}\n${second}\n</div>`));
 
       expect(html).toContain('<strong>400</strong>');
@@ -1682,7 +1728,7 @@ the /{customer\\_id}/config/clients operation
 <table><td>example</td></table>
 \`\`\`
 
-${table}
+${lowercaseTable}
 
 </div>`;
       const html = toHtml(mdxish(md));
@@ -1694,11 +1740,21 @@ ${table}
       expect(html).toContain('<code>CODE</code>');
     });
 
+    it('keeps trailing content when a nested table is never closed', () => {
+      const md = `<div>
+<table><tr><td>x</td></tr>
+important trailing content
+</div>`;
+      const html = toHtml(mdxish(md));
+
+      expect(html).toContain('important trailing content');
+    });
+
     it('positions the lifted table fragment at its real location in a multi-line wrapper', () => {
       const md = `<div>
 some prose before the table
 another line here
-${table}
+${lowercaseTable}
 </div>`;
 
       const { tree, parserReadyContent } = astAndSource(md);

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -4,7 +4,7 @@ import type { MdxFlowExpression, MdxJsxTextElement } from 'mdast-util-mdx';
 import { toHtml } from 'hast-util-to-html';
 
 import { mdxish, mdxishAstProcessor } from '../../lib/mdxish';
-import { splitHtmlWithNestedTables } from '../../processor/transform/mdxish/tables/utils';
+import { splitHtmlWithNestedTables } from '../../processor/transform/mdxish/tables/split-nested-tables';
 import { collectNodes, findAllElementsByTagName, parseMdxishWithSource, roundTripMdxish } from '../helpers';
 
 const htmlNode = (value: string, start?: { column: number; line: number; offset: number }): Html => ({

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -1556,4 +1556,49 @@ the /{customer\\_id}/config/clients operation
       expect(out).toContain('    "c": "y"');
     });
   });
+
+  describe('given a <table> wrapped in a raw HTML block', () => {
+    // A wrapping `<div>` makes CommonMark html-flow / the mdxComponent plain-block
+    // claim swallow the whole block, so the nested table never reaches the table
+    // machinery and its cell markdown stays literal. The pre-pass lifts the table
+    // out so its cells parse and rehype-raw re-nests it inside the wrapper.
+    const table = `<table>
+<thead>
+<tr>
+<th>Response Code</th>
+<th>Error Code</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>**400**</td>
+<td>\`CODE\`</td>
+</tr>
+</tbody>
+</table>`;
+
+    it('parses cell markdown and keeps the wrapper when a blank line follows the <div>', () => {
+      const html = toHtml(mdxish(`<div>\n\n${table}\n \n</div>`));
+
+      expect(html).toContain('<div>');
+      expect(html).toContain('<strong>400</strong>');
+      expect(html).toContain('<code>CODE</code>');
+      expect(html).not.toContain('**400**');
+    });
+
+    it('parses cell markdown when the table is directly adjacent to the <div>', () => {
+      const html = toHtml(mdxish(`<div>\n${table}\n</div>`));
+
+      expect(html).toContain('<div>');
+      expect(html).toContain('<strong>400</strong>');
+      expect(html).toContain('<code>CODE</code>');
+    });
+
+    it('preserves attributes on the wrapping element', () => {
+      const html = toHtml(mdxish(`<div className="wrap">\n\n${table}\n\n</div>`));
+
+      expect(html).toContain('class="wrap"');
+      expect(html).toContain('<strong>400</strong>');
+    });
+  });
 });

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -4,6 +4,7 @@ import type { MdxFlowExpression, MdxJsxTextElement } from 'mdast-util-mdx';
 import { toHtml } from 'hast-util-to-html';
 
 import { mdxish, mdxishAstProcessor } from '../../lib/mdxish';
+import { pointAt } from '../../processor/transform/mdxish/tables/mdxish-tables';
 import { collectNodes, findAllElementsByTagName, parseMdxishWithSource, roundTripMdxish } from '../helpers';
 
 const astProcessor = (md: string): Root => {
@@ -1557,6 +1558,40 @@ the /{customer\\_id}/config/clients operation
     });
   });
 
+  describe('pointAt', () => {
+    it('returns the base point unchanged when index is 0', () => {
+      const base = { line: 5, column: 3, offset: 40 };
+      expect(pointAt(base, 'anything', 0)).toStrictEqual({ line: 5, column: 3, offset: 40 });
+    });
+
+    it('advances only the column and offset when index stays on the base line', () => {
+      const base = { line: 5, column: 3, offset: 40 };
+      expect(pointAt(base, '0123456789', 4)).toStrictEqual({ line: 5, column: 7, offset: 44 });
+    });
+
+    it('advances the line and resets the column relative to the last newline when index crosses lines', () => {
+      const base = { line: 1, column: 1, offset: 0 };
+      // "ab\ncdef\nghij" — index 9 lands on 'h', the 2nd character of the 3rd line.
+      expect(pointAt(base, 'ab\ncdef\nghij', 9)).toStrictEqual({ line: 3, column: 2, offset: 9 });
+    });
+
+    it('places the column at 1 when index lands exactly on the first character after a newline', () => {
+      const base = { line: 1, column: 1, offset: 0 };
+      // "ab\ncdef" — index 3 lands on 'c', the 1st character of the 2nd line.
+      expect(pointAt(base, 'ab\ncdef', 3)).toStrictEqual({ line: 2, column: 1, offset: 3 });
+    });
+
+    it('treats a missing base offset as 0', () => {
+      const base = { line: 2, column: 5 };
+      expect(pointAt(base, 'xyz', 2)).toStrictEqual({ line: 2, column: 7, offset: 2 });
+    });
+
+    it('carries a non-zero base offset through unchanged in the same-line case', () => {
+      const base = { line: 1, column: 1, offset: 1000 };
+      expect(pointAt(base, 'hello world', 6)).toStrictEqual({ line: 1, column: 7, offset: 1006 });
+    });
+  });
+
   describe('given a <table> wrapped in a raw HTML block', () => {
     // A wrapping `<div>` makes CommonMark html-flow / the mdxComponent plain-block
     // claim swallow the whole block, so the nested table never reaches the table
@@ -1609,6 +1644,77 @@ the /{customer\\_id}/config/clients operation
       expect(html).toContain('<code>CODE</code>');
       expect(html).toContain('<strong>500</strong>');
       expect(html).toContain('<code>OTHER</code>');
+    });
+
+    it('still renders nested tables when there are blank lines inside the table', () => {
+      const md = `
+<div>
+
+<table>
+
+<thead>
+<tr>
+<th>Header 1</th>
+<th>Header 2</th>
+</tr>
+</thead>
+
+<tbody>
+
+<tr>
+<td>**Bold**</td>
+<td>\`CODE\`</td>
+</tr>
+</tbody>
+</table>
+
+</div>
+`;
+      const html = toHtml(mdxish(md));
+      expect(html).toContain('<strong>Bold</strong>');
+      expect(html).toContain('<code>CODE</code>');
+    });
+
+    it('does not treat a <table> inside a fenced code example as a real table', () => {
+      const md = `<div>
+
+\`\`\`html
+<table><td>example</td></table>
+\`\`\`
+
+${table}
+
+</div>`;
+      const html = toHtml(mdxish(md));
+
+      // The fenced example survives verbatim (its cell markdown is NOT parsed)...
+      expect(html).toContain('&#x3C;table>&#x3C;td>example&#x3C;/td>&#x3C;/table>');
+      // ...while the real table below it still gets its cells parsed.
+      expect(html).toContain('<strong>400</strong>');
+      expect(html).toContain('<code>CODE</code>');
+    });
+
+    it('positions the lifted table fragment at its real location in a multi-line wrapper', () => {
+      const md = `<div>
+some prose before the table
+another line here
+${table}
+</div>`;
+
+      const { tree, parserReadyContent } = astAndSource(md);
+      const [tableNode] = collectNodes(tree, 'table');
+
+      expect(tableNode).toBeDefined();
+      const { start, end } = tableNode.position!;
+      const slice = parserReadyContent.slice(start.offset!, end.offset!);
+      expect(slice.startsWith('<table>')).toBe(true);
+      expect(slice.endsWith('</table>')).toBe(true);
+
+      // Independently recompute the expected line by counting newlines up to
+      // the fragment's offset, cross-checking pointAt's line/offset outputs
+      // are consistent as actually wired into the tree.
+      const expectedLine = parserReadyContent.slice(0, start.offset!).split('\n').length;
+      expect(start.line).toBe(expectedLine);
     });
   });
 });

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -4,6 +4,7 @@ import type { Plugin } from 'unified';
 
 import { GENERIC_MDX_COMPONENT_EXCLUDED_TAGS } from '../../../../lib/constants';
 import { type ParseAttributesOptions, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
+import { pointAfter } from '../../../utils';
 
 import { getInlineMdProcessor, hasExpressionAttr, isPascalCase } from './utils';
 
@@ -65,21 +66,6 @@ interface ComponentNodeOptions {
   startPosition?: Node['position'];
   tag: string;
 }
-
-type Point = NonNullable<Node['position']>['start'];
-
-/**
- * Advance a point by the substring of source consumed from it.
- */
-const pointAfter = (start: Point, consumed: string): Point => {
-  const newlineIndex = consumed.lastIndexOf('\n');
-  const newlineCount = newlineIndex === -1 ? 0 : consumed.split('\n').length - 1;
-  return {
-    line: start.line + newlineCount,
-    column: newlineCount === 0 ? start.column + consumed.length : consumed.length - newlineIndex,
-    offset: start.offset + consumed.length,
-  };
-};
 
 /**
  * Build a position ending at `consumedLength` into the html node's value, so the

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -27,6 +27,7 @@ import { normalizeTagSpacing } from './normalize-tag-spacing';
 import { remapPositionsToOriginal } from './remap-positions';
 import { repairExpressionEscapes } from './repair-expression-escapes';
 import { repairUnclosedTags } from './repair-unclosed-tags';
+import { walkTags } from './tag-walker';
 import { tableTags, unwrapParagraphNodes, unwrapSoleParagraph, type Insert, type RepairResult } from './utils';
 
 interface MdxJsxTableCell extends Omit<MdxJsxFlowElement, 'name'> {
@@ -337,16 +338,12 @@ const processTableNode = (
   parent.children[index] = mdNode;
 };
 
-// Every `<table`/`</table>` opener/closer whose tag-name is properly delimited
-// (so `<tablefoo>` never matches).
-const TABLE_TAG_RE = /<\/?table(?=[\s/>])/gi;
-
 /**
  * Resolve the source `Point` at character `index` within `value`, given the
  * `Point` of `value`'s first character. Lets a split-out sub-node carry accurate
  * document positions so `parseTableNode`'s offset shifting stays correct.
  */
-const pointAt = (base: Point, value: string, index: number): Point => {
+export const pointAt = (base: Point, value: string, index: number): Point => {
   const before = value.slice(0, index);
   const newlines = before.split('\n').length - 1;
   return {
@@ -357,25 +354,27 @@ const pointAt = (base: Point, value: string, index: number): Point => {
   };
 };
 
-/** Find every balanced, depth-matched `<table>…</table>` range in `value`. */
+/**
+ * Find every balanced, depth-matched `<table>…</table>` range in `value`.
+ * Uses `walkTags` so `<table>`s inside code spans / fenced blocks (masked away)
+ * are never matched.
+ */
 const findTableRanges = (value: string): { end: number; start: number }[] => {
   const ranges: { end: number; start: number }[] = [];
   let depth = 0;
   let start = 0;
-  TABLE_TAG_RE.lastIndex = 0;
-  for (let match = TABLE_TAG_RE.exec(value); match; match = TABLE_TAG_RE.exec(value)) {
-    if (match[0][1] !== '/') {
-      if (depth === 0) start = match.index;
+  walkTags(value, {
+    onOpen: ({ name, start: openStart, isStrayCloser }) => {
+      if (name.toLowerCase() !== 'table' || isStrayCloser) return;
+      if (depth === 0) start = openStart;
       depth += 1;
-    } else if (depth > 0) {
+    },
+    onClose: ({ name, end }) => {
+      if (name.toLowerCase() !== 'table' || depth === 0) return;
       depth -= 1;
-      if (depth === 0) {
-        const closeGt = value.indexOf('>', TABLE_TAG_RE.lastIndex);
-        if (closeGt === -1) break;
-        ranges.push({ start, end: closeGt + 1 });
-      }
-    }
-  }
+      if (depth === 0) ranges.push({ start, end });
+    },
+  });
   return ranges;
 };
 

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -1,4 +1,4 @@
-import type { Html, Node, Parents, Root, RootContent, Table, TableCell, TableRow } from 'mdast';
+import type { Html, Node, Parents, Root, Table, TableCell, TableRow } from 'mdast';
 import type { Transform } from 'mdast-util-from-markdown';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
 import type { Point } from 'unist';
@@ -337,9 +337,8 @@ const processTableNode = (
   parent.children[index] = mdNode;
 };
 
-// Opening `<table` whose tag-name is properly delimited (so `<tablefoo>` never matches).
-const NESTED_TABLE_OPEN_RE = /<table(?=[\s/>])/i;
-// Every `<table`/`</table>` opener/closer, for depth-matching the outer close tag.
+// Every `<table`/`</table>` opener/closer whose tag-name is properly delimited
+// (so `<tablefoo>` never matches).
 const TABLE_TAG_RE = /<\/?table(?=[\s/>])/gi;
 
 /**
@@ -350,13 +349,34 @@ const TABLE_TAG_RE = /<\/?table(?=[\s/>])/gi;
 const pointAt = (base: Point, value: string, index: number): Point => {
   const before = value.slice(0, index);
   const newlines = before.split('\n').length - 1;
-  const lastNewline = before.lastIndexOf('\n');
   return {
     line: base.line + newlines,
     // Same line → advance the base column; a later line → column is the run since its newline.
-    column: newlines === 0 ? base.column + index : index - lastNewline,
+    column: newlines === 0 ? base.column + index : index - before.lastIndexOf('\n'),
     offset: (base.offset ?? 0) + index,
   };
+};
+
+/** Find every balanced, depth-matched `<table>…</table>` range in `value`. */
+const findTableRanges = (value: string): { end: number; start: number }[] => {
+  const ranges: { end: number; start: number }[] = [];
+  let depth = 0;
+  let start = 0;
+  TABLE_TAG_RE.lastIndex = 0;
+  for (let match = TABLE_TAG_RE.exec(value); match; match = TABLE_TAG_RE.exec(value)) {
+    if (match[0][1] !== '/') {
+      if (depth === 0) start = match.index;
+      depth += 1;
+    } else if (depth > 0) {
+      depth -= 1;
+      if (depth === 0) {
+        const closeGt = value.indexOf('>', TABLE_TAG_RE.lastIndex);
+        if (closeGt === -1) break;
+        ranges.push({ start, end: closeGt + 1 });
+      }
+    }
+  }
+  return ranges;
 };
 
 /**
@@ -364,56 +384,35 @@ const pointAt = (base: Point, value: string, index: number): Point => {
  * swallowed whole by CommonMark html-flow / the mdxComponent plain-block claim,
  * so `mdxishTables` never sees it as a table and its cell markdown stays literal.
  *
- * Split such a node into `[html before, <table…> html, html after]` so the outer
- * table machinery below processes the middle node exactly as a top-level table,
- * while the surrounding raw HTML (the wrapper's open/close tags) is re-nested
- * around the parsed table by rehype-raw downstream.
+ * Split such a node at each table's boundaries so the main pass below processes
+ * every table exactly like a top-level one, while the surrounding raw HTML (the
+ * wrapper's open/close tags) is re-nested around the parsed tables by rehype-raw
+ * downstream.
  *
  * Returns null when there is no wrapped table to extract.
  */
-const splitHtmlWithNestedTable = (node: Html): RootContent[] | null => {
+const splitHtmlWithNestedTables = (node: Html): Html[] | null => {
   const { value } = node;
   // Top-level tables are handled directly by the main pass.
   if (value.startsWith('<table') || value.startsWith('<Table')) return null;
-
-  const open = NESTED_TABLE_OPEN_RE.exec(value);
-  if (!open) return null;
-  const start = open.index;
-  // Only target genuinely-wrapped tables: there must be raw HTML (a wrapper tag)
-  // before the table. Leading plain text/whitespace alone is left untouched.
-  if (!value.slice(0, start).includes('<')) return null;
-
-  // Depth-match the outer `</table>` so nested tables don't close it early.
-  TABLE_TAG_RE.lastIndex = start;
-  let depth = 0;
-  let end = -1;
-  let match: RegExpExecArray | null;
-  while ((match = TABLE_TAG_RE.exec(value))) {
-    if (match[0][1] === '/') {
-      depth -= 1;
-      if (depth === 0) {
-        const closeGt = value.indexOf('>', TABLE_TAG_RE.lastIndex);
-        if (closeGt === -1) return null;
-        end = closeGt + 1;
-        break;
-      }
-    } else {
-      depth += 1;
-    }
-  }
-  if (end === -1) return null;
+  const ranges = findTableRanges(value);
+  if (ranges.length === 0) return null;
 
   const base = node.position?.start;
-  const makeHtml = (from: number, to: number): Html => ({
+  const sliceToHtml = (from: number, to: number): Html => ({
     type: 'html',
     value: value.slice(from, to),
     ...(base && { position: { start: pointAt(base, value, from), end: pointAt(base, value, to) } }),
   });
 
-  const parts: RootContent[] = [];
-  if (start > 0) parts.push(makeHtml(0, start));
-  parts.push(makeHtml(start, end)); // now starts with `<table` → picked up by the main pass
-  if (end < value.length) parts.push(makeHtml(end, value.length));
+  const parts: Html[] = [];
+  let cursor = 0;
+  ranges.forEach(({ start, end }) => {
+    if (start > cursor) parts.push(sliceToHtml(cursor, start));
+    parts.push(sliceToHtml(start, end)); // starts with `<table` → picked up by the main pass
+    cursor = end;
+  });
+  if (cursor < value.length) parts.push(sliceToHtml(cursor, value.length));
   return parts;
 };
 
@@ -429,15 +428,15 @@ const splitHtmlWithNestedTable = (node: Html): RootContent[] | null => {
  * is kept as a JSX <Table> element so that remarkRehype can properly handle the flow content.
  */
 const mdxishTables = (): Transform => tree => {
-  // Pre-pass: lift any `<table>` wrapped in a raw HTML block out into its own
-  // html node so the main pass below treats it like a top-level table.
+  // Pre-pass: lift `<table>`s wrapped in a raw HTML block out into their own
+  // html nodes so the main pass below treats them like top-level tables.
   visit(tree, 'html', (_node, index, parent) => {
     const node = _node as Html;
     if (typeof index !== 'number' || !parent || !('children' in parent)) return;
-    const parts = splitHtmlWithNestedTable(node);
+    const parts = splitHtmlWithNestedTables(node);
     if (!parts) return;
-    // The inserted parts can't re-trigger a split (the middle one starts with
-    // `<table`; the wrappers hold no nested table), so plain in-place splicing
+    // The inserted parts can't re-trigger a split (table parts start with
+    // `<table`; the wrapper slices hold no table), so plain in-place splicing
     // visits each once without looping.
     parent.children.splice(index, 1, ...(parts as typeof parent.children));
   });

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -1,7 +1,6 @@
 import type { Html, Node, Parents, Root, Table, TableCell, TableRow } from 'mdast';
 import type { Transform } from 'mdast-util-from-markdown';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
-import type { Point } from 'unist';
 
 import { mdxFromMarkdown } from 'mdast-util-mdx';
 import { phrasing } from 'mdast-util-phrasing';
@@ -27,8 +26,14 @@ import { normalizeTagSpacing } from './normalize-tag-spacing';
 import { remapPositionsToOriginal } from './remap-positions';
 import { repairExpressionEscapes } from './repair-expression-escapes';
 import { repairUnclosedTags } from './repair-unclosed-tags';
-import { walkTags } from './tag-walker';
-import { tableTags, unwrapParagraphNodes, unwrapSoleParagraph, type Insert, type RepairResult } from './utils';
+import {
+  splitHtmlWithNestedTables,
+  tableTags,
+  unwrapParagraphNodes,
+  unwrapSoleParagraph,
+  type Insert,
+  type RepairResult,
+} from './utils';
 
 interface MdxJsxTableCell extends Omit<MdxJsxFlowElement, 'name'> {
   name: 'td' | 'th';
@@ -336,83 +341,6 @@ const processTableNode = (
   };
 
   parent.children[index] = mdNode;
-};
-
-/**
- * Resolve the source `Point` at character `index` within `value`, given the
- * `Point` of `value`'s first character. Lets a split-out sub-node carry accurate
- * document positions so `parseTableNode`'s offset shifting stays correct.
- */
-export const pointAt = (base: Point, value: string, index: number): Point => {
-  const before = value.slice(0, index);
-  const newlines = before.split('\n').length - 1;
-  return {
-    line: base.line + newlines,
-    // Same line → advance the base column; a later line → column is the run since its newline.
-    column: newlines === 0 ? base.column + index : index - before.lastIndexOf('\n'),
-    offset: (base.offset ?? 0) + index,
-  };
-};
-
-/**
- * Find every balanced, depth-matched `<table>…</table>` range in `value`.
- * Uses `walkTags` so `<table>`s inside code spans / fenced blocks (masked away)
- * are never matched.
- */
-const findTableRanges = (value: string): { end: number; start: number }[] => {
-  const ranges: { end: number; start: number }[] = [];
-  let depth = 0;
-  let start = 0;
-  walkTags(value, {
-    onOpen: ({ name, start: openStart, isStrayCloser }) => {
-      if (name.toLowerCase() !== 'table' || isStrayCloser) return;
-      if (depth === 0) start = openStart;
-      depth += 1;
-    },
-    onClose: ({ name, end }) => {
-      if (name.toLowerCase() !== 'table' || depth === 0) return;
-      depth -= 1;
-      if (depth === 0) ranges.push({ start, end });
-    },
-  });
-  return ranges;
-};
-
-/**
- * A `<table>` nested inside a raw HTML block (e.g. wrapped in a `<div>`) is
- * swallowed whole by CommonMark html-flow / the mdxComponent plain-block claim,
- * so `mdxishTables` never sees it as a table and its cell markdown stays literal.
- *
- * Split such a node at each table's boundaries so the main pass below processes
- * every table exactly like a top-level one, while the surrounding raw HTML (the
- * wrapper's open/close tags) is re-nested around the parsed tables by rehype-raw
- * downstream.
- *
- * Returns null when there is no wrapped table to extract.
- */
-const splitHtmlWithNestedTables = (node: Html): Html[] | null => {
-  const { value } = node;
-  // Top-level tables are handled directly by the main pass.
-  if (value.startsWith('<table') || value.startsWith('<Table')) return null;
-  const ranges = findTableRanges(value);
-  if (ranges.length === 0) return null;
-
-  const base = node.position?.start;
-  const sliceToHtml = (from: number, to: number): Html => ({
-    type: 'html',
-    value: value.slice(from, to),
-    ...(base && { position: { start: pointAt(base, value, from), end: pointAt(base, value, to) } }),
-  });
-
-  const parts: Html[] = [];
-  let cursor = 0;
-  ranges.forEach(({ start, end }) => {
-    if (start > cursor) parts.push(sliceToHtml(cursor, start));
-    parts.push(sliceToHtml(start, end)); // starts with `<table` → picked up by the main pass
-    cursor = end;
-  });
-  if (cursor < value.length) parts.push(sliceToHtml(cursor, value.length));
-  return parts;
 };
 
 /**

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -1,6 +1,7 @@
-import type { Html, Node, Parents, Root, Table, TableCell, TableRow } from 'mdast';
+import type { Html, Node, Parents, Root, RootContent, Table, TableCell, TableRow } from 'mdast';
 import type { Transform } from 'mdast-util-from-markdown';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
+import type { Point } from 'unist';
 
 import { mdxFromMarkdown } from 'mdast-util-mdx';
 import { phrasing } from 'mdast-util-phrasing';
@@ -336,6 +337,86 @@ const processTableNode = (
   parent.children[index] = mdNode;
 };
 
+// Opening `<table` whose tag-name is properly delimited (so `<tablefoo>` never matches).
+const NESTED_TABLE_OPEN_RE = /<table(?=[\s/>])/i;
+// Every `<table`/`</table>` opener/closer, for depth-matching the outer close tag.
+const TABLE_TAG_RE = /<\/?table(?=[\s/>])/gi;
+
+/**
+ * Resolve the source `Point` at character `index` within `value`, given the
+ * `Point` of `value`'s first character. Lets a split-out sub-node carry accurate
+ * document positions so `parseTableNode`'s offset shifting stays correct.
+ */
+const pointAt = (base: Point, value: string, index: number): Point => {
+  const before = value.slice(0, index);
+  const newlines = before.split('\n').length - 1;
+  const lastNewline = before.lastIndexOf('\n');
+  return {
+    line: base.line + newlines,
+    // Same line → advance the base column; a later line → column is the run since its newline.
+    column: newlines === 0 ? base.column + index : index - lastNewline,
+    offset: (base.offset ?? 0) + index,
+  };
+};
+
+/**
+ * A `<table>` nested inside a raw HTML block (e.g. wrapped in a `<div>`) is
+ * swallowed whole by CommonMark html-flow / the mdxComponent plain-block claim,
+ * so `mdxishTables` never sees it as a table and its cell markdown stays literal.
+ *
+ * Split such a node into `[html before, <table…> html, html after]` so the outer
+ * table machinery below processes the middle node exactly as a top-level table,
+ * while the surrounding raw HTML (the wrapper's open/close tags) is re-nested
+ * around the parsed table by rehype-raw downstream.
+ *
+ * Returns null when there is no wrapped table to extract.
+ */
+const splitHtmlWithNestedTable = (node: Html): RootContent[] | null => {
+  const { value } = node;
+  // Top-level tables are handled directly by the main pass.
+  if (value.startsWith('<table') || value.startsWith('<Table')) return null;
+
+  const open = NESTED_TABLE_OPEN_RE.exec(value);
+  if (!open) return null;
+  const start = open.index;
+  // Only target genuinely-wrapped tables: there must be raw HTML (a wrapper tag)
+  // before the table. Leading plain text/whitespace alone is left untouched.
+  if (!value.slice(0, start).includes('<')) return null;
+
+  // Depth-match the outer `</table>` so nested tables don't close it early.
+  TABLE_TAG_RE.lastIndex = start;
+  let depth = 0;
+  let end = -1;
+  let match: RegExpExecArray | null;
+  while ((match = TABLE_TAG_RE.exec(value))) {
+    if (match[0][1] === '/') {
+      depth -= 1;
+      if (depth === 0) {
+        const closeGt = value.indexOf('>', TABLE_TAG_RE.lastIndex);
+        if (closeGt === -1) return null;
+        end = closeGt + 1;
+        break;
+      }
+    } else {
+      depth += 1;
+    }
+  }
+  if (end === -1) return null;
+
+  const base = node.position?.start;
+  const makeHtml = (from: number, to: number): Html => ({
+    type: 'html',
+    value: value.slice(from, to),
+    ...(base && { position: { start: pointAt(base, value, from), end: pointAt(base, value, to) } }),
+  });
+
+  const parts: RootContent[] = [];
+  if (start > 0) parts.push(makeHtml(0, start));
+  parts.push(makeHtml(start, end)); // now starts with `<table` → picked up by the main pass
+  if (end < value.length) parts.push(makeHtml(end, value.length));
+  return parts;
+};
+
 /**
  * Converts JSX Table elements to markdown table nodes and re-parses markdown in cells.
  *
@@ -348,6 +429,19 @@ const processTableNode = (
  * is kept as a JSX <Table> element so that remarkRehype can properly handle the flow content.
  */
 const mdxishTables = (): Transform => tree => {
+  // Pre-pass: lift any `<table>` wrapped in a raw HTML block out into its own
+  // html node so the main pass below treats it like a top-level table.
+  visit(tree, 'html', (_node, index, parent) => {
+    const node = _node as Html;
+    if (typeof index !== 'number' || !parent || !('children' in parent)) return;
+    const parts = splitHtmlWithNestedTable(node);
+    if (!parts) return;
+    // The inserted parts can't re-trigger a split (the middle one starts with
+    // `<table`; the wrappers hold no nested table), so plain in-place splicing
+    // visits each once without looping.
+    parent.children.splice(index, 1, ...(parts as typeof parent.children));
+  });
+
   visit(tree, 'html', (_node, index, parent) => {
     const node = _node as Html;
     if (typeof index !== 'number' || !parent || !('children' in parent)) return;

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -26,14 +26,8 @@ import { normalizeTagSpacing } from './normalize-tag-spacing';
 import { remapPositionsToOriginal } from './remap-positions';
 import { repairExpressionEscapes } from './repair-expression-escapes';
 import { repairUnclosedTags } from './repair-unclosed-tags';
-import {
-  splitHtmlWithNestedTables,
-  tableTags,
-  unwrapParagraphNodes,
-  unwrapSoleParagraph,
-  type Insert,
-  type RepairResult,
-} from './utils';
+import { splitHtmlWithNestedTables } from './split-nested-tables';
+import { tableTags, unwrapParagraphNodes, unwrapSoleParagraph, type Insert, type RepairResult } from './utils';
 
 interface MdxJsxTableCell extends Omit<MdxJsxFlowElement, 'name'> {
   name: 'td' | 'th';

--- a/processor/transform/mdxish/tables/split-nested-tables.ts
+++ b/processor/transform/mdxish/tables/split-nested-tables.ts
@@ -1,0 +1,74 @@
+import type { Html } from 'mdast';
+
+import { pointAfter } from '../../../utils';
+
+import { walkTags } from './tag-walker';
+
+const TOP_LEVEL_TABLE_TAG_RE = /^<(?:table|Table)(?=[\s/>])/;
+
+/**
+ * Find every balanced, depth-matched `<table>…</table>` range in an html string.
+ * Uses `walkTags` so `<table>`s inside code spans / fenced blocks (masked away)
+ * are never matched.
+ *
+ * Note: An implicitly-closed table (no `</table>`, so htmlparser2 synthesizes the
+ * close at a later tag) is skipped: splitting there would swallow whatever
+ * followed the table into the fragment and drop it, so we leave such a node
+ * whole for downstream raw-HTML handling instead.
+ */
+const findTableRanges = (html: string): { end: number; start: number }[] => {
+  const ranges: { end: number; start: number }[] = [];
+  let depth = 0;
+  let start = 0;
+  walkTags(html, {
+    onOpen: ({ name, start: openStart, isStrayCloser }) => {
+      if (name.toLowerCase() !== 'table' || isStrayCloser) return;
+      if (depth === 0) start = openStart;
+      depth += 1;
+    },
+    onClose: ({ name, end, implicit }) => {
+      if (implicit || name.toLowerCase() !== 'table' || depth === 0) return;
+      depth -= 1;
+      if (depth === 0) ranges.push({ start, end });
+    },
+  });
+  return ranges;
+};
+
+/**
+ * Given an HTML node that might contain table sequences inside it, split
+ * the node based on the table boundaries so they become a top level node.
+ *
+ * The surrounding raw HTML (the wrapper's open/close tags) would be re-nested
+ * around the parsed tables by rehype-raw.
+ *
+ * Returns null when there is no wrapped table to extract.
+ */
+export const splitHtmlWithNestedTables = (node: Html): Html[] | null => {
+  const { value } = node;
+  // This is a top-level table, so we don't need to split it
+  if (TOP_LEVEL_TABLE_TAG_RE.test(value)) return null;
+  // No table text anywhere in the value → skip the htmlparser2 walk entirely.
+  if (!/<\/?table/i.test(value)) return null;
+  const ranges = findTableRanges(value);
+  if (ranges.length === 0) return null;
+
+  const base = node.position?.start;
+  const sliceToHtml = (from: number, to: number): Html => ({
+    type: 'html',
+    value: value.slice(from, to),
+    ...(base && {
+      position: { start: pointAfter(base, value.slice(0, from)), end: pointAfter(base, value.slice(0, to)) },
+    }),
+  });
+
+  const parts: Html[] = [];
+  let cursor = 0;
+  ranges.forEach(({ start, end }) => {
+    if (start > cursor) parts.push(sliceToHtml(cursor, start));
+    parts.push(sliceToHtml(start, end)); // starts with `<table` → picked up by the main pass
+    cursor = end;
+  });
+  if (cursor < value.length) parts.push(sliceToHtml(cursor, value.length));
+  return parts;
+};

--- a/processor/transform/mdxish/tables/utils.ts
+++ b/processor/transform/mdxish/tables/utils.ts
@@ -1,8 +1,4 @@
-import type { Html, Node } from 'mdast';
-
-import { pointAfter } from '../../../utils';
-
-import { walkTags } from './tag-walker';
+import type { Node } from 'mdast';
 
 export interface Insert {
   consumes?: number;
@@ -76,72 +72,5 @@ export const applyInserts = (html: string, inserts: Insert[]): RepairResult => {
     cursor = Math.min(cursor + consumes, html.length);
   });
   return { value: out + html.slice(cursor), inserts: sorted };
-};
-
-/**
- * Find every balanced, depth-matched `<table>…</table>` range in an html string
- * Uses `walkTags` so `<table>`s inside code spans / fenced blocks (masked away)
- * are never matched.
- *
- * Note: An implicitly-closed table (no `</table>`, so htmlparser2 synthesizes the
- * close at a later tag) is skipped: splitting there would swallow whatever
- * followed the table into the fragment and drop it, so we leave such a node
- * whole for downstream raw-HTML handling instead.
- */
-const findTableRanges = (html: string): { end: number; start: number }[] => {
-  const ranges: { end: number; start: number }[] = [];
-  let depth = 0;
-  let start = 0;
-  walkTags(html, {
-    onOpen: ({ name, start: openStart, isStrayCloser }) => {
-      if (name.toLowerCase() !== 'table' || isStrayCloser) return;
-      if (depth === 0) start = openStart;
-      depth += 1;
-    },
-    onClose: ({ name, end, implicit }) => {
-      if (implicit || name.toLowerCase() !== 'table' || depth === 0) return;
-      depth -= 1;
-      if (depth === 0) ranges.push({ start, end });
-    },
-  });
-  return ranges;
-};
-
-/**
- * Given an HTML node that might contain table sequences inside it, split
- * the node based on the table boundaries so they become a top level node
- * 
- * The surrounding raw HTML (the wrapper's open/close tags) would be re-nested 
- * around the parsed tables by rehype-raw
- *
- * Returns null when there is no wrapped table to extract.
- */
-const TOP_LEVEL_TABLE_TAG_RE = /^<(?:table|Table)(?=[\s/>])/;
-
-export const splitHtmlWithNestedTables = (node: Html): Html[] | null => {
-  const { value } = node;
-  // This is a top-level table, so we don't need to split it
-  if (TOP_LEVEL_TABLE_TAG_RE.test(value)) return null;
-  const ranges = findTableRanges(value);
-  if (ranges.length === 0) return null;
-
-  const base = node.position?.start;
-  const sliceToHtml = (from: number, to: number): Html => ({
-    type: 'html',
-    value: value.slice(from, to),
-    ...(base && {
-      position: { start: pointAfter(base, value.slice(0, from)), end: pointAfter(base, value.slice(0, to)) },
-    }),
-  });
-
-  const parts: Html[] = [];
-  let cursor = 0;
-  ranges.forEach(({ start, end }) => {
-    if (start > cursor) parts.push(sliceToHtml(cursor, start));
-    parts.push(sliceToHtml(start, end)); // starts with `<table` → picked up by the main pass
-    cursor = end;
-  });
-  if (cursor < value.length) parts.push(sliceToHtml(cursor, value.length));
-  return parts;
 };
 

--- a/processor/transform/mdxish/tables/utils.ts
+++ b/processor/transform/mdxish/tables/utils.ts
@@ -1,4 +1,8 @@
-import type { Node } from 'mdast';
+import type { Html, Node } from 'mdast';
+
+import { pointAfter } from '../../../utils';
+
+import { walkTags } from './tag-walker';
 
 export interface Insert {
   consumes?: number;
@@ -72,5 +76,70 @@ export const applyInserts = (html: string, inserts: Insert[]): RepairResult => {
     cursor = Math.min(cursor + consumes, html.length);
   });
   return { value: out + html.slice(cursor), inserts: sorted };
+};
+
+/**
+ * Find every balanced, depth-matched `<table>…</table>` range in an html string
+ * Uses `walkTags` so `<table>`s inside code spans / fenced blocks (masked away)
+ * are never matched.
+ *
+ * Note: An implicitly-closed table (no `</table>`, so htmlparser2 synthesizes the
+ * close at a later tag) is skipped: splitting there would swallow whatever
+ * followed the table into the fragment and drop it, so we leave such a node
+ * whole for downstream raw-HTML handling instead.
+ */
+const findTableRanges = (html: string): { end: number; start: number }[] => {
+  const ranges: { end: number; start: number }[] = [];
+  let depth = 0;
+  let start = 0;
+  walkTags(html, {
+    onOpen: ({ name, start: openStart, isStrayCloser }) => {
+      if (name.toLowerCase() !== 'table' || isStrayCloser) return;
+      if (depth === 0) start = openStart;
+      depth += 1;
+    },
+    onClose: ({ name, end, implicit }) => {
+      if (implicit || name.toLowerCase() !== 'table' || depth === 0) return;
+      depth -= 1;
+      if (depth === 0) ranges.push({ start, end });
+    },
+  });
+  return ranges;
+};
+
+/**
+ * Given an HTML node that might contain table sequences inside it, split
+ * the node based on the table boundaries so they become a top level node
+ * 
+ * The surrounding raw HTML (the wrapper's open/close tags) would be re-nested 
+ * around the parsed tables by rehype-raw
+ *
+ * Returns null when there is no wrapped table to extract.
+ */
+export const splitHtmlWithNestedTables = (node: Html): Html[] | null => {
+  const { value } = node;
+  // This is a top-level table, so we don't need to split it
+  if (value.startsWith('<table') || value.startsWith('<Table')) return null;
+  const ranges = findTableRanges(value);
+  if (ranges.length === 0) return null;
+
+  const base = node.position?.start;
+  const sliceToHtml = (from: number, to: number): Html => ({
+    type: 'html',
+    value: value.slice(from, to),
+    ...(base && {
+      position: { start: pointAfter(base, value.slice(0, from)), end: pointAfter(base, value.slice(0, to)) },
+    }),
+  });
+
+  const parts: Html[] = [];
+  let cursor = 0;
+  ranges.forEach(({ start, end }) => {
+    if (start > cursor) parts.push(sliceToHtml(cursor, start));
+    parts.push(sliceToHtml(start, end)); // starts with `<table` → picked up by the main pass
+    cursor = end;
+  });
+  if (cursor < value.length) parts.push(sliceToHtml(cursor, value.length));
+  return parts;
 };
 

--- a/processor/transform/mdxish/tables/utils.ts
+++ b/processor/transform/mdxish/tables/utils.ts
@@ -116,10 +116,12 @@ const findTableRanges = (html: string): { end: number; start: number }[] => {
  *
  * Returns null when there is no wrapped table to extract.
  */
+const TOP_LEVEL_TABLE_TAG_RE = /^<(?:table|Table)(?=[\s/>])/;
+
 export const splitHtmlWithNestedTables = (node: Html): Html[] | null => {
   const { value } = node;
   // This is a top-level table, so we don't need to split it
-  if (value.startsWith('<table') || value.startsWith('<Table')) return null;
+  if (TOP_LEVEL_TABLE_TAG_RE.test(value)) return null;
   const ranges = findTableRanges(value);
   if (ranges.length === 0) return null;
 

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -7,6 +7,7 @@ import type {
   MdxJsxAttributeValueExpression,
   MdxJsxAttributeValueExpressionData,
 } from 'mdast-util-mdx-jsx';
+import type { Point } from 'unist';
 
 import { Parser } from 'acorn';
 import acornJsx from 'acorn-jsx';
@@ -42,6 +43,24 @@ export function evaluate(source: string, scope: Record<string, unknown> = {}) {
   // eslint-disable-next-line no-new-func
   return new Function(...names, `return (${source})`)(...values);
 }
+
+/**
+ * Advance a `Point` by the `consumed` substring that follows it, returning the
+ * point at the consumed string's end. 
+ * 
+ * Use case: Lets split-out sub-nodes carry accurate document positions 
+ * so downstream offset shifting stays correct.
+ */
+export const pointAfter = (start: Point, consumed: string): Point => {
+  const newlineIndex = consumed.lastIndexOf('\n');
+  const newlineCount = newlineIndex === -1 ? 0 : consumed.split('\n').length - 1;
+  return {
+    line: start.line + newlineCount,
+    // Same line → advance the base column; a later line → column is the run since its newline.
+    column: newlineCount === 0 ? start.column + consumed.length : consumed.length - newlineIndex,
+    offset: (start.offset ?? 0) + consumed.length,
+  };
+};
 
 /**
  * Formats the hProperties of a node as a string, so they can be compiled back into JSX/MDX.

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -46,10 +46,8 @@ export function evaluate(source: string, scope: Record<string, unknown> = {}) {
 
 /**
  * Advance a `Point` by the `consumed` substring that follows it, returning the
- * point at the consumed string's end. 
- * 
- * Use case: Lets split-out sub-nodes carry accurate document positions 
- * so downstream offset shifting stays correct.
+ * point at the consumed string's end. Lets split-out sub-nodes carry accurate
+ * document positions so downstream offset shifting stays correct.
  */
 export const pointAfter = (start: Point, consumed: string): Point => {
   const newlineIndex = consumed.lastIndexOf('\n');


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

Found a regression while QA'ing from #1532 where markdown inside tables, if the table is wrapped in lowercase HTML, will not get parsed. The cause is that the change enhances the MDX tokenizer to also claim plain lowercase HTML, so now `<table>` inside the structure gets claimed, and our table transformer `mdxish-tables.ts` only checks if the HTML **starts** with `<table>`, so nested tables don't work on it. 

We'd still want to keep claiming the lowercase HTML in the tokenizer as it has solved other bugs, so my fix here is to extend the table transformer to also search for `<table>` syntaxes in the HTML blocks, so it can extract the nested tables. Then the transformer would operate on them.

## 🧪 QA tips

- Lowercase & uppercase tables nested inside HTML tags should have their markdown content parsed in mdxish
- Compare with MDX results
- Add multiple tables inside the HTML, add the tables in other components and verify it still works

With example:
```
<div>
<table>
<thead>
<tr>
<th>Response Code</th>
<th>Error Code</th>
</tr>
</thead>
<tbody>
<tr>
<td>**400**</td>
<td>\`CODE\`</td>
</tr>
</tbody>
</table>
</div>
```

## 📸 Screenshot or Loom

Before vs After (MDX vs MDXish):

<img width="1007" height="196" alt="Screenshot 2026-07-09 at 11 29 52 pm" src="https://github.com/user-attachments/assets/bdd96c41-6314-4388-a6d0-ec6a478516a2" />

<img width="987" height="183" alt="Screenshot 2026-07-09 at 11 29 45 pm" src="https://github.com/user-attachments/assets/595e4051-6f47-4a7f-b368-78cce1f2d63e" />


