### PR TITLE
fix: esm statements in JSX component child text crash rendering

### DIFF
--- a/__tests__/processor/plugin/mdxish-components.test.ts
+++ b/__tests__/processor/plugin/mdxish-components.test.ts
@@ -110,6 +110,42 @@ hello
 });
 
 /**
+ * A component's plain-text child is recursively re-parsed as its own
+ * standalone markdown document (via `processMarkdown`), so nested
+ * markdown/JSX inside it that happens to start with the literal word
+ * `export` (e.g. "export Lorem Ipsum") can be mistaken for a JS
+ * export statement.
+ */
+describe('recovering from "export"/"import" text inside a component', () => {
+  it('does not crash when a component text child begins with the literal word "export"', () => {
+    const md = 'See the <Anchor href="/x">export Lorem Ipsum</Anchor> feature.';
+    expect(() => mdxish(md)).not.toThrow();
+    expect(mix(md)).toContain('export Lorem Ipsum');
+  });
+
+  it('does not crash for other built-in components whose text child begins with "export"', () => {
+    // Must be inline (preceded by other text) so CommonMark's raw inline-html
+    // tokenizer — not the flow-level component tokenizer — claims the tag and
+    // routes it through the vulnerable `rehypeMdxishComponents` code path.
+    const md = 'Some text <Callout>export Lorem Ipsum</Callout> more text.';
+    expect(() => mdxish(md)).not.toThrow();
+    expect(mix(md)).toContain('export Lorem Ipsum');
+  });
+
+  it('does not crash when a self-closing component is immediately followed by "export" text', () => {
+    const md = 'Some text <Anchor href="/x" /> export Lorem Ipsum more text.';
+    expect(() => mdxish(md)).not.toThrow();
+    expect(mix(md)).toContain('export Lorem Ipsum');
+  });
+
+  it('does not crash when an image caption begins with "export" and preserves the caption text', () => {
+    const md = '<Image src="test.png" alt="test" caption="export Lorem Ipsum" />';
+    expect(() => mdxish(md)).not.toThrow();
+    expect(mix(md)).toContain('export Lorem Ipsum');
+  });
+});
+
+/**
  * Tests for smartCamelCase prop normalization.
  *
  * HTML lowercases attribute names, so `iconColor` becomes `iconcolor`.

--- a/processor/plugin/mdxish-components.ts
+++ b/processor/plugin/mdxish-components.ts
@@ -101,6 +101,21 @@ function isActualHtmlTag(tagName: string, originalExcerpt: string): boolean {
   return false;
 }
 
+/**
+ * Re-parsing a component's text child treats it as a standalone document, so
+ * content that happens to start with the literal word `export`/`import`
+ * (e.g. link text like "export Lorem Ipsum") sits at true column 1 and
+ * gets mistaken for an MDX ESM statement, which then fails to parse as JS.
+ * Fall back to `undefined` rather than letting one such child crash the page.
+ */
+function tryProcessMarkdown(processMarkdown: (content: string) => Root, content: string): Root | undefined {
+  try {
+    return processMarkdown(content);
+  } catch {
+    return undefined;
+  }
+}
+
 /** Parse and replace text children with processed markdown */
 function parseTextChildren(node: Element, processMarkdown: (content: string) => Root, components: CustomComponents): void {
   if (!node.children?.length) return;
@@ -116,7 +131,8 @@ function parseTextChildren(node: Element, processMarkdown: (content: string) => 
       return [];
     }
 
-    const hast = processMarkdown(child.value.trim());
+    const hast = tryProcessMarkdown(processMarkdown, child.value.trim());
+    if (!hast) return [child];
     const children = (hast.children ?? []).filter(isElementContentNode);
 
     // For inline components, preserve plain text instead of wrapping in <p>
@@ -199,8 +215,9 @@ export const rehypeMdxishComponents = ({ components, processMarkdown }: Options)
       // rehypeRaw strips children from <img> (void element), so we must
       // re-process the caption here, after rehypeRaw.
       if (node.tagName === 'img' && typeof node.properties?.caption === 'string' && !node.children?.length) {
-        const captionHast = processMarkdown(node.properties.caption as string);
-        node.children = (captionHast.children ?? []).filter(isElementContentNode);
+        const caption = node.properties.caption as string;
+        const captionHast = tryProcessMarkdown(processMarkdown, caption);
+        node.children = captionHast ? (captionHast.children ?? []).filter(isElementContentNode) : [{ type: 'text', value: caption }];
       }
 
       // Skip runtime components and standard HTML tags


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

- Fixes a page-crashing bug in the `mdxish` pipeline: when a recognized custom component's text content (or an image caption) begins with the literal word `export`/`import` (e.g. link text like "export Release Bundle v2"), the pipeline's recursive re-parse of that text (`processMarkdown`) treats it as a brand-new standalone document. Since MDX's ESM extension only ever fires at true column 1, it mistakes the phrase for a real JS `import`/`export` statement, fails to parse it with acorn, and throws — crashing the entire page render instead of just that one snippet.
- `tryProcessMarkdown` now catches that failure and falls back to the original text (or, for image captions, a plain text node) instead of letting the error propagate.

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [x] Added regression tests in `__tests__/processor/plugin/mdxish-components.test.ts` covering: an inline component whose text starts with "export", another built-in component in the same position, a self-closing component immediately followed by "export" text (parse5 doesn't self-close unknown tags, so the trailing text becomes a child), and an image caption starting with "export". Verified all 4 fail against the pre-fix code and pass with the fix.
- Repro before this fix: `mdxish('See the <Anchor href="/x">export Release Notes</Anchor> feature.')` threw `Could not parse import/exports with acorn`.

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->

N/A — parser-only fix, no UI changes. Covered by the regression tests above.
