### PR TITLE
fix(mdxish): parse indented markdown inside plain html wrappers

### DIFF
--- a/__tests__/fixtures/markdown-in-html-tests.mdx
+++ b/__tests__/fixtures/markdown-in-html-tests.mdx
@@ -1,0 +1,74 @@
+## Markdown Nested In HTML
+
+Markdown living inside plain HTML wrappers — headings, links, emphasis, inline
+code, lists, blockquotes, and tables — must parse in both engines (`mdx` and
+`mdxish`), even when the author indents it for readability.
+
+<Columns layout="auto">
+  <Column>
+    <div className="simple-list" data-testid="column-card-1">
+      ## Learn By Example
+
+      Use the API Simulator alongside step-by-step [Guides](https://example.com/docs) to get up and running quickly.
+    </div>
+  </Column>
+
+  <Column>
+    <div className="simple-list" data-testid="column-card-2">
+      ## Stay Informed
+
+      Review [Release Notes](https://example.com/changelog) to learn about **new features** and upcoming changes.
+    </div>
+  </Column>
+</Columns>
+
+<div className="top-level-wrapper" data-testid="top-level-wrapper">
+  ### Indented Markdown After The Opening Tag
+
+  This heading and paragraph are indented two columns yet still parse, with `inline code` and [a link](https://example.com/indented).
+</div>
+
+<section data-testid="island-section">
+
+#### A Blank-Line Separated Island
+
+- List item one
+- List item two
+
+</section>
+
+<div data-testid="glossary-links">
+        <a className="glossary-letter" href="#a">A</a> |
+        <a className="glossary-letter" href="#b">B</a> |
+</div>
+
+<div className="steps" data-testid="ordered-steps">
+  ###### Quickstart Steps
+
+  1. Install the SDK
+  2. Configure your **API key**
+  3. Make your first request
+</div>
+
+<aside data-testid="quote-aside">
+  ###### Words Of Wisdom
+
+  > Documentation is a love letter that you write to your future self.
+</aside>
+
+<div data-testid="table-wrapper">
+
+| Method | Path         |
+| ------ | ------------ |
+| GET    | /v1/examples |
+| POST   | /v1/tokens   |
+
+</div>
+
+<div className="outer-wrapper" data-testid="nested-wrappers">
+  <div className="inner-wrapper">
+  ##### Markdown After A Nested Opening Tag
+
+  Stacked plain wrappers still parse ~~strikethrough~~ and *emphasis*.
+  </div>
+</div>

--- a/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
@@ -1,0 +1,119 @@
+import { toHtml } from 'hast-util-to-html';
+
+import { mdxish } from '../../../lib';
+import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
+
+// Markdown inside plain lowercase HTML must parse even when indented for
+// readability — at top level and nested inside custom components (whose bodies are
+// re-parsed). Guards HTML-flow swallowing and 4+-column indented-code fallout.
+describe('markdown inside indented plain HTML blocks', () => {
+  it('parses indented markdown in a <div> nested inside <Columns>/<Column>', () => {
+    const md = `<Columns layout="auto">
+  <Column>
+    <div className="simple-list">
+      ## Learn By Example
+
+      Use the API Simulator alongside step-by-step [Guides](https://example.com/docs) and [prepared collections](https://example.com/collections) to get up and running quickly.
+    </div>
+  </Column>
+
+  <Column>
+    <div className="simple-list">
+      ## Stay Informed
+
+      Review [Release Notes](https://example.com/changelog) to learn about new features.
+    </div>
+  </Column>
+</Columns>`;
+
+    const ast = mdxish(md);
+    const html = toHtml(ast);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'code')).toBeNull();
+
+    const headings = findAllElementsByTagName(ast, 'h2');
+    expect(headings).toHaveLength(2);
+    expect(html).toContain('Learn By Example</h2>');
+    expect(html).toContain('Stay Informed</h2>');
+    expect(html).toContain('<a href="https://example.com/docs">Guides</a>');
+
+    // Headings and paragraphs re-nest inside their wrapper divs
+    const wrappers = findAllElementsByTagName(ast, 'div').filter(
+      el => Array.isArray(el.properties.className) && el.properties.className.includes('simple-list'),
+    );
+    expect(wrappers).toHaveLength(2);
+    expect(findElementByTagName(wrappers[0], 'h2')).not.toBeNull();
+    expect(findElementByTagName(wrappers[0], 'p')).not.toBeNull();
+  });
+
+  it('parses markdown indented 1-3 columns directly after a top-level opening tag', () => {
+    const md = `<div className="simple-list">
+  ## Learn By Example
+
+  Use the [API Simulator](https://example.com) alongside guides.
+</div>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'h2')).toMatchObject({
+      children: [{ type: 'text', value: 'Learn By Example' }],
+    });
+    expect(findElementByTagName(ast, 'a')).toMatchObject({
+      properties: { href: 'https://example.com' },
+      children: [{ type: 'text', value: 'API Simulator' }],
+    });
+
+    const wrapper = findElementByTagName(ast, 'div');
+    expect(findElementByTagName(wrapper!, 'h2')).not.toBeNull();
+  });
+
+  it('parses an indented markdown island (blank-line separated) nested inside components', () => {
+    const md = `<Columns layout="auto">
+  <Column>
+    <div className="simple-list">
+
+      ## Learn By Example
+
+      Use the [API Simulator](https://example.com) alongside guides.
+    </div>
+  </Column>
+</Columns>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'h2')).not.toBeNull();
+    expect(findElementByTagName(ast, 'a')).toMatchObject({ properties: { href: 'https://example.com' } });
+  });
+
+  it('keeps deeply indented (4+ columns) HTML lines inside a wrapper as HTML (#1344)', () => {
+    const md = `<div>
+        <a class="glossary-letter" href="#a">A</a> |
+        <a class="glossary-letter" href="#b">B</a> |
+</div>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'code')).toBeNull();
+    expect(findAllElementsByTagName(ast, 'a')).toHaveLength(2);
+  });
+
+  it('keeps content indented 4+ columns relative to its nested wrapper as an indented code block', () => {
+    // Relative indentation is preserved when component bodies are dedented, so
+    // content 4+ columns deeper than the surrounding tags still parses as code.
+    const md = `<Column>
+  <div>
+
+      const literal = 'code';
+
+  </div>
+</Column>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'code')).not.toBeNull();
+  });
+});

--- a/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
@@ -125,8 +125,9 @@ describe('markdown inside indented plain HTML blocks', () => {
   </Card>
 </Cards>`;
 
-    const ast = mdxish(md);
-
+    const ast = mdxish(md);    
+    const html = toHtml(ast);
+    expect(html).toContain('Account balances, position changes, and transaction activity updated instantly');
     expect(findElementByTagName(ast, 'code')).toBeNull();
   });
 });

--- a/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
@@ -116,4 +116,17 @@ describe('markdown inside indented plain HTML blocks', () => {
 
     expect(findElementByTagName(ast, 'code')).not.toBeNull();
   });
+
+  it('does not treat deeply indented content as code when nested under unindented HTML', () => {
+    const md = `<Cards>
+  <Card class="card">
+   <p class="Card-title">Title</p>
+    Account balances, position changes, and transaction activity updated instantly for faster financial  response.<br />
+  </Card>
+</Cards>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'code')).toBeNull();
+  });
 });

--- a/__tests__/lib/render-mdxish/markdown-in-html.test.tsx
+++ b/__tests__/lib/render-mdxish/markdown-in-html.test.tsx
@@ -1,92 +1,124 @@
-import type { RenderResult } from '@testing-library/react';
-
-import fs from 'node:fs';
-
 import '@testing-library/jest-dom';
 import { render, within } from '@testing-library/react';
 import React from 'react';
 
 import { compile, mdxish, renderMdxish, run } from '../../../lib';
 
-const body = fs.readFileSync('__tests__/fixtures/markdown-in-html-tests.mdx', { encoding: 'utf8' });
-
-// Renders the fixture to a real DOM through each engine. Both must agree:
-// markdown nested inside plain HTML wrappers (indented or not, nested in
-// custom components or not) parses as markdown and re-nests into its wrapper.
-const engines: Record<string, () => RenderResult> = {
-  mdxish: () => {
-    const mod = renderMdxish(mdxish(body));
-    const Content = mod.default;
+// Markdown nested inside plain HTML wrappers — indented or not, at top level or
+// inside custom components — must parse as markdown and re-nest into its wrapper.
+// Both engines must agree, so every case renders through each to a real DOM.
+//
+// NOTE: markdown indented 4+ columns inside a *plain* (non-component)
+// wrapper stays literal HTML text per CommonMark's indented-code-block rule — see
+// the "keeps deeply indented (4+ columns) HTML lines as HTML" case below. Only
+// custom-component bodies get dedented (via safeDeindent in mdx-blocks.ts) before
+// re-parsing, so nesting inside a component sidesteps the limit.
+const renderThrough = {
+  mdxish: (md: string) => {
+    const Content = renderMdxish(mdxish(md)).default;
     return render(<Content />);
   },
-  mdx: () => {
-    const Content = run(compile(body)).default;
+  mdx: (md: string) => {
+    const Content = run(compile(md)).default;
     return render(<Content />);
   },
-};
+} as const;
 
-describe.each(Object.keys(engines))('markdown nested in HTML fixture (%s engine)', engine => {
-  const renderFixture = () => engines[engine]();
+describe.each(['mdxish', 'mdx'] as const)('markdown nested in HTML (%s engine)', engine => {
+  const renderMarkdown = (md: string) => renderThrough[engine](md);
 
   it('renders indented markdown inside a <div> nested in <Columns>/<Column>', () => {
-    const { getByTestId } = renderFixture();
+    const { getByTestId } = renderMarkdown(`<Columns layout="auto">
+  <Column>
+    <div className="simple-list" data-testid="card">
+      ## Learn By Example
 
-    const firstCard = within(getByTestId('column-card-1'));
-    expect(firstCard.getByRole('heading', { level: 2, name: /Learn By Example/ })).toBeVisible();
-    expect(firstCard.getByRole('link', { name: /Guides/ })).toHaveAttribute('href', 'https://example.com/docs');
+      Use the [Guides](https://example.com/docs) to learn about **new features**.
+    </div>
+  </Column>
+</Columns>`);
 
-    const secondCard = within(getByTestId('column-card-2'));
-    expect(secondCard.getByRole('heading', { level: 2, name: /Stay Informed/ })).toBeVisible();
-    expect(secondCard.getByRole('link', { name: /Release Notes/ })).toHaveAttribute(
-      'href',
-      'https://example.com/changelog',
-    );
-    // Emphasis nested inside html nested inside components still parses
-    expect(secondCard.getByText('new features').tagName).toBe('STRONG');
+    const card = within(getByTestId('card'));
+    expect(card.getByRole('heading', { level: 2, name: /Learn By Example/ })).toBeVisible();
+    expect(card.getByRole('link', { name: /Guides/ })).toHaveAttribute('href', 'https://example.com/docs');
+    // Emphasis nested inside html nested inside a component still parses
+    expect(card.getByText('new features').tagName).toBe('STRONG');
   });
 
   it('renders indented markdown directly after a top-level opening tag', () => {
-    const { getByTestId } = renderFixture();
+    const { getByTestId } = renderMarkdown(`<div className="wrapper" data-testid="wrapper">
+  ### Indented Markdown After The Opening Tag
 
-    const wrapper = within(getByTestId('top-level-wrapper'));
+  This paragraph has \`inline code\` and [a link](https://example.com/indented).
+</div>`);
+
+    const wrapper = within(getByTestId('wrapper'));
     expect(wrapper.getByRole('heading', { level: 3, name: /Indented Markdown After The Opening Tag/ })).toBeVisible();
     expect(wrapper.getByRole('link', { name: /a link/ })).toHaveAttribute('href', 'https://example.com/indented');
     expect(wrapper.getByText('inline code').tagName).toBe('CODE');
   });
 
   it('renders a blank-line separated markdown island inside a wrapper', () => {
-    const { getByTestId } = renderFixture();
+    const { getByTestId } = renderMarkdown(`<section data-testid="island">
 
-    const section = within(getByTestId('island-section'));
+#### A Blank-Line Separated Island
+
+- List item one
+- List item two
+
+</section>`);
+
+    const section = within(getByTestId('island'));
     expect(section.getByRole('heading', { level: 4, name: /A Blank-Line Separated Island/ })).toBeVisible();
     expect(section.getAllByRole('listitem')).toHaveLength(2);
   });
 
-  it('keeps deeply indented (4+ columns) HTML lines as HTML', () => {
-    const { getByTestId } = renderFixture();
+  it('keeps deeply indented (4+ columns) HTML lines as HTML (#1344)', () => {
+    const { container, getByTestId } = renderMarkdown(`<div data-testid="glossary-links">
+        <a className="glossary-letter" href="#a">A</a> |
+        <a className="glossary-letter" href="#b">B</a> |
+</div>`);
 
     const links = within(getByTestId('glossary-links')).getAllByRole('link');
     expect(links).toHaveLength(2);
     expect(links[0]).toHaveAttribute('href', '#a');
+    expect(container.querySelector('pre')).toBeNull();
   });
 
   it('renders an indented ordered list inside a wrapper', () => {
-    const { getByTestId } = renderFixture();
+    const { getByTestId } = renderMarkdown(`<div className="steps" data-testid="steps">
+  ###### Quickstart Steps
 
-    const steps = within(getByTestId('ordered-steps'));
+  1. Install the SDK
+  2. Configure your **API key**
+  3. Make your first request
+</div>`);
+
+    const steps = within(getByTestId('steps'));
     expect(steps.getAllByRole('listitem')).toHaveLength(3);
     expect(steps.getByText('API key').tagName).toBe('STRONG');
   });
 
   it('renders an indented blockquote inside a wrapper', () => {
-    const { getByTestId } = renderFixture();
+    const { getByTestId } = renderMarkdown(`<aside data-testid="quote">
+  ###### Words Of Wisdom
 
-    const quote = within(getByTestId('quote-aside')).getByText(/love letter/);
+  > Documentation is a love letter that you write to your future self.
+</aside>`);
+
+    const quote = within(getByTestId('quote')).getByText(/love letter/);
     expect(quote.closest('blockquote')).not.toBeNull();
   });
 
   it('renders a markdown table island inside a wrapper', () => {
-    const { getByTestId } = renderFixture();
+    const { getByTestId } = renderMarkdown(`<div data-testid="table-wrapper">
+
+| Method | Path         |
+| ------ | ------------ |
+| GET    | /v1/examples |
+| POST   | /v1/tokens   |
+
+</div>`);
 
     const wrapper = within(getByTestId('table-wrapper'));
     expect(wrapper.getByRole('table')).toBeVisible();
@@ -94,17 +126,19 @@ describe.each(Object.keys(engines))('markdown nested in HTML fixture (%s engine)
   });
 
   it('renders markdown after a nested opening tag inside stacked plain wrappers', () => {
-    const { getByTestId } = renderFixture();
+    const { container, getByTestId } = renderMarkdown(`<div className="outer-wrapper" data-testid="nested">
+  <div className="inner-wrapper">
+  ##### Markdown After A Nested Opening Tag
 
-    const nested = within(getByTestId('nested-wrappers'));
+  Stacked plain wrappers still parse ~~strikethrough~~ and *emphasis*.
+  </div>
+</div>`);
+
+    const nested = within(getByTestId('nested'));
     expect(nested.getByRole('heading', { level: 5, name: /Nested Opening Tag/ })).toBeVisible();
     expect(nested.getByText('strikethrough').tagName).toBe('DEL');
     expect(nested.getByText('emphasis').tagName).toBe('EM');
-  });
-
-  it('never renders the nested markdown as an indented code block', () => {
-    const { container } = renderFixture();
-
+    // The indented markdown must never fall through to an indented code block
     expect(container.querySelector('pre')).toBeNull();
   });
 });

--- a/__tests__/lib/render-mdxish/markdown-in-html.test.tsx
+++ b/__tests__/lib/render-mdxish/markdown-in-html.test.tsx
@@ -1,0 +1,110 @@
+import type { RenderResult } from '@testing-library/react';
+
+import fs from 'node:fs';
+
+import '@testing-library/jest-dom';
+import { render, within } from '@testing-library/react';
+import React from 'react';
+
+import { compile, mdxish, renderMdxish, run } from '../../../lib';
+
+const body = fs.readFileSync('__tests__/fixtures/markdown-in-html-tests.mdx', { encoding: 'utf8' });
+
+// Renders the fixture to a real DOM through each engine. Both must agree:
+// markdown nested inside plain HTML wrappers (indented or not, nested in
+// custom components or not) parses as markdown and re-nests into its wrapper.
+const engines: Record<string, () => RenderResult> = {
+  mdxish: () => {
+    const mod = renderMdxish(mdxish(body));
+    const Content = mod.default;
+    return render(<Content />);
+  },
+  mdx: () => {
+    const Content = run(compile(body)).default;
+    return render(<Content />);
+  },
+};
+
+describe.each(Object.keys(engines))('markdown nested in HTML fixture (%s engine)', engine => {
+  const renderFixture = () => engines[engine]();
+
+  it('renders indented markdown inside a <div> nested in <Columns>/<Column>', () => {
+    const { getByTestId } = renderFixture();
+
+    const firstCard = within(getByTestId('column-card-1'));
+    expect(firstCard.getByRole('heading', { level: 2, name: /Learn By Example/ })).toBeVisible();
+    expect(firstCard.getByRole('link', { name: /Guides/ })).toHaveAttribute('href', 'https://example.com/docs');
+
+    const secondCard = within(getByTestId('column-card-2'));
+    expect(secondCard.getByRole('heading', { level: 2, name: /Stay Informed/ })).toBeVisible();
+    expect(secondCard.getByRole('link', { name: /Release Notes/ })).toHaveAttribute(
+      'href',
+      'https://example.com/changelog',
+    );
+    // Emphasis nested inside html nested inside components still parses
+    expect(secondCard.getByText('new features').tagName).toBe('STRONG');
+  });
+
+  it('renders indented markdown directly after a top-level opening tag', () => {
+    const { getByTestId } = renderFixture();
+
+    const wrapper = within(getByTestId('top-level-wrapper'));
+    expect(wrapper.getByRole('heading', { level: 3, name: /Indented Markdown After The Opening Tag/ })).toBeVisible();
+    expect(wrapper.getByRole('link', { name: /a link/ })).toHaveAttribute('href', 'https://example.com/indented');
+    expect(wrapper.getByText('inline code').tagName).toBe('CODE');
+  });
+
+  it('renders a blank-line separated markdown island inside a wrapper', () => {
+    const { getByTestId } = renderFixture();
+
+    const section = within(getByTestId('island-section'));
+    expect(section.getByRole('heading', { level: 4, name: /A Blank-Line Separated Island/ })).toBeVisible();
+    expect(section.getAllByRole('listitem')).toHaveLength(2);
+  });
+
+  it('keeps deeply indented (4+ columns) HTML lines as HTML', () => {
+    const { getByTestId } = renderFixture();
+
+    const links = within(getByTestId('glossary-links')).getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', '#a');
+  });
+
+  it('renders an indented ordered list inside a wrapper', () => {
+    const { getByTestId } = renderFixture();
+
+    const steps = within(getByTestId('ordered-steps'));
+    expect(steps.getAllByRole('listitem')).toHaveLength(3);
+    expect(steps.getByText('API key').tagName).toBe('STRONG');
+  });
+
+  it('renders an indented blockquote inside a wrapper', () => {
+    const { getByTestId } = renderFixture();
+
+    const quote = within(getByTestId('quote-aside')).getByText(/love letter/);
+    expect(quote.closest('blockquote')).not.toBeNull();
+  });
+
+  it('renders a markdown table island inside a wrapper', () => {
+    const { getByTestId } = renderFixture();
+
+    const wrapper = within(getByTestId('table-wrapper'));
+    expect(wrapper.getByRole('table')).toBeVisible();
+    expect(wrapper.getByText('/v1/tokens')).toBeVisible();
+  });
+
+  it('renders markdown after a nested opening tag inside stacked plain wrappers', () => {
+    const { getByTestId } = renderFixture();
+
+    const nested = within(getByTestId('nested-wrappers'));
+    expect(nested.getByRole('heading', { level: 5, name: /Nested Opening Tag/ })).toBeVisible();
+    expect(nested.getByText('strikethrough').tagName).toBe('DEL');
+    expect(nested.getByText('emphasis').tagName).toBe('EM');
+  });
+
+  it('never renders the nested markdown as an indented code block', () => {
+    const { container } = renderFixture();
+
+    expect(container.querySelector('pre')).toBeNull();
+  });
+});

--- a/__tests__/transformers/terminate-html-flow-blocks.test.ts
+++ b/__tests__/transformers/terminate-html-flow-blocks.test.ts
@@ -167,6 +167,32 @@ const x = 1;
 [/block]`);
     });
 
+    it('inserts blank line after a lone opening tag when the next line is markdown indented 1-3 columns', () => {
+      const input = `<div className="simple-list">
+  ## Learn By Example
+
+  Use the [API Simulator](https://example.com) alongside guides.
+</div>`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div className="simple-list">
+
+  ## Learn By Example
+
+  Use the [API Simulator](https://example.com) alongside guides.
+</div>`);
+    });
+
+    it('inserts blank line after an indented (1-3 columns) lone opening tag followed by markdown', () => {
+      const input = `  <div>
+text at column 0`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`  <div>
+
+text at column 0`);
+    });
+
     it('inserts blank line when HTML line has text content between and after tags', () => {
       const input = `<div><p>Inner text</p></div>Outer text
 [block:callout]
@@ -232,17 +258,58 @@ Hello
       expect(terminateHtmlFlowBlocks(input)).toBe(input);
     });
 
-    it('does not modify indented non-HTML lines after an HTML tag', () => {
+    it('does not insert after a tab-indented opening tag (a tab counts as 4 columns)', () => {
+      const input = `\t<div>
+text at column 0`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not modify non-HTML lines indented 4+ columns after an HTML tag', () => {
       const input = `<div>
-  indented line
+      indented line
       with some text after
 
       should be left alone
-<div>
-  nested divs should be left alone too
-</div>
 </div>
       `;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not insert for indented shapes when the current line has more than a lone opening tag', () => {
+      const input = `  <div><span>x</span>
+  text after`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not insert after an opening tag when the indented next line opens a tag', () => {
+      const input = `<div>
+  <div
+    style={{ display: "grid" }}
+  >
+  </div>
+</div>`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not insert after an opening tag when the indented next line opens an expression', () => {
+      const input = `<div className="grid">
+  {[1, 2].map(item => (
+    <span>{item}</span>
+  ))}
+</div>`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not insert for indented shapes inside a still-open raw-content element', () => {
+      const input = `<pre>
+<div>
+  # verbatim, not a heading
+</pre>`;
 
       expect(terminateHtmlFlowBlocks(input)).toBe(input);
     });
@@ -375,6 +442,22 @@ Some text
 </pre>`;
 
       expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('still inserts for column-0 pairs inside a still-open raw-content element', () => {
+      // Locks in the col-0 asymmetry: only the line's own unclosed opener blocks
+      // insertion at column 0 — cumulative tracking is deliberately not consulted,
+      // so one unclosed <pre>/<table> typo can't poison the rest of the document.
+      const input = `<pre>
+<div>
+# consumed by the still-open pre
+</pre>`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(`<pre>
+<div>
+
+# consumed by the still-open pre
+</pre>`);
     });
 
     it('does not insert blank line after <pre> opener even when next line looks like a magic block', () => {

--- a/example/docs.ts
+++ b/example/docs.ts
@@ -3,6 +3,7 @@ import childTests from '../__tests__/fixtures/child-tests.mdx';
 import codeBlockTests from '../__tests__/fixtures/code-block-tests.md';
 import exportTests from '../__tests__/fixtures/export-tests.mdx';
 import imageTests from '../__tests__/fixtures/image-tests.mdx';
+import markdownInHtmlTests from '../__tests__/fixtures/markdown-in-html-tests.mdx';
 import sanitizingTests from '../__tests__/fixtures/sanitizing-tests.md';
 import tableOfContentsTests from '../__tests__/fixtures/table-of-contents-tests.md';
 import tailwindRootTests from '../__tests__/fixtures/tailwind-root-tests.mdx';
@@ -40,6 +41,7 @@ const fixtures = Object.entries({
   images,
   imageTests,
   lists,
+  markdownInHtmlTests,
   mdxComponents,
   builtInComponents,
   mermaid,

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -15,9 +15,11 @@ export { parseAttributes, parseTag } from '../../../../lib/utils/mdxish/mdxish-c
 const NESTED_ATTR_EXPRESSION_RE = /[\w-]+\s*=\s*\{/;
 
 /**
- * Dedent component bodies so readability indentation isn't parsed as indented code
- * (4+ spaces). Shallow bodies (min indent ≤3) stay byte-identical to preserve
- * whitespace text nodes; deeper bodies dedent fully, keeping relative indentation.
+ * Strip the shared leading indentation from a component body so readability indentation
+ * isn't parsed as indented code (4+ spaces), e.g. `  <p>` / `   text` -> `<p>` / ` text`.
+ * Relative indentation is kept, so content genuinely 4+ columns deeper stays code. We
+ * only strip when a line actually reaches 4 columns; otherwise the body is left as-is so
+ * its leading whitespace survives as text nodes (mixed component + HTML content needs it).
  */
 function safeDeindent(text: string): string {
   const lines = text.split('\n');
@@ -25,16 +27,12 @@ function safeDeindent(text: string): string {
   if (nonEmptyLines.length === 0) return text;
 
   // Indent counts characters (tab = 1), unlike indentWidth's CommonMark columns
-  // (tab = 4) in terminate-html-flow-blocks; tab-indented bodies stay untouched.
-  const minIndent = Math.min(
-    ...nonEmptyLines.map(line => {
-      const match = line.match(/^(\s*)/);
-      return match ? match[1].length : 0;
-    }),
-  );
+  // (tab = 4) in terminate-html-flow-blocks.
+  const indents = nonEmptyLines.map(line => line.match(/^(\s*)/)?.[1].length ?? 0);
+  const minIndent = Math.min(...indents);
+  const maxIndent = Math.max(...indents);
 
-  // Bodies already below the code threshold stay byte-identical.
-  const stripAmount = minIndent > 3 ? minIndent : 0;
+  const stripAmount = maxIndent > 3 ? minIndent : 0;
   if (stripAmount === 0) return text;
   return lines.map(line => line.slice(stripAmount)).join('\n');
 }

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -5,6 +5,7 @@ import type { Plugin } from 'unified';
 import { GENERIC_MDX_COMPONENT_EXCLUDED_TAGS } from '../../../../lib/constants';
 import { type ParseAttributesOptions, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
 import { pointAfter } from '../../../utils';
+import { terminateHtmlFlowBlocks } from '../terminate-html-flow-blocks';
 
 import { getInlineMdProcessor, hasExpressionAttr, isPascalCase } from './utils';
 
@@ -14,16 +15,17 @@ export { parseAttributes, parseTag } from '../../../../lib/utils/mdxish/mdxish-c
 const NESTED_ATTR_EXPRESSION_RE = /[\w-]+\s*=\s*\{/;
 
 /**
- * Reduce leading whitespace on all lines just enough to prevent
- * remark from treating indented content as code blocks (4+ spaces).
- * Preserves relative indentation so whitespace text nodes are
- * maintained in the HAST output.
+ * Dedent component bodies so readability indentation isn't parsed as indented code
+ * (4+ spaces). Shallow bodies (min indent ≤3) stay byte-identical to preserve
+ * whitespace text nodes; deeper bodies dedent fully, keeping relative indentation.
  */
 function safeDeindent(text: string): string {
   const lines = text.split('\n');
   const nonEmptyLines = lines.filter(line => line.trim().length > 0);
   if (nonEmptyLines.length === 0) return text;
 
+  // Indent counts characters (tab = 1), unlike indentWidth's CommonMark columns
+  // (tab = 4) in terminate-html-flow-blocks; tab-indented bodies stay untouched.
   const minIndent = Math.min(
     ...nonEmptyLines.map(line => {
       const match = line.match(/^(\s*)/);
@@ -31,19 +33,19 @@ function safeDeindent(text: string): string {
     }),
   );
 
-  // Only strip enough indent to keep all lines below the 4-space code threshold
-  const stripAmount = Math.max(0, minIndent - 3);
+  // Bodies already below the code threshold stay byte-identical.
+  const stripAmount = minIndent > 3 ? minIndent : 0;
   if (stripAmount === 0) return text;
   return lines.map(line => line.slice(stripAmount)).join('\n');
 }
 
 /**
- * Parse markdown content into mdast children nodes.
- * Dedents the content first to prevent indented component content
- * (from nested components) from being treated as code blocks.
+ * Parse component-body markdown into mdast children. Dedenting shifts columns and
+ * stales the top-level `terminateHtmlFlowBlocks` decisions, so that one preprocessor
+ * re-runs here; other column-anchored fixups (compact headings, tables) do not.
  */
 const parseMdChildren = (value: string, safeMode: boolean): RootContent[] => {
-  const parsed = getInlineMdProcessor({ safeMode }).parse(safeDeindent(value).trim());
+  const parsed = getInlineMdProcessor({ safeMode }).parse(terminateHtmlFlowBlocks(safeDeindent(value).trim()));
   return parsed.children || [];
 };
 

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -7,6 +7,10 @@ const STANDALONE_HTML_LINE_REGEX = /^(<[a-z][^<>]*>|<\/[a-z][^<>]*>)+\s*$/;
 
 const HTML_LINE_WITH_CONTENT_REGEX = /^<[a-z][^<>]*>.*<\/[a-z][^<>]*>(?:[^<]*)$/;
 
+// A line that is exactly one lowercase opening (or self-closing) tag — the shape
+// that opens a CommonMark type-6/7 HTML block and swallows the lines below it.
+const SINGLE_OPENING_TAG_REGEX = /^<[a-z][^<>]*>$/;
+
 // Tags whose contents must be preserved as is, inserting a blank line after the
 // opener corrupts the payload.
 // htmlRawNames here refer to <pre>, <textarea>, <script>, <style>
@@ -22,54 +26,97 @@ function isLineHtml(line: string) {
   return STANDALONE_HTML_LINE_REGEX.test(line) || HTML_LINE_WITH_CONTENT_REGEX.test(line);
 }
 
-// True if any RAW_CONTENT_TAGS opener on this line is not closed on the same line.
-function hasUnclosedRawContentOpener(line: string): boolean {
-  return RAW_CONTENT_TAG_MATCHERS.some(({ open, close }) => {
-    const opens = (line.match(open) ?? []).length;
-    const closes = (line.match(close) ?? []).length;
-    return opens > closes;
-  });
+// Per-tag {opens, closes} counts of RAW_CONTENT_TAGS on one line — feeds both the
+// per-line net-open check and the cumulative still-open depth tracking.
+function countRawContentTags(line: string): { closes: number; opens: number }[] {
+  return RAW_CONTENT_TAG_MATCHERS.map(({ open, close }) => ({
+    opens: (line.match(open) ?? []).length,
+    closes: (line.match(close) ?? []).length,
+  }));
+}
+
+// Indentation width in columns, counting a tab as 4 per CommonMark.
+function indentWidth(line: string): number {
+  const leading = line.match(/^[ \t]*/)?.[0] ?? '';
+  return leading.replace(/\t/g, '    ').length;
+}
+
+interface RawContentFacts {
+  /** Any raw-content element is still open at the boundary after `line`. */
+  insideRawContent: boolean;
+  /** A raw-content opener on `line` itself is left unclosed by that line. */
+  lineLeavesRawOpen: boolean;
 }
 
 /**
- * Preprocessor to terminate HTML flow blocks.
- *
- * In CommonMark, HTML blocks (types 6 and 7) only terminate on a blank line.
- * Without one, any content on the next line is consumed as part of the HTML block
- * and never parsed as its own construct. For example, a `[block:callout]` immediately
- * following `<div><p></p></div>` gets swallowed into the HTML flow token.
+ * Decides whether a blank line belongs between `line` and `next` so the HTML
+ * flow block opened on `line` terminates and `next` parses as markdown.
+ */
+function shouldTerminateBetween(
+  line: string,
+  next: string,
+  { insideRawContent, lineLeavesRawOpen }: RawContentFacts,
+): boolean {
+  if (next.trim().length === 0) return false;
+
+  const currentIndent = indentWidth(line);
+  const nextIndent = indentWidth(next);
+  // 4+ columns is CommonMark indented-code territory: an inserted blank line
+  // would turn the next line into a code block instead of freeing it (#1344).
+  if (currentIndent > 3 || nextIndent > 3) return false;
+
+  const currentTrimmed = line.trim();
+  const nextTrimmed = next.trim();
+  if (!isLineHtml(currentTrimmed) || isLineHtml(nextTrimmed) || lineLeavesRawOpen) {
+    return false;
+  }
+
+  // Column-0 pairs keep the original (pre-relaxation) rule, deliberately ignoring
+  // `insideRawContent`: one unclosed <pre>/<table> typo would otherwise suppress
+  // termination for the whole rest of the document.
+  if (currentIndent === 0 && nextIndent === 0) return true;
+
+  // Indented shapes (either line at 1–3 columns) are stricter: only a lone opening
+  // tag followed by markdown. A next line opening a tag or expression must stay
+  // glued for the mdxComponent tokenizer; raw-content payloads stay byte-exact.
+  return (
+    !insideRawContent &&
+    SINGLE_OPENING_TAG_REGEX.test(currentTrimmed) &&
+    !nextTrimmed.startsWith('<') &&
+    !nextTrimmed.startsWith('{')
+  );
+}
+
+/**
+ * CommonMark HTML blocks (types 6/7) end only at a blank line, so markdown on the
+ * next line is swallowed as HTML (`## heading` after `<div>` renders as literal text).
+ * Inserts the missing blank line; the gating rules live in `shouldTerminateBetween`.
  *
  * @link https://spec.commonmark.org/0.29/#html-blocks
- *
- * This preprocessor inserts a blank line after standalone HTML lines when the next
- * line is non-blank and not an HTML construct, ensuring micromark's HTML flow
- * tokenizer terminates and subsequent content is parsed independently.
- *
- * Conditions:
- * 1. Only non-indented lines with lowercase tag names are considered. Uppercase tags
- *    (e.g. `<Table>`, `<MyComponent>`) are JSX custom components and don't trigger
- *    CommonMark HTML blocks.
- * 2. Lines inside protected blocks (e.g. fenced code) are left untouched.
- * 3. Lines with an unclosed RAW_CONTENT_TAGS opener are exempted.
  */
 export function terminateHtmlFlowBlocks(content: string) {
   const { protectedContent, protectedCode } = protectCodeBlocks(content);
 
   const lines = protectedContent.split('\n');
   const result: string[] = [];
+  // Per-tag count of still-open raw-content elements at the current boundary.
+  const rawContentDepths = RAW_CONTENT_TAG_MATCHERS.map(() => 0);
 
   for (let i = 0; i < lines.length; i += 1) {
-    result.push(lines[i]);
+    const line = lines[i];
+    result.push(line);
 
-    // Skip blank & indented lines
-    if (i >= lines.length - 1 || lines[i + 1].trim().length === 0 || lines[i + 1].startsWith(' ') || lines[i + 1].startsWith('\t')) {
-      // eslint-disable-next-line no-continue
-      continue;
-    }
+    const tagCounts = countRawContentTags(line);
+    tagCounts.forEach(({ opens, closes }, tagIndex) => {
+      rawContentDepths[tagIndex] = Math.max(0, rawContentDepths[tagIndex] + opens - closes);
+    });
 
-    const isCurrentLineHtml = isLineHtml(lines[i]);
-    const isNextLineHtml = isLineHtml(lines[i + 1]);
-    if (isCurrentLineHtml && !isNextLineHtml && !hasUnclosedRawContentOpener(lines[i])) {
+    const next = lines[i + 1];
+    const rawContentFacts = {
+      insideRawContent: rawContentDepths.some(depth => depth > 0),
+      lineLeavesRawOpen: tagCounts.some(({ opens, closes }) => opens > closes),
+    };
+    if (next !== undefined && shouldTerminateBetween(line, next, rawContentFacts)) {
       result.push('');
     }
   }


### PR DESCRIPTION
([See slack thread](https://readmeio.slack.com/archives/C09TLJGD8M8/p1783973320213679))

Markdown indented for readability right after a plain HTML opening tag (`<div>` … `  ## Heading`) rendered as literal text. CommonMark HTML blocks only end at a blank line, so the content got swallowed. Same problem inside component bodies such as `<Tabs>`, where leftover indentation could also turn paragraphs into code blocks.

## 🎯 What does this PR do?
- `terminateHtmlFlowBlocks` now also terminates 1–3 column shapes, but only after a lone opening tag followed by markdown. Column-0 behavior is unchanged, 4+ columns is still left alone (indented-code territory, #1344), and open `<pre>`/`<table>` payloads stay byte-exact.
- Component bodies dedent fully (shallowest line = column 0) and re-run `terminateHtmlFlowBlocks` afterward, since dedenting invalidates the top-level pass's decisions.

Covered by unit tests, AST tests, and a new fixture rendered through **both engines** to ensure mdx/mdxish parity (headings, links, lists, quotes, tables in HTML wrappers).

Surfaced along the way, not fixed here: lists/blockquotes *directly* after a plain HTML opener don't parse in mdxish (pre-existing tokenizer limitation) — follow-up material.

## 🧪 QA tips

- Run locally in the dev playground. Everything should render as real markdown inside its wrapper — no literal `##`/`>` text, no stray code blocks.
- Paste fixture sections into an mdxish page and the output should match.

- [ ]

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
