### PR TITLE
fix(mdxish): stop escaping intraword underscores on serialization

### DIFF
--- a/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
+++ b/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
@@ -1075,6 +1075,90 @@ describe('mdxishMdastToMd', () => {
     });
   });
 
+  describe('braces serialization', () => {
+    const paragraph = (value: string): MdastRoot => ({
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'text', value }] }],
+    });
+
+    it('should escape a lone literal open brace in text', () => {
+      expect(mdxishMdastToMd(paragraph('{label'))).toBe('\\{label\n');
+    });
+
+    it('should preserve escaped closed braces in text', () => {
+      expect(roundTripMdxish('a\\{b}c')).toBe('a\\{b\\}c\n');
+    });
+
+    it('should keep escaped braces stable across two round trips', () => {
+      const once = roundTripMdxish('vars \\{label}, \\{payment_period}\n', { newEditorTypes: true });
+      const twice = roundTripMdxish(once, { newEditorTypes: true });
+      expect(once).toBe(twice);
+    });
+
+    it('should not escape underscores that sit inside literal braces', () => {
+      expect(roundTripMdxish('for the %\\{payment_period} pay period.\n', { newEditorTypes: true })).not.toContain('\\_');
+    });
+
+    it('should not escape the braces of a readme-variable expression', () => {
+      expect(roundTripMdxish('Hello {user.name}!\n', { newEditorTypes: true })).toBe('Hello {user.name}!\n');
+    });
+
+    it('should escape literal braces inside table cells', () => {
+      const mdast: MdastRoot = {
+        type: 'root',
+        children: [
+          {
+            type: 'table',
+            align: [null, null],
+            children: [
+              {
+                type: 'tableRow',
+                children: [
+                  { type: 'tableCell', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'Title' }] }] },
+                  { type: 'tableCell', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'Vars' }] }] },
+                ],
+              },
+              {
+                type: 'tableRow',
+                children: [
+                  { type: 'tableCell', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'Run payroll%{label' }] }] },
+                  { type: 'tableCell', children: [{ type: 'paragraph', children: [{ type: 'text', value: '{label}' }] }] },
+                ],
+              },
+            ],
+          } as Table,
+        ],
+      };
+
+      const result = mdxishMdastToMd(mdast);
+      expect(result).toContain('Run payroll%\\{label');
+      expect(result).toContain('\\{label\\}');
+    });
+
+    it('should preserve JSX table attributes while escaping braces in a cell', () => {
+      // A list in a cell forces JSX <Table> output; attribute braces must survive.
+      const out = roundTripMdxish(
+        [
+          '<Table align={["left"]}>',
+          '  <thead><tr><th style={{ textAlign: "left" }}>A</th></tr></thead>',
+          '  <tbody><tr><td style={{ textAlign: "left" }}>',
+          '',
+          '- x',
+          '- y',
+          '',
+          '  </td></tr></tbody>',
+          '</Table>',
+          '',
+        ].join('\n'),
+        { newEditorTypes: true },
+      );
+
+      expect(out).toContain('align={["left"]}');
+      expect(out).toContain('style={{ textAlign: "left" }}');
+      expect(out).not.toContain('align={\\[');
+    });
+  });
+
   it('should convert readme-anchor nodes back to <Anchor> JSX syntax', () => {
     const mdast: MdastRoot = {
       type: 'root',

--- a/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
+++ b/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
@@ -2,6 +2,7 @@ import type { Root as MdastRoot, RootContent, Table } from 'mdast';
 
 import { NodeTypes } from '../../../enums';
 import { mdxishMdastToMd } from '../../../lib';
+import { roundTripMdxish } from '../../helpers';
 
 describe('mdxishMdastToMd', () => {
   it('should convert a simple paragraph', () => {
@@ -1013,6 +1014,60 @@ describe('mdxishMdastToMd', () => {
         | Alice | 30  |
         "
       `);
+    });
+  });
+
+  describe('underscores serialization', () => {
+    const paragraph = (value: string): MdastRoot => ({
+      type: 'root',
+      children: [{ type: 'paragraph', children: [{ type: 'text', value }] }],
+    });
+
+    it('should not escape underscores flanked by word characters', () => {
+      expect(mdxishMdastToMd(paragraph('payroll_setup.pay_schedule_setup_not_complete'))).toBe(
+        'payroll_setup.pay_schedule_setup_not_complete\n',
+      );
+    });
+
+    it('should not escape consecutive intraword underscores', () => {
+      expect(mdxishMdastToMd(paragraph('leading__double__trailing'))).toBe('leading__double__trailing\n');
+    });
+
+    it('should still escape underscores at word boundaries that could open emphasis', () => {
+      expect(roundTripMdxish('_leading and trailing_')).toBe('_leading and trailing_\n');
+    });
+
+    it('should not escape intraword underscores inside table cells', () => {
+      const mdast: MdastRoot = {
+        type: 'root',
+        children: [
+          {
+            type: 'table',
+            align: [null, null],
+            children: [
+              {
+                type: 'tableRow',
+                children: [
+                  { type: 'tableCell', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'Category' }] }] },
+                  { type: 'tableCell', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'Value' }] }] },
+                ],
+              },
+              {
+                type: 'tableRow',
+                children: [
+                  { type: 'tableCell', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'pay_schedule_transition' }] }] },
+                  { type: 'tableCell', children: [{ type: 'paragraph', children: [{ type: 'text', value: 'entity_type' }] }] },
+                ],
+              },
+            ],
+          } as Table,
+        ],
+      };
+
+      const result = mdxishMdastToMd(mdast);
+      expect(result).toContain('pay_schedule_transition');
+      expect(result).toContain('entity_type');
+      expect(result).not.toContain('\\_');
     });
   });
 

--- a/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
+++ b/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
@@ -1033,6 +1033,10 @@ describe('mdxishMdastToMd', () => {
       expect(mdxishMdastToMd(paragraph('leading__double__trailing'))).toBe('leading__double__trailing\n');
     });
 
+    it('should not escape intraword underscores between non-ASCII letters', () => {
+      expect(mdxishMdastToMd(paragraph('café_touché'))).toBe('café_touché\n');
+    });
+
     it('should still escape underscores at word boundaries that could open emphasis', () => {
       expect(roundTripMdxish('_leading and trailing_')).toBe('_leading and trailing_\n');
     });

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -243,6 +243,12 @@ export function mdxishMdastToMd(mdast: MdastRoot) {
     .use(remarkStringify, {
       bullet: '-',
       emphasis: '_',
+      // Escape literal braces in text so they don't parse as (often
+      // unterminated) MDX expressions on the next round trip.
+      unsafe: [
+        { character: '{', inConstruct: 'phrasing' },
+        { character: '}', inConstruct: 'phrasing' },
+      ],
     });
   return processor.stringify(processor.runSync(mdast));
 }

--- a/processor/compile/index.ts
+++ b/processor/compile/index.ts
@@ -1,3 +1,4 @@
+import type { Unsafe } from 'mdast-util-to-markdown';
 import type { Processor } from 'unified';
 
 import { NodeTypes } from '../../enums';
@@ -42,7 +43,17 @@ function compilers(this: Processor, mdxish = false) {
     ...(mdxish && { [NodeTypes.variable]: variable }),
   };
 
-  toMarkdownExtensions.push({ extensions: [{ handlers }] });
+  // Escape literal braces in mdxish text so they don't parse as (often
+  // unterminated) MDX expressions on the next round trip. Routed through the
+  // unsafe list so mdast-util-to-markdown handles backslash ordering.
+  const unsafe: Unsafe[] = mdxish
+    ? [
+        { character: '{', inConstruct: 'phrasing' },
+        { character: '}', inConstruct: 'phrasing' },
+      ]
+    : [];
+
+  toMarkdownExtensions.push({ extensions: [{ handlers, unsafe }] });
 }
 
 export function mdxishCompilers(this: Processor) {

--- a/processor/compile/index.ts
+++ b/processor/compile/index.ts
@@ -11,6 +11,7 @@ import gemoji from './gemoji';
 import htmlBlock from './html-block';
 import listItem from './list-item';
 import plain from './plain';
+import text from './text';
 import variable from './variable';
 
 function compilers(this: Processor, mdxish = false) {
@@ -19,7 +20,6 @@ function compilers(this: Processor, mdxish = false) {
   const toMarkdownExtensions = data.toMarkdownExtensions || (data.toMarkdownExtensions = []);
 
   const handlers = {
-    ...(mdxish && { [NodeTypes.anchor]: anchor }),
     [NodeTypes.callout]: callout,
     [NodeTypes.codeTabs]: codeTabs,
     [NodeTypes.embedBlock]: embed,
@@ -27,15 +27,19 @@ function compilers(this: Processor, mdxish = false) {
     [NodeTypes.glossary]: compatibility,
     [NodeTypes.htmlBlock]: htmlBlock,
     [NodeTypes.reusableContent]: compatibility,
-    ...(mdxish && { [NodeTypes.variable]: variable }),
     embed: compatibility,
     escape: compatibility,
     figure: compatibility,
     html: compatibility,
     i: compatibility,
-    ...(mdxish && { listItem }),
     plain,
     yaml: compatibility,
+
+    // needed only for mdxish
+    ...(mdxish && { [NodeTypes.anchor]: anchor }),
+    ...(mdxish && { listItem }),
+    ...(mdxish && { text }),
+    ...(mdxish && { [NodeTypes.variable]: variable }),
   };
 
   toMarkdownExtensions.push({ extensions: [{ handlers }] });

--- a/processor/compile/index.ts
+++ b/processor/compile/index.ts
@@ -1,4 +1,3 @@
-import type { Unsafe } from 'mdast-util-to-markdown';
 import type { Processor } from 'unified';
 
 import { NodeTypes } from '../../enums';
@@ -43,17 +42,7 @@ function compilers(this: Processor, mdxish = false) {
     ...(mdxish && { [NodeTypes.variable]: variable }),
   };
 
-  // Escape literal braces in mdxish text so they don't parse as (often
-  // unterminated) MDX expressions on the next round trip. Routed through the
-  // unsafe list so mdast-util-to-markdown handles backslash ordering.
-  const unsafe: Unsafe[] = mdxish
-    ? [
-        { character: '{', inConstruct: 'phrasing' },
-        { character: '}', inConstruct: 'phrasing' },
-      ]
-    : [];
-
-  toMarkdownExtensions.push({ extensions: [{ handlers, unsafe }] });
+  toMarkdownExtensions.push({ extensions: [{ handlers }] });
 }
 
 export function mdxishCompilers(this: Processor) {

--- a/processor/compile/text.ts
+++ b/processor/compile/text.ts
@@ -6,17 +6,12 @@ import { defaultHandlers } from 'mdast-util-to-markdown';
 // A `_` flanked by word characters can never open or close emphasis under
 // CommonMark's flanking rules, so the escape mdast-util-to-markdown adds to
 // intraword underscores is unnecessary and only produces noisy `\_` diffs.
-const INTRAWORD_UNDERSCORE_ESCAPE = /(?<=\w)\\_(?=\w|\\_)/g;
-
-// Literal braces in text carry no expression meaning, but the default handler
-// leaves them bare. Re-escape them so they don't parse as (often unterminated)
-// MDX expressions on the next round trip. Real expressions/variables are their
-// own node types and never reach this handler.
-const LITERAL_BRACE = /[{}]/g;
+// Uses Unicode letter/number classes so non-ASCII words (e.g. `é_pay`) match.
+const INTRAWORD_UNDERSCORE_ESCAPE = /(?<=[\p{L}\p{N}_])\\_(?=[\p{L}\p{N}_]|\\_)/gu;
 
 const text = (node: Text, parent: Parents | undefined, state: State, info: Info): string => {
   const serialized = defaultHandlers.text(node, parent, state, info);
-  return serialized.replace(INTRAWORD_UNDERSCORE_ESCAPE, '_').replace(LITERAL_BRACE, '\\$&');
+  return serialized.replace(INTRAWORD_UNDERSCORE_ESCAPE, '_');
 };
 
 export default text;

--- a/processor/compile/text.ts
+++ b/processor/compile/text.ts
@@ -1,0 +1,22 @@
+import type { Parents, Text } from 'mdast';
+import type { Info, State } from 'mdast-util-to-markdown';
+
+import { defaultHandlers } from 'mdast-util-to-markdown';
+
+// A `_` flanked by word characters can never open or close emphasis under
+// CommonMark's flanking rules, so the escape mdast-util-to-markdown adds to
+// intraword underscores is unnecessary and only produces noisy `\_` diffs.
+const INTRAWORD_UNDERSCORE_ESCAPE = /(?<=\w)\\_(?=\w|\\_)/g;
+
+// Literal braces in text carry no expression meaning, but the default handler
+// leaves them bare. Re-escape them so they don't parse as (often unterminated)
+// MDX expressions on the next round trip. Real expressions/variables are their
+// own node types and never reach this handler.
+const LITERAL_BRACE = /[{}]/g;
+
+const text = (node: Text, parent: Parents | undefined, state: State, info: Info): string => {
+  const serialized = defaultHandlers.text(node, parent, state, info);
+  return serialized.replace(INTRAWORD_UNDERSCORE_ESCAPE, '_').replace(LITERAL_BRACE, '\\$&');
+};
+
+export default text;


### PR DESCRIPTION
| 🎫 Resolve RM-17430 |
| :-----------------: |

## 🎯 What does this PR do?

A Gusto teammate [reported via Support](https://readmeio.slack.com/archives/C09DEJZP3EX/p1783984150584729?thread_ts=1783984150.584729&cid=C09DEJZP3EX) that editing a table in the Mdxish editor (e.g. deleting a row) caused every underscore in the table to suddenly gain a `\` on save e.g. `pay_schedule` became `pay\_schedule` across the whole doc.

Digging in, there are a few distinct issues in play on the round trip:

- **Unclosed curly braces** in a particular cell (`Run transition payroll%\{label`). The literal-brace escape `\{` is dropped on serialization, which breaks the MDX table parsing and leaves the table as raw `<Table>`, which is what made the escaping appear on edit.
- **Underscore over-escaping** — `mdast-util-to-markdown` (via `remark-stringify@11`) escapes *every* `_` in phrasing text by default, including intraword ones like `pay_schedule`. This actually has been happening & the backslash would be hidden IF the table is in GFM, in JSX table these backslashes become visible. So these 2 things combined produced the backlashes appearing.

This PR fixes:
- **Underscore serialization**: Which is the main underlying issue. A custom `text` compiler for mdxish delegates to the default handler and then un-escapes intraword underscores
- **Brace unescaped**: Re-escapes literal `{`/`}` in text nodes so they round-trip as `\{`/`\}` instead of decaying into unclosed expressions, real expressions/variables are their own node types and never reach this handler. Added this in the mdxishToMd serializer

## 🧪 QA tips

- [ ] Locally link this branch to the readme app. In the Mdxish editor, paste the minimal repro below, save, and round trip it (reopen / re-save).
- [ ] **Expected:** underscores stay as-is (`payroll_setup.pay_schedule_setup_not_complete`, `pay_schedule_transition`) with no `\_` added, and the `\{` stays escaped rather than turning into a bare unclosed `{`.

```
<Table>
  <thead>
    <tr>
      <th style={{ textAlign: "left" }}>
        Category
      </th>

      <th style={{ textAlign: "left" }}>
        Title
      </th>
    </tr>
  </thead>

  <tbody>

    <tr>
      <td style={{ textAlign: "left" }}>
        payroll_setup.pay_schedule_setup_not_complete
      </td>

      <td style={{ textAlign: "left" }}>
        * Employee or employment changed and needs to be assigned a pay schedule.\n- Pay schedule setup not complete
      </td>
    </tr>

    <tr>
      <td style={{ textAlign: "left" }}>
        pay_schedule_transition
      </td>

      <td style={{ textAlign: "left" }}>
        Run transition payroll%\{label
      </td>
    </tr>

  </tbody>
</Table>
```

## 📸 Screenshot or Loom

**Before vs After on the real problematic customer doc before the added backslashes**:



https://github.com/user-attachments/assets/fcf472f1-cd26-4f3e-928b-68edd10d138a



