### PR TITLE
fix(mdxish): keep tables whole when their closer has stray whitespace

### DIFF
--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -1964,4 +1964,100 @@ ${lowercaseTable}
       expect(start.line).toBe(expectedLine);
     });
   });
+
+  describe('given a raw-HTML table whose closer has stray whitespace (CX-3706)', () => {
+    // `jsxTable` captures a raw `<table>` by scanning for a literal `</table>`.
+    // A `</ table >` closer (the same "spaces in the tag" defect the source has
+    // in its `</ td >` cells) isn't recognized, so the table used to look
+    // unclosed: it fragmented at blank lines into an empty `<table></table>`
+    // plus a `<pre>` code block. Normalizing the closer keeps the table whole.
+    it('recovers a table closed with </ table > into a single table with every row', () => {
+      const doc = `<table>
+  <thead>
+    <tr><th>Country</th><th>Src</th></tr>
+  </thead>
+
+  <tr>
+    <td>Russia</td>
+    <td>Federal Tax Service</td>
+  </tr>
+
+  <tr>
+    <td>USA</td>
+    <td>IRS</td>
+  </tr>
+</ table >`;
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).not.toContain('<pre');
+      const tables = findAllElementsByTagName(hast, 'table');
+      expect(tables).toHaveLength(1);
+      // header row + 2 body rows
+      expect(findAllElementsByTagName(tables[0], 'tr')).toHaveLength(3);
+      expect(html).toContain('Federal Tax Service');
+      expect(html).toContain('IRS');
+    });
+
+    it('does not fragment 4-space-indented rows into a <pre> code block', () => {
+      const doc = `<table>
+    <thead>
+        <tr><th>Country</th><th>Src</th></tr>
+    </thead>
+
+    <tr>
+        <td>Russia</td>
+        <td>Federal Tax Service</td>
+    </tr>
+</ table >`;
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).not.toContain('<pre');
+      expect(html).not.toContain('<code');
+      expect(findAllElementsByTagName(hast, 'table')).toHaveLength(1);
+    });
+
+    it('recovers a </ table >-closed table wrapped in a plain <div>', () => {
+      const doc = `<div class="rdmd-table">
+<table>
+  <thead>
+    <tr><th>Country</th><th>Src</th></tr>
+  </thead>
+
+  <tr>
+    <td>Russia</td>
+    <td>Federal Tax Service</td>
+  </tr>
+</ table >
+</div>`;
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).not.toContain('<pre');
+      expect(findAllElementsByTagName(hast, 'table')).toHaveLength(1);
+      expect(html).toContain('Federal Tax Service');
+    });
+
+    it('drops the stray comment a spaced </ td > cell closer used to leave behind', () => {
+      const doc = `<table>
+  <thead>
+    <tr><th>Country</th><th>Src</th></tr>
+  </thead>
+
+  <tr>
+    <td>Marshall Islands </ td >
+    <td>International Registries Inc.</td>
+  </tr>
+</table>`;
+      const hast = mdxish(doc);
+      const html = toHtml(hast);
+
+      expect(html).not.toContain('<!--');
+      const cells = findAllElementsByTagName(hast, 'td');
+      expect(cells.length).toBeGreaterThanOrEqual(2);
+      expect(html).toContain('Marshall Islands');
+      expect(html).toContain('International Registries Inc.');
+    });
+  });
 });

--- a/__tests__/transformers/normalize-closing-tag-whitespace.test.ts
+++ b/__tests__/transformers/normalize-closing-tag-whitespace.test.ts
@@ -1,0 +1,78 @@
+import { normalizeClosingTagWhitespace } from '../../processor/transform/mdxish/normalize-closing-tag-whitespace';
+
+describe('normalizeClosingTagWhitespace (string-level preprocessor)', () => {
+  describe('canonicalizes closing tags with stray whitespace', () => {
+    it('strips inner spaces from </ td >', () => {
+      expect(normalizeClosingTagWhitespace('Marshall Islands </ td >')).toBe('Marshall Islands </td>');
+    });
+
+    it('strips a trailing space from </table >', () => {
+      expect(normalizeClosingTagWhitespace('</table >')).toBe('</table>');
+    });
+
+    it('strips a leading space from </ table>', () => {
+      expect(normalizeClosingTagWhitespace('</ table>')).toBe('</table>');
+    });
+
+    it('collapses multiple spaces </  th  >', () => {
+      expect(normalizeClosingTagWhitespace('</  th  >')).toBe('</th>');
+    });
+
+    it('handles tabs', () => {
+      expect(normalizeClosingTagWhitespace('</\ttd\t>')).toBe('</td>');
+    });
+
+    it.each(['table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'ul', 'li', 'div', 'span'])(
+      'normalizes </ %s >',
+      tag => {
+        expect(normalizeClosingTagWhitespace(`</ ${tag} >`)).toBe(`</${tag}>`);
+      },
+    );
+  });
+
+  describe('leaves canonical and non-tag input untouched', () => {
+    it('leaves an already-canonical </td> unchanged', () => {
+      expect(normalizeClosingTagWhitespace('</td>')).toBe('</td>');
+    });
+
+    it('leaves opening tags unchanged', () => {
+      expect(normalizeClosingTagWhitespace('<td> content </td>')).toBe('<td> content </td>');
+    });
+
+    it('does not touch non-HTML tag names (custom components)', () => {
+      expect(normalizeClosingTagWhitespace('</ MyComponent >')).toBe('</ MyComponent >');
+    });
+
+    it('does not touch prose that looks like a stray closer', () => {
+      expect(normalizeClosingTagWhitespace('a </ b and c > d')).toBe('a </ b and c > d');
+    });
+
+    it('does not span newlines', () => {
+      const input = 'x </\ntd\n> y';
+      expect(normalizeClosingTagWhitespace(input)).toBe(input);
+    });
+
+    it('preserves the authored tag-name case', () => {
+      expect(normalizeClosingTagWhitespace('</ TD >')).toBe('</TD>');
+    });
+  });
+
+  describe('protects code', () => {
+    it('leaves a spaced closer inside inline code alone', () => {
+      expect(normalizeClosingTagWhitespace('use `</ td >` to close')).toBe('use `</ td >` to close');
+    });
+
+    it('leaves a spaced closer inside a fenced code block alone', () => {
+      const input = '```html\n</ td >\n```';
+      expect(normalizeClosingTagWhitespace(input)).toBe(input);
+    });
+  });
+
+  describe('real-world table shapes', () => {
+    it('normalizes both the cell closer and the table closer', () => {
+      const input = ['<table>', '  <tr>', '    <td>Sri Lanka </ td >', '  </tr>', '</ table >'].join('\n');
+      const expected = ['<table>', '  <tr>', '    <td>Sri Lanka </td>', '  </tr>', '</table>'].join('\n');
+      expect(normalizeClosingTagWhitespace(input)).toBe(expected);
+    });
+  });
+});

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -120,9 +120,8 @@ function preprocessContent(
   const { knownComponents } = opts;
 
   // Runs first so `jsxTable` sees a literal `</table>` (and the HTML-line
-  // classification in `terminateHtmlFlowBlocks` is accurate) rather than a
-  // whitespace-mangled closer that would leave the table looking unclosed.
-  let result = normalizeClosingTagWhitespace(content);
+  // classification in `terminateHtmlFlowBlocks` is accurate)
+  let result = normalizeClosingTagWhitespace(content); 
   result = normalizeTableSeparator(result);
   result = terminateHtmlFlowBlocks(result);
   result = closeSelfClosingHtmlTags(result);

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -41,6 +41,7 @@ import magicBlockTransformer from '../processor/transform/mdxish/magic-blocks/ma
 import mdxishHtmlBlocks from '../processor/transform/mdxish/mdxish-html-blocks';
 import mdxishJsxToMdast from '../processor/transform/mdxish/mdxish-jsx-to-mdast';
 import mdxishMermaidTransformer from '../processor/transform/mdxish/mdxish-mermaid';
+import { normalizeClosingTagWhitespace } from '../processor/transform/mdxish/normalize-closing-tag-whitespace';
 import { normalizeCompactHeadings } from '../processor/transform/mdxish/normalize-compact-headings';
 import normalizeEmphasisAST from '../processor/transform/mdxish/normalize-malformed-md-syntax';
 import normalizeMdxJsxNodes from '../processor/transform/mdxish/normalize-mdx-jsx-nodes';
@@ -105,11 +106,12 @@ const defaultTransformers: PluggableList = [
  * CommonMark/remark limitations and reach parity with legacy (rdmd) rendering.
  *
  * Runs a series of string-level transformations before micromark/remark parsing:
- * 1. Normalize malformed table separator syntax (e.g., `|: ---` → `| :---`)
- * 2. Terminate HTML flow blocks so subsequent content isn't swallowed
- * 3. Close invalid "self-closing" HTML tags (e.g., `<i />` → `<i></i>`)
- * 4. Normalize compact ATX headings (e.g., `#Heading` → `# Heading`)
- * 5. Replace snake_case component names with parser-safe placeholders
+ * 1. Canonicalize closing tags with stray whitespace (e.g., `</ td >` → `</td>`)
+ * 2. Normalize malformed table separator syntax (e.g., `|: ---` → `| :---`)
+ * 3. Terminate HTML flow blocks so subsequent content isn't swallowed
+ * 4. Close invalid "self-closing" HTML tags (e.g., `<i />` → `<i></i>`)
+ * 5. Normalize compact ATX headings (e.g., `#Heading` → `# Heading`)
+ * 6. Replace snake_case component names with parser-safe placeholders
  */
 function preprocessContent(
   content: string,
@@ -117,7 +119,11 @@ function preprocessContent(
 ) {
   const { knownComponents } = opts;
 
-  let result = normalizeTableSeparator(content);
+  // Runs first so `jsxTable` sees a literal `</table>` (and the HTML-line
+  // classification in `terminateHtmlFlowBlocks` is accurate) rather than a
+  // whitespace-mangled closer that would leave the table looking unclosed.
+  let result = normalizeClosingTagWhitespace(content);
+  result = normalizeTableSeparator(result);
   result = terminateHtmlFlowBlocks(result);
   result = closeSelfClosingHtmlTags(result);
   result = normalizeCompactHeadings(result);

--- a/processor/transform/mdxish/normalize-closing-tag-whitespace.ts
+++ b/processor/transform/mdxish/normalize-closing-tag-whitespace.ts
@@ -1,45 +1,20 @@
 import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
 import { STANDARD_HTML_TAGS } from '../../../utils/common-html-words';
 
-/**
- * Matches an HTML closing tag carrying stray inline whitespace between `</`, the
- * tag name, and `>` — e.g. `</ td >`, `</table >`, `</ ul>`, `</  th  >`.
- *
- * Whitespace is limited to spaces/tabs (not newlines) so a genuinely
- * cross-line `<` / `>` in prose can never be swept into one "tag".
- *
- * Capture 1 — the tag name.
- */
+// Spaces/tabs only — newlines would let prose `<` / `>` across lines look like one tag.
 const SPACED_CLOSING_TAG_RE = /<\/[ \t]*([a-zA-Z][a-zA-Z0-9-]*)[ \t]*>/g;
 
 /**
- * String-level preprocessor that canonicalizes closing tags written with stray
- * whitespace (`</ td >` → `</td>`).
+ * Canonicalize spaced closing tags (`</ td >` → `</td>`) for known HTML names.
  *
- * Per the HTML spec, `</` immediately followed by whitespace opens a *bogus
- * comment*, so a browser drops `</ td >` entirely and lets the element
- * auto-close later. Our pipeline mirrors that (htmlparser2 emits a comment),
- * but two things break as a result:
- *
- *  1. `jsxTable` captures a raw-HTML `<table>` as a single flow block by
- *     scanning for a *literal* `</table>`. A `</ table >` (or `</table >`)
- *     closer isn't recognized, so the table looks unclosed: it falls back to a
- *     CommonMark HTML block that fragments at blank lines, and its indented
- *     rows collapse into an empty `<table></table>` plus a `<pre>` code block
- *     (CX-3706).
- *  2. Even when the table is otherwise closed, a dropped cell closer leaves a
- *     stray `<!-- td -->` comment in the rendered output.
- *
- * The author unambiguously meant a closing tag, so we normalize the whitespace
- * back out before parsing — matching the browser's *intent* while keeping the
- * table whole. Scoped to standard HTML tag names, so custom components and
- * incidental prose (`a </ b`) are left untouched; code blocks are protected.
+ * In HTML, `</` + whitespace is a bogus comment, so `</ table >` never closes the
+ * table (jsxTable misses it → empty table + pre; CX-3706). Only standard HTML tags;
+ * custom components, prose (`a </ b`), and code blocks are left alone.
  *
  * @example
- * normalizeClosingTagWhitespace('Marshall Islands </ td >') // 'Marshall Islands </td>'
- * normalizeClosingTagWhitespace('</table >')                // '</table>'
- * normalizeClosingTagWhitespace('</td>')                    // '</td>' (already canonical)
- * normalizeClosingTagWhitespace('a </ b > c')               // 'a </ b > c' (not a known tag)
+ * normalizeClosingTagWhitespace('</ td >')   // '</td>'
+ * normalizeClosingTagWhitespace('</table >') // '</table>'
+ * normalizeClosingTagWhitespace('a </ b >')  // unchanged
  */
 export function normalizeClosingTagWhitespace(content: string) {
   const { protectedContent, protectedCode } = protectCodeBlocks(content);

--- a/processor/transform/mdxish/normalize-closing-tag-whitespace.ts
+++ b/processor/transform/mdxish/normalize-closing-tag-whitespace.ts
@@ -1,0 +1,52 @@
+import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
+import { STANDARD_HTML_TAGS } from '../../../utils/common-html-words';
+
+/**
+ * Matches an HTML closing tag carrying stray inline whitespace between `</`, the
+ * tag name, and `>` — e.g. `</ td >`, `</table >`, `</ ul>`, `</  th  >`.
+ *
+ * Whitespace is limited to spaces/tabs (not newlines) so a genuinely
+ * cross-line `<` / `>` in prose can never be swept into one "tag".
+ *
+ * Capture 1 — the tag name.
+ */
+const SPACED_CLOSING_TAG_RE = /<\/[ \t]*([a-zA-Z][a-zA-Z0-9-]*)[ \t]*>/g;
+
+/**
+ * String-level preprocessor that canonicalizes closing tags written with stray
+ * whitespace (`</ td >` → `</td>`).
+ *
+ * Per the HTML spec, `</` immediately followed by whitespace opens a *bogus
+ * comment*, so a browser drops `</ td >` entirely and lets the element
+ * auto-close later. Our pipeline mirrors that (htmlparser2 emits a comment),
+ * but two things break as a result:
+ *
+ *  1. `jsxTable` captures a raw-HTML `<table>` as a single flow block by
+ *     scanning for a *literal* `</table>`. A `</ table >` (or `</table >`)
+ *     closer isn't recognized, so the table looks unclosed: it falls back to a
+ *     CommonMark HTML block that fragments at blank lines, and its indented
+ *     rows collapse into an empty `<table></table>` plus a `<pre>` code block
+ *     (CX-3706).
+ *  2. Even when the table is otherwise closed, a dropped cell closer leaves a
+ *     stray `<!-- td -->` comment in the rendered output.
+ *
+ * The author unambiguously meant a closing tag, so we normalize the whitespace
+ * back out before parsing — matching the browser's *intent* while keeping the
+ * table whole. Scoped to standard HTML tag names, so custom components and
+ * incidental prose (`a </ b`) are left untouched; code blocks are protected.
+ *
+ * @example
+ * normalizeClosingTagWhitespace('Marshall Islands </ td >') // 'Marshall Islands </td>'
+ * normalizeClosingTagWhitespace('</table >')                // '</table>'
+ * normalizeClosingTagWhitespace('</td>')                    // '</td>' (already canonical)
+ * normalizeClosingTagWhitespace('a </ b > c')               // 'a </ b > c' (not a known tag)
+ */
+export function normalizeClosingTagWhitespace(content: string) {
+  const { protectedContent, protectedCode } = protectCodeBlocks(content);
+
+  const result = protectedContent.replace(SPACED_CLOSING_TAG_RE, (match, tagName: string) =>
+    STANDARD_HTML_TAGS.has(tagName.toLowerCase()) ? `</${tagName}>` : match,
+  );
+
+  return restoreCodeBlocks(result, protectedCode);
+}


### PR DESCRIPTION
| 🎫 Resolve [CX-3706](https://linear.app/readme-io/issue/CX-3706/mdxish-malformed-raw-html-tables-unclosed-ul-stray-litd) | 🤖 Prepared with `/prep-pr` |
| :-----------------: | :-------------------------: |

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

Malformed raw-HTML tables whose closing tag carries stray whitespace — `</ table >`, `</table >` — rendered broken under MDXish. `jsxTable` captures a raw `<table>` by scanning for a **literal** `</table>`, so a whitespace-mangled closer isn't recognized: the table looks unclosed, falls back to a CommonMark HTML block that fragments at blank lines, and its rows collapse into an empty `<table></table>` plus a `<pre>` code block. The same defect in cell closers (`</ td >`) additionally left a stray `<!-- td -->` comment behind.

- Add a `normalizeClosingTagWhitespace` string preprocessor that canonicalizes `</[ \t]*tag[ \t]*>` → `</tag>` for standard HTML tags before parsing, so `jsxTable` sees a literal closer and the table stays whole.
- Wire it **first** in `preprocessContent` so both `jsxTable` and `terminateHtmlFlowBlocks` (whose HTML-line classification also needs the literal closer) act on normalized input.
- Scoped to standard HTML tag names — custom components and incidental prose (`a </ b`) are untouched, and code blocks are protected. Whitespace is limited to spaces/tabs (not newlines) so a cross-line `<`/`>` in prose can't be swept into one "tag".

## 🧪 QA tips

This snippet should render correctly:

```
<table>
  <thead>
    <tr><th>Country</th><th>Src</th></tr>
  </thead>

  <tr>
    <td>Russia</td>
    <td><li>Federal Tax Service</td>          <!-- stray <li> directly in <td>, unclosed -->
  </tr>

  <tr>
    <td>Marshall Islands </ td >               <!-- closing tag with spaces: `</ td >` -->
    <td>International Registries Inc.</td>
  </tr>

  <tr>
    <td>UAE</td>
    <td>
      <ul>
        <li>Ministry of Economy</li>
        <ul>                                   <!-- unclosed nested <ul> -->
    </td>
  </tr>
</table>
```

## 📸 Screenshot or Loom


