### PR TITLE
feat: Add MDXComponent processor, to preserve whitespace and prevent …

### DIFF
--- a/__tests__/lib/stripComments.test.ts
+++ b/__tests__/lib/stripComments.test.ts
@@ -332,6 +332,64 @@ end"`);
     expect(output).toBe('render a \\<b when a is less than b');
   });
 
+  describe('Custom components render correctly in mdxish mode', () => {
+    // Expressions should be preserved, and component should not be escaped with a backslash prefix
+    it.each([
+      { name: 'a literal < inside an expression', input: '<Card ok={a < b} />' },
+      { name: 'a literal < inside a quoted attribute', input: '<Card note="use a < b here" />' },
+      // eslint-disable-next-line no-template-curly-in-string
+      { name: 'a template literal attribute with interpolation', input: '<Card label={`Hello ${user.name}`} />' },
+      { name: 'a spread attribute', input: '<Card {...props} title="Hi" />' },
+      { name: 'a boolean shorthand attribute', input: '<Card disabled title="Hi" />' },
+      { name: 'an inline component surrounded by markdown', input: 'See the *shiny* <Anchor href={url}>link</Anchor> for **more**.' },
+      {
+        name: 'a component nested inside a <div>',
+        input: `<div>
+  <Callout icon="info" data={[{ a: 1 }]}>
+    Body text
+  </Callout>
+</div>`,
+      },
+      {
+        name: 'same-name components nested inside each other',
+        input: `<Accordion title="Outer">
+  <Accordion title="Inner">
+    Inner body
+  </Accordion>
+</Accordion>`,
+      },
+    ])('preserves $name without escaping', async ({ input }) => {
+      const output = await stripComments(input, { mdxish: true });
+      expect(output).toBe(input);
+      expect(output).not.toContain('\\<');
+    });
+
+    // A JSDoc block inside a component's expression is treated as code and not stripped
+    it('preserves a multi-line JSDoc block inside an expression attribute', async () => {
+      const input = `<Card
+  data={
+    /**
+     * A JSDoc comment inside the expression
+     */
+    values
+  }
+/>`;
+      const output = await stripComments(input, { mdxish: true });
+      expect(output).toBe(input);
+    });
+
+    it('strips an HTML comment inside a component body', async () => {
+      const input = `<Callout data={[{ a: 1 }]}>
+  <!-- strip me -->
+  Body
+</Callout>`;
+      const output = await stripComments(input, { mdxish: true });
+      expect(output).not.toContain('<!-- strip me -->');
+      expect(output).toContain('<Callout data={[{ a: 1 }]}>');
+      expect(output).toContain('Body');
+    });
+  });
+
   // TODO: enable this test after fixing the heading parsing issue
   // https://linear.app/readme-io/issue/CX-2603/sanitize-comment-flag-causing-certain-emphasized-text-and-headings-to
   // eslint-disable-next-line vitest/no-disabled-tests

--- a/__tests__/lib/stripComments.test.ts
+++ b/__tests__/lib/stripComments.test.ts
@@ -310,6 +310,28 @@ end"`);
     expect(output).toBe(input);
   });
 
+  it('does not escape custom components with array/object expression props in mdxish mode', async () => {
+    // Component should not be escaped when stripping comments, and whitespace preserved
+    const input = `<DosAndDonts
+      title="Your Section Title"
+      dos={[
+        { label: "Your first do item.", code: "Optional code example" },
+      ]}
+      donts={[
+        { label: "Your first dont item." },
+      ]}
+    />`;
+
+    const output = await stripComments(input, { mdxish: true });
+    expect(output).toBe(input);
+    expect(output).not.toContain('\\<');
+  });
+
+  it('still escapes lowercase literal angle brackets in mdxish mode', async () => {
+    const output = await stripComments('render a \\<b when a is less than b', { mdxish: true });
+    expect(output).toBe('render a \\<b when a is less than b');
+  });
+
   // TODO: enable this test after fixing the heading parsing issue
   // https://linear.app/readme-io/issue/CX-2603/sanitize-comment-flag-causing-certain-emphasized-text-and-headings-to
   // eslint-disable-next-line vitest/no-disabled-tests

--- a/__tests__/lib/stripComments.test.ts
+++ b/__tests__/lib/stripComments.test.ts
@@ -328,7 +328,7 @@ end"`);
   });
 
   it('still escapes lowercase literal angle brackets in mdxish mode', async () => {
-    const output = await stripComments('render a \\<b when a is less than b', { mdxish: true });
+    const output = await stripComments('render a <b when a is less than b', { mdxish: true });
     expect(output).toBe('render a \\<b when a is less than b');
   });
 

--- a/lib/stripComments.ts
+++ b/lib/stripComments.ts
@@ -12,8 +12,10 @@ import { stripCommentsTransformer } from '../processor/transform/stripComments';
 
 import { htmlBlockComponentFromMarkdown } from './mdast-util/html-block-component';
 import { jsxTableFromMarkdown } from './mdast-util/jsx-table';
+import { mdxComponentFromMarkdown } from './mdast-util/mdx-component';
 import { htmlBlockComponent } from './micromark/html-block-component';
 import { jsxTable } from './micromark/jsx-table';
+import { mdxComponent } from './micromark/mdx-component';
 import { extractMagicBlocks, restoreMagicBlocks } from './utils/extractMagicBlocks';
 
 interface Opts {
@@ -33,10 +35,16 @@ async function stripComments(doc: string, { mdx, mdxish }: Opts = {}): Promise<s
   // 1. we can rely on remarkMdx to parse MDXish
   // 2. we need to parse JSX comments into mdxTextExpression nodes so that the transformers can pick them up
   // 3. we need to claim <HTMLBlock> before htmlFlow intercepts its inner HTML tags
+  // 4. we need mdxComponent to parse custom components as one node, and prevent the tag from getting escaped
   if (mdxish) {
     processor
-      .data('micromarkExtensions', [htmlBlockComponent(), jsxTable(), mdxExpression({ allowEmpty: true })])
-      .data('fromMarkdownExtensions', [htmlBlockComponentFromMarkdown(), jsxTableFromMarkdown(), mdxExpressionFromMarkdown()])
+      .data('micromarkExtensions', [htmlBlockComponent(), jsxTable(), mdxComponent(), mdxExpression({ allowEmpty: true })])
+      .data('fromMarkdownExtensions', [
+        htmlBlockComponentFromMarkdown(),
+        jsxTableFromMarkdown(),
+        mdxComponentFromMarkdown(),
+        mdxExpressionFromMarkdown(),
+      ])
       .data('toMarkdownExtensions', [mdxExpressionToMarkdown()]);
   }
 


### PR DESCRIPTION
| 🎫 [Resolves ISSUE_ID](RM-17243/ai-translations-qa-while-ai-translations-are-in-queue-some-mdx) |
| :-----------------: |

## 🎯 What does this PR do?

- After an investigation, discovered that MDXEditor was escaping custom components during comment sanitization.
- This only affects components with attributes and an expression ie. array/object with a whitespace delimeter. Such components are escaped and do not render
- Sanitisation does not apply to admin/logged in users, hence appeared during Incognito mode

#### Why does adding the tokenizer in `stripComments` fix it?

With the default parser, a custom component whose attributes hold an expression containing whitespace (e.g. an array/object spread across lines) gets fragmented into several nodes. The remark-stringify method then escapes the leading `<` as `\<`, so the component no longer renders in the MDX Editor

The `mdxComponent` micromark tokenizer gets the whole component including its tag, attributes, expressions and body as a single html node before it's split up. This allows it to preserve white space whilst comments elsewhere are stripped

## 🧪 QA tips

- Create a custom component with attributes in the form of an array ie. ["A", "B", "C"] or an array of objects.
- Publish the page, and view the page in incognito or as a logged out user. Ensure that it correctly renders

## 📸 Screenshot or Loom

https://www.loom.com/share/94001a13fcc94db6bdc246bef45f7aee
