### PR TITLE
fix(tabs): tailwind styles not applied initially on hidden tabs

### DIFF
--- a/__tests__/components/Tabs.test.tsx
+++ b/__tests__/components/Tabs.test.tsx
@@ -2,7 +2,7 @@ import type { Element } from 'hast';
 import type { Root as MdastRoot } from 'mdast';
 
 import '@testing-library/jest-dom';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 
 import Tabs, { Tab } from '../../components/Tabs';
@@ -31,11 +31,13 @@ describe('Tabs', () => {
       expect(container).toHaveTextContent('First tab content');
     });
 
-    it('keeps inactive tabs mounted in the DOM but hidden', () => {
+    it('keeps inactive tabs mounted in the DOM but hidden, and swaps visibility on click', () => {
       const md = `
 <Tabs>
   <Tab title="First">First tab content</Tab>
-  <Tab title="Second">Second tab content</Tab>
+  <Tab title="Second">
+    <Accordion title="Random">Second tab content</Accordion>
+  </Tab>
 </Tabs>
 `;
       const Component = renderContent(md);
@@ -44,9 +46,18 @@ describe('Tabs', () => {
       const panels = container.querySelectorAll('.TabGroup section > div');
       expect(panels).toHaveLength(2);
       // Inactive panel stays in the DOM so runtime Tailwind can scan its classes on first paint
-      expect(panels[1]).toHaveTextContent('Second tab content');
+      expect(panels[1].querySelector('.Accordion')).toBeInTheDocument();
       expect(panels[0]).toBeVisible();
       expect(panels[1]).not.toBeVisible();
+
+      const buttons = container.querySelectorAll('.TabGroup-nav button');
+      fireEvent.click(buttons[1]);
+
+      // Panel visibility swaps, and the custom component stays mounted and rendered
+      expect(panels[0]).not.toBeVisible();
+      expect(panels[1]).toBeVisible();
+      expect(panels[1].querySelector('.Accordion')).toBeInTheDocument();
+      expect(panels[1]).toHaveTextContent('Second tab content');
     });
 
     it('renders a single Tab without crashing', () => {
@@ -279,7 +290,7 @@ Hello
       expect(buttons[1]).toHaveTextContent('B');
     });
 
-    it('keeps every tab mounted but shows only the active one', () => {
+    it('keeps every tab mounted but shows only the active one, and swaps on click', () => {
       const { container } = render(
         <Tabs>
           <Tab title="A">aaa</Tab>
@@ -292,6 +303,12 @@ Hello
       expect(panels[0]).toHaveTextContent('aaa');
       expect(panels[1]).not.toBeVisible();
       expect(panels[1]).toHaveTextContent('bbb');
+
+      const buttons = container.querySelectorAll('.TabGroup-nav button');
+      fireEvent.click(buttons[1]);
+
+      expect(panels[0]).not.toBeVisible();
+      expect(panels[1]).toBeVisible();
     });
 
     it('renders a single Tab without crashing', () => {

--- a/__tests__/components/Tabs.test.tsx
+++ b/__tests__/components/Tabs.test.tsx
@@ -31,6 +31,24 @@ describe('Tabs', () => {
       expect(container).toHaveTextContent('First tab content');
     });
 
+    it('keeps inactive tabs mounted in the DOM but hidden', () => {
+      const md = `
+<Tabs>
+  <Tab title="First">First tab content</Tab>
+  <Tab title="Second">Second tab content</Tab>
+</Tabs>
+`;
+      const Component = renderContent(md);
+      const { container } = render(<Component />);
+
+      const panels = container.querySelectorAll('.TabGroup section > div');
+      expect(panels).toHaveLength(2);
+      // Inactive panel stays in the DOM so runtime Tailwind can scan its classes on first paint
+      expect(panels[1]).toHaveTextContent('Second tab content');
+      expect(panels[0]).toBeVisible();
+      expect(panels[1]).not.toBeVisible();
+    });
+
     it('renders a single Tab without crashing', () => {
       const md = `
 <Tabs>
@@ -261,15 +279,19 @@ Hello
       expect(buttons[1]).toHaveTextContent('B');
     });
 
-    it('displays only the active tab content', () => {
+    it('keeps every tab mounted but shows only the active one', () => {
       const { container } = render(
         <Tabs>
           <Tab title="A">aaa</Tab>
           <Tab title="B">bbb</Tab>
         </Tabs>,
       );
-      expect(container).toHaveTextContent('aaa');
-      expect(container).not.toHaveTextContent('bbb');
+      const panels = container.querySelectorAll('.TabGroup section > div');
+      expect(panels).toHaveLength(2);
+      expect(panels[0]).toBeVisible();
+      expect(panels[0]).toHaveTextContent('aaa');
+      expect(panels[1]).not.toBeVisible();
+      expect(panels[1]).toHaveTextContent('bbb');
     });
 
     it('renders a single Tab without crashing', () => {

--- a/components/Tabs/index.tsx
+++ b/components/Tabs/index.tsx
@@ -35,7 +35,14 @@ const Tabs = ({ children }: TabsProps) => {
           ))}
         </nav>
       </header>
-      <section>{tabs[activeTab]}</section>
+      <section>
+        {/* Keep every panel mounted so runtime Tailwind can scan inactive tabs' classes on first paint */}
+        {tabs.map((tab, index: number) => (
+          <div key={tab.props.title} hidden={index !== activeTab}>
+            {tab}
+          </div>
+        ))}
+      </section>
     </div>
   );
 };

--- a/components/Tabs/index.tsx
+++ b/components/Tabs/index.tsx
@@ -23,7 +23,7 @@ const Tabs = ({ children }: TabsProps) => {
         <nav className="TabGroup-nav">
           {tabs.map((tab, index: number) => (
             <button
-              key={tab.props.title}
+              key={tab.key}
               className={`TabGroup-tab${activeTab === index ? '_active' : ''}`}
               onClick={() => setActiveTab(index)}
             >
@@ -38,7 +38,7 @@ const Tabs = ({ children }: TabsProps) => {
       <section>
         {/* Keep every panel mounted so runtime Tailwind can scan inactive tabs' classes on first paint */}
         {tabs.map((tab, index: number) => (
-          <div key={tab.props.title} hidden={index !== activeTab}>
+          <div key={tab.key} hidden={index !== activeTab}>
             {tab}
           </div>
         ))}


### PR DESCRIPTION
| 🎫 Resolve RM-17395 |
| :-----------------: |

## 🎯 What does this PR do?

A customer on mdxish reported their custom component didn't have its styles applied on first view, and only appearing when interacting on it. Upon investigation, the core issue seems to be that:
- The component is inside a tab that's hidden (not the first tab)
- The component has tailwind styles that don't get applied straight away since it's not in the DOM as the Tab component only renders the first tab initially. 

My fix here is to now mount all the tabs from the start and set them hidden (except the first one) so the tailwind compiler can identify them. I've verified this won't mess with custom CSS.

## 🧪 QA tips

In the markdown playground / app, create a custom component with tailwind styling on it. For example:
```
import React, { useState } from 'react';

export const Accordion = ({ children, icon, iconColor, title }) => {
  const [isOpen, setIsOpen] = useState(false);

  return (
    <details className="border border-gray-200 dark:border-gray-600 rounded-md" onToggle={() => setIsOpen(!isOpen)}>
      <summary
        className={\`
          flex items-center justify-start w-full p-2 text-base font-medium rounded-md hover:bg-gray-100 dark:hover:bg-gray-700
          [&::-webkit-details-marker]:hidden marker:content-['']
          \${isOpen && 'rounded-b-none'}
        \`}
      >
        <span><i className={\`fa fa-regular fa-chevron-right text-sm text-gray-500 dark:text-gray-300 mr-3 transition-transform \${isOpen && 'rotate-90'}\`}></i>
        {icon && (
          <i className={\`fa-duotone fa-solid \${icon} text-\${iconColor} mr-2\`} style={{ color: iconColor }}></i>
        )} </span>
        {title}
      </summary>
      <div className="text-gray-700 dark:text-white px-4 pt-1">{children}</div>
    </details>
  );
};
```

Put it in a Tab component that's not the first one:
```
<Tabs>
   <Tab title="First">
   Hi
   </Tab>
   <Tab title="Second">
      <Accordion title="Random">
      Hello
      </Accordion>

      <Accordion title="Random 2">
      Yo
      </Accordion>
   </Tab>
</Tabs>
```
- Render that doc in mdxish. When switching the 2nd tab, the accordion should be rendered with round & grey edges
- [ ] Also test with other custom components in a Tab component, their styling should look the same upon view

## 📸 Screenshot or Loom

Before vs After of the customer doc (notice on the left that the accordion styling is different when interacted on):

https://github.com/user-attachments/assets/b9f888ab-8bbe-4a18-98cb-58705e9597c1

