### PR TITLE
fix(mdxish): recognize indented fenced code in component bodies

### DIFF
--- a/__tests__/lib/mdxish/components.test.ts
+++ b/__tests__/lib/mdxish/components.test.ts
@@ -5,7 +5,7 @@ import React from 'react';
 import { visit } from 'unist-util-visit';
 
 import { mdxish, compile, run } from '../../../lib';
-import { findElementByTagName } from '../../helpers';
+import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
 
 describe('end-to-end tests in the mdxish pipeline for various types and variations of MDX components', () => {
   // Create & compile example component
@@ -422,6 +422,49 @@ labore et dolore magna aliqua.`,
         children: [{ type: 'text', value: 'Link' }],
       });
       expect(trailing).toMatchObject({ type: 'text', value: ' done.' });
+    });
+  });
+
+  describe('fenced code with an unbalanced brace inside a Callout (CX-3704)', () => {
+    const md = `<Callout icon="⚠️" theme="warn">
+  **Title line**
+
+  Intro paragraph inside the callout.
+
+  \`\`\`
+  {
+  \`\`\`
+
+  Closing paragraph inside the callout.
+</Callout>
+
+* **After-marker bullet**
+
+  Indented continuation after the callout.
+
+Final plain paragraph at end of file.`;
+
+    it('closes the callout at </Callout> and renders following content outside it', () => {
+      const tree = mdxish(md);
+
+      // Exactly one Callout, and the content after </Callout> is NOT swallowed.
+      const callouts = findAllElementsByTagName(tree, 'Callout');
+      expect(callouts).toHaveLength(1);
+
+      // The after-marker bullet renders as a real list, not a literal `*`
+      // paragraph, and that list lives OUTSIDE the callout.
+      expect(findAllElementsByTagName(tree, 'ul')).toHaveLength(1);
+      expect(findAllElementsByTagName(callouts[0], 'ul')).toHaveLength(0);
+
+      // The unbalanced `{` stays inside a code block within the callout.
+      const pre = findElementByTagName(callouts[0], 'pre');
+      expect(pre).not.toBeNull();
+      expect(JSON.stringify(pre)).toContain('{');
+    });
+
+    it('does not strand a literal </Callout> in the output', () => {
+      const tree = mdxish(md);
+      expect(JSON.stringify(tree)).not.toContain('</Callout>');
     });
   });
 });

--- a/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
+++ b/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
@@ -1159,6 +1159,52 @@ describe('mdxishMdastToMd', () => {
     });
   });
 
+  describe('git round-trip of a Callout with an unbalanced brace in a fence (CX-3704)', () => {
+    // The customer's real trigger: a truncated snippet (more `{` than `}`) fenced
+    // inside a Callout. Before the fix the mis-parsed tree re-serialized as
+    // corrupted Markdown on every save: bullets escaped to `\*`, lists flattened,
+    // prose wrapped in fences, and `</Callout>` merged onto the preceding line.
+    const md = `<Callout icon="⚠️" theme="warn">
+  Update your reverse-proxy config:
+
+  \`\`\`nginx
+  location / {
+      proxy_pass http://backend;
+  \`\`\`
+
+  Then restart the service.
+</Callout>
+
+- First list item
+- Second list item
+
+Final plain paragraph at end of file.
+`;
+
+    it('serializes back without corrupting the surrounding Markdown', () => {
+      const out = roundTripMdxish(md);
+      const lines = out.split('\n');
+
+      // `</Callout>` closes on its own line (not merged onto text).
+      expect(lines).toContain('</Callout>');
+      // No bullets escaped to `\*`.
+      expect(out).not.toContain('\\*');
+      // The list survives as a list (two items), not flattened prose.
+      expect(out).toContain('- First list item');
+      expect(out).toContain('- Second list item');
+      // Trailing prose is a paragraph, not wrapped in a code fence.
+      expect(out).toContain('Final plain paragraph at end of file.');
+      // The unbalanced brace stays inside the fenced code block.
+      expect(out).toContain('location / {');
+    });
+
+    it('is idempotent — re-saving does not re-corrupt the file', () => {
+      const once = roundTripMdxish(md);
+      const twice = roundTripMdxish(once);
+      expect(twice).toBe(once);
+    });
+  });
+
   it('should convert readme-anchor nodes back to <Anchor> JSX syntax', () => {
     const mdast: MdastRoot = {
       type: 'root',

--- a/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
+++ b/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
@@ -1160,10 +1160,6 @@ describe('mdxishMdastToMd', () => {
   });
 
   describe('git round-trip of a Callout with an unbalanced brace in a fence (CX-3704)', () => {
-    // The customer's real trigger: a truncated snippet (more `{` than `}`) fenced
-    // inside a Callout. Before the fix the mis-parsed tree re-serialized as
-    // corrupted Markdown on every save: bullets escaped to `\*`, lists flattened,
-    // prose wrapped in fences, and `</Callout>` merged onto the preceding line.
     const md = `<Callout icon="⚠️" theme="warn">
   Update your reverse-proxy config:
 

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -863,6 +863,43 @@ third\`} />`;
       expect(code).toHaveLength(1);
       expect(code[0].value).toBe('</Terminal>');
     });
+
+    it('treats an INDENTED fence as fenced code so an unbalanced `{` inside stays inert (CX-3704)', () => {
+      // Regression test: inside a component body the fence is indented for
+      // readability. An unbalanced `{` in that fence must not open a
+      // brace-expression that scans past the real `</Callout>` to EOF — which
+      // would fail the whole construct and let CommonMark html-flow swallow the
+      // rest of the document.
+      const markdown = `<Callout icon="⚠️" theme="warn">
+  Intro.
+
+  \`\`\`
+  {
+  \`\`\`
+
+  Closing.
+</Callout>
+
+After the callout.`;
+      const tree = parseWithPlugin(markdown);
+
+      // The whole callout is captured as a single component node...
+      const mdxNodes = collectNodes(tree, 'mdxJsxFlowElement');
+      expect(mdxNodes).toHaveLength(1);
+      expect(mdxNodes[0]).toMatchObject({ name: 'Callout' });
+
+      // ...its fenced content (the lone `{`) survives as a code node...
+      const code = collectNodes<Code>(tree, 'code');
+      expect(code).toHaveLength(1);
+      expect(code[0].value).toBe('{');
+
+      // ...and `</Callout>` never leaks out as a stray html node.
+      const strayCloser = collectNodes(tree, n => n.type === 'html' && (n as { value?: string }).value === '</Callout>');
+      expect(strayCloser).toHaveLength(0);
+
+      // Trailing content lands as a sibling after the callout, not inside it.
+      expect(tree.children.at(-1)).toMatchObject({ type: 'paragraph' });
+    });
   });
 
   describe('unclosed `<Tag>` opener does not swallow following blocks', () => {

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -865,11 +865,6 @@ third\`} />`;
     });
 
     it('treats an INDENTED fence as fenced code so an unbalanced `{` inside stays inert (CX-3704)', () => {
-      // Regression test: inside a component body the fence is indented for
-      // readability. An unbalanced `{` in that fence must not open a
-      // brace-expression that scans past the real `</Callout>` to EOF — which
-      // would fail the whole construct and let CommonMark html-flow swallow the
-      // rest of the document.
       const markdown = `<Callout icon="⚠️" theme="warn">
   Intro.
 

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -895,6 +895,34 @@ After the callout.`;
       // Trailing content lands as a sibling after the callout, not inside it.
       expect(tree.children.at(-1)).toMatchObject({ type: 'paragraph' });
     });
+
+    it('does not split component when there is an unclosed braces inside the component, and its closer is outside the component', () => {
+      const markdown = `<Component>
+
+  \`\`\`
+  {
+  \`\`\`
+  test
+</Component>
+
+  }`;
+      const tree = parseWithPlugin(markdown);
+      expect(tree.children).toHaveLength(2);
+      expect(tree.children).toMatchObject([
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'Component',
+          children: [
+            { type: 'code', value: '  {' },
+            { type: 'paragraph', children: [{ type: 'text', value: 'test' }] },
+          ],
+        },
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', value: '}' }],
+        },
+      ]);
+    });
   });
 
   describe('unclosed `<Tag>` opener does not swallow following blocks', () => {

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -619,6 +619,17 @@ function createTokenize(mode: 'flow' | 'text') {
       }
       effects.enter('mdxComponentData');
       fenceCloseLength = 0;
+      return fencedCodeMaybeClose(code);
+    }
+
+    // Skip leading indentation before the closing-fence check: an indented fence
+    // (the norm in a component body) closes on an equally-indented line, else the
+    // closer is never matched and scanning runs to EOF (CX-3704).
+    function fencedCodeMaybeClose(code: Code): State | undefined {
+      if (markdownSpace(code)) {
+        effects.consume(code);
+        return fencedCodeMaybeClose;
+      }
 
       // Check for closing fence
       if (code === fenceChar) {
@@ -871,6 +882,13 @@ function createTokenize(mode: 'flow' | 'text') {
 
     // Dispatch a non-blank continuation line: fenced code at line start, else body.
     function bodyLineStart(code: Code): State | undefined {
+      // Skip leading indentation while staying "at line start" so an indented
+      // fence is still recognized. Otherwise the first space clears `atLineStart`
+      // and its content — including any unbalanced `{` — stays live text (CX-3704).
+      if (atLineStart && markdownSpace(code)) {
+        effects.consume(code);
+        return bodyLineStart;
+      }
       if (atLineStart && code === codes.tilde) return bodyAfterLineStart(code);
       if (atLineStart && code === codes.graveAccent) {
         codeSpanOpenSize = 0;


### PR DESCRIPTION
| 🎫 Resolve [CX-3704](https://linear.app/readme-io/issue/CX-3704/mdxish-an-unbalanced-inside-a-fenced-code-block-within-callout-breaks) | 🤖 Prepared with `/prep-pr` |
| :-----------------: | :-------------------------: |

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

The `mdxComponent` flow tokenizer (`lib/micromark/mdx-component/syntax.ts`) scans a component body character-by-character to locate the closing tag, treating fenced code as opaque so `{` braces inside it stay inert. Fence detection hinges on an `atLineStart` flag — but **leading indentation cleared `atLineStart` before the backticks were counted**, so an _indented_ fence (the norm inside a component body) was never recognized. Its content stayed "live": an unbalanced `{` inside such a fence opened a brace-expression that ran to EOF and failed the whole `<Callout>`. Micromark then fell back to CommonMark html-flow, which truncates the callout at the first blank line and strands `</Callout>` — swallowing the rest of the page, rendering bullets as literal `*`, and (on bi-directional Git sync) re-serializing corrupted Markdown on every save.

**Fix:** skip leading whitespace while keeping `atLineStart` set, for both the fence-**open** check (`bodyLineStart`) and the fence-**close** check (`fencedCodeMaybeClose`). Column-0 fences already worked (covered by the existing `<Terminal>` test).

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

This snippet should render correctly:

````
<Callout icon="⚠️" theme="warn">
  **Title line**

  Intro paragraph inside the callout.

  ```
  {
  ```

  Closing paragraph inside the callout.
</Callout>

* **After-marker bullet**

  Indented continuation after the callout.

Final plain paragraph at end of file.
````
## 📸 Screenshot or Loom


