### PR TITLE
feat(mdxish): parse markdown inside single-line HTML tags

### DIFF
--- a/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
@@ -1,0 +1,215 @@
+import { toHtml } from 'hast-util-to-html';
+
+import { mdxish } from '../../../lib';
+import { collectNodes, findAllElementsByTagName, findElementByTagName, parseMdxish } from '../../helpers';
+
+// Markdown sharing a line with its wrapping HTML tag (`<div>**bold**</div>`) is
+// swallowed into a single raw html flow node, so `terminateHtmlFlowBlocks` can't
+// split it. The mdx-blocks transformer re-parses and promotes these wrappers.
+describe('markdown inside single-line plain HTML tags', () => {
+  it('parses emphasis inside a single-line <div>', () => {
+    const ast = mdxish('<div>**bold**</div>');
+    const html = toHtml(ast);
+
+    expect(findElementByTagName(ast, 'div')).toMatchObject({
+      tagName: 'div',
+      children: [{ tagName: 'strong', children: [{ type: 'text', value: 'bold' }] }],
+    });
+    expect(html).not.toContain('**');
+  });
+
+  it('preserves plain HTML attributes on the promoted wrapper', () => {
+    const ast = mdxish('<div class="card-title">**a**</div>');
+    const html = toHtml(ast);
+
+    expect(findElementByTagName(ast, 'strong')).not.toBeNull();
+    expect(html).toContain('class="card-title"');
+  });
+
+  it('parses markdown around a nested inline tag', () => {
+    const ast = mdxish('<div>**a** <span>_b_</span></div>');
+
+    expect(findElementByTagName(ast, 'strong')).toMatchObject({
+      children: [{ type: 'text', value: 'a' }],
+    });
+    const span = findElementByTagName(ast, 'span');
+    expect(span).not.toBeNull();
+    expect(findElementByTagName(span!, 'em')).toMatchObject({
+      children: [{ type: 'text', value: 'b' }],
+    });
+  });
+
+  it('parses markdown in single-line headings and list items', () => {
+    const ast = mdxish('<h3>_Card Title_</h3>');
+    const heading = findElementByTagName(ast, 'h3');
+
+    expect(heading).not.toBeNull();
+    expect(findElementByTagName(heading!, 'em')).toMatchObject({
+      children: [{ type: 'text', value: 'Card Title' }],
+    });
+  });
+
+  it('parses each sibling wrapper independently', () => {
+    const ast = mdxish('<div>**a**</div><div>**b**</div>');
+
+    const strongs = findAllElementsByTagName(ast, 'strong');
+    expect(strongs).toHaveLength(2);
+    expect(findAllElementsByTagName(ast, 'div')).toHaveLength(2);
+  });
+
+  it('parses markdown when the closing tag sits on a later glued line', () => {
+    const ast = mdxish('<div>**bold**\nmore</div>');
+
+    expect(findElementByTagName(ast, 'strong')).toMatchObject({
+      children: [{ type: 'text', value: 'bold' }],
+    });
+    expect(toHtml(ast)).toContain('more');
+  });
+
+  it('parses markdown inside a single-line tag nested in a component body', () => {
+    const md = `<Card>
+  <p class="card-title">**Fast** setup</p>
+</Card>`;
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'strong')).toMatchObject({
+      children: [{ type: 'text', value: 'Fast' }],
+    });
+  });
+
+  describe('non-promotion (unchanged behavior)', () => {
+    it('keeps plain HTML without markdown as raw html', () => {
+      const md = '<div>hello <span>x</span></div>';
+
+      expect(toHtml(mdxish(md))).toBe(toHtml(mdxish(`${md}\n`)));
+      expect(findElementByTagName(mdxish(md), 'div')).toMatchObject({
+        children: [
+          { type: 'text', value: 'hello ' },
+          { tagName: 'span', children: [{ type: 'text', value: 'x' }] },
+        ],
+      });
+    });
+
+    it('keeps raw-content tag bodies literal', () => {
+      const preHtml = toHtml(mdxish('<pre>**x**</pre>'));
+      expect(preHtml).toContain('**x**');
+
+      const scriptHtml = toHtml(mdxish('<script>var a = 1;</script>'));
+      expect(scriptHtml).toContain('var a = 1;');
+    });
+
+    it('keeps single-line tables owned by the table transformer', () => {
+      const ast = mdxish('<table><tr><td>**x**</td></tr></table>');
+
+      expect(findElementByTagName(ast, 'table')).not.toBeNull();
+      expect(findElementByTagName(ast, 'strong')).toMatchObject({
+        children: [{ type: 'text', value: 'x' }],
+      });
+    });
+
+    it('does not promote a wrapper holding a nested table', () => {
+      const ast = mdxish('<div><table><tr><td>**x**</td></tr></table></div>');
+
+      expect(findElementByTagName(ast, 'table')).not.toBeNull();
+      expect(findElementByTagName(ast, 'strong')).not.toBeNull();
+    });
+
+    it('keeps HTMLBlock content literal', () => {
+      const md = '<HTMLBlock>{`<div>**bold**</div>`}</HTMLBlock>';
+      const html = toHtml(mdxish(md));
+
+      expect(html).toContain('**bold**');
+      expect(html).not.toContain('<strong>');
+    });
+
+    it('leaves an unclosed tag literal', () => {
+      const html = toHtml(mdxish('<div>**bold**'));
+
+      expect(html).toContain('**bold**');
+    });
+
+    it('leaves a stray unbalanced brace literal instead of throwing', () => {
+      expect(() => mdxish('<div>**a** {foo </div>')).not.toThrow();
+      expect(toHtml(mdxish('<div>{foo </div>'))).toContain('{foo');
+    });
+  });
+
+  describe('safe mode', () => {
+    it('parses emphasis while keeping braces literal', () => {
+      const ast = mdxish('<div>**a** {1+1}</div>', { safeMode: true });
+      const html = toHtml(ast);
+
+      expect(findElementByTagName(ast, 'strong')).toMatchObject({
+        children: [{ type: 'text', value: 'a' }],
+      });
+      expect(html).toContain('{1+1}');
+    });
+  });
+
+  describe('formatting variants', () => {
+    it('parses with 1-3 leading spaces before the tag', () => {
+      const ast = mdxish('   <div>**bold**</div>');
+
+      expect(findElementByTagName(ast, 'pre')).toBeNull();
+      expect(findElementByTagName(ast, 'strong')).not.toBeNull();
+    });
+
+    it('parses with trailing whitespace after the closing tag', () => {
+      const ast = mdxish('<div>**bold**</div>   ');
+
+      expect(findElementByTagName(ast, 'strong')).not.toBeNull();
+    });
+  });
+
+  describe('inside ReadMe components', () => {
+    it('parses markdown in a single-line <div> inside a callout', () => {
+      const md = `<Callout icon="📘" theme="info">
+<div>**bold** in callout</div>
+</Callout>`;
+      const ast = mdxish(md);
+
+      const callout = findElementByTagName(ast, 'div');
+      expect(callout).not.toBeNull();
+      expect(findElementByTagName(ast, 'strong')).toMatchObject({
+        children: [{ type: 'text', value: 'bold' }],
+      });
+    });
+
+    it('parses markdown in a single-line <p> title inside a Card', () => {
+      const md = `<Cards>
+<Card title="Title">
+<p class="card-title">**Fast** setup</p>
+</Card>
+</Cards>`;
+      const ast = mdxish(md);
+
+      expect(findElementByTagName(ast, 'strong')).toMatchObject({
+        children: [{ type: 'text', value: 'Fast' }],
+      });
+      expect(toHtml(ast)).toContain('class="card-title"');
+    });
+
+    it('parses markdown in a single-line <div> inside a Column', () => {
+      const md = `<Columns>
+<Column>
+<div>**bold** in col</div>
+</Column>
+</Columns>`;
+      const ast = mdxish(md);
+
+      expect(findElementByTagName(ast, 'strong')).toMatchObject({
+        children: [{ type: 'text', value: 'bold' }],
+      });
+    });
+
+    it('parses markdown in a single-line wrapper inside a custom component', () => {
+      // Custom components without a definition are dropped from the rendered
+      // hast, so assert on the promoted mdast instead.
+      const tree = parseMdxish('<CustomThing><div>**bold**</div></CustomThing>');
+
+      expect(collectNodes(tree, 'strong')).toMatchObject([
+        { children: [{ type: 'text', value: 'bold' }] },
+      ]);
+    });
+  });
+});

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -507,6 +507,26 @@ More content here
 
         expect(tree.children).toMatchObject([{ type: 'html', value: '<br />' }]);
       });
+
+      it('should ignore a closing-tag-shaped nested attribute when finding the real close', () => {
+        // The `</div>` inside `title="…"` must not be mistaken for the wrapper's
+        // close, or the div would slice short and the `<span>` would be orphaned.
+        const tree = parseWithPlugin('<div>**a** <span title="</div>">b</span></div>');
+
+        expect(tree.children).toMatchObject([
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'div',
+            children: [
+              { type: 'strong', children: [{ type: 'text', value: 'a' }] },
+              { type: 'text', value: ' ' },
+              { type: 'html', value: '<span title="</div>">' },
+              { type: 'text', value: 'b' },
+              { type: 'html', value: '</span>' },
+            ],
+          },
+        ]);
+      });
     });
 
     describe('case 3: embedded closing tag with trailing content', () => {

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -450,6 +450,65 @@ More content here
       });
     });
 
+    describe('plain lowercase HTML with markdown content', () => {
+      it('should promote a single-line wrapper whose body holds markdown', () => {
+        const tree = parseWithPlugin('<div>**bold**</div>');
+
+        expect(tree.children).toMatchObject([
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'div',
+            attributes: [],
+            children: [{ type: 'strong', children: [{ type: 'text', value: 'bold' }] }],
+          },
+        ]);
+      });
+
+      it('should promote sibling same-tag wrappers independently', () => {
+        const tree = parseWithPlugin('<div>**a**</div><div>**b**</div>');
+
+        expect(tree.children).toMatchObject([
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'div',
+            children: [{ type: 'strong', children: [{ type: 'text', value: 'a' }] }],
+          },
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'div',
+            children: [{ type: 'strong', children: [{ type: 'text', value: 'b' }] }],
+          },
+        ]);
+      });
+
+      it('should not promote a wrapper without markdown content', () => {
+        const tree = parseWithPlugin('<div>plain <span>x</span></div>');
+
+        expect(tree.children).toMatchObject([{ type: 'html', value: '<div>plain <span>x</span></div>' }]);
+      });
+
+      it('should not promote table-structural or raw-content tags', () => {
+        const inputs = ['<td>**x**</td>', '<pre>**x**</pre>', '<table><tr><td>**x**</td></tr></table>'];
+        inputs.forEach(input => {
+          const tree = parseWithPlugin(input);
+          expect(tree.children).toMatchObject([{ type: 'html', value: input }]);
+        });
+      });
+
+      it('should not promote a wrapper holding a nested table', () => {
+        const input = '<div><table><tr><td>**x**</td></tr></table></div>';
+        const tree = parseWithPlugin(input);
+
+        expect(tree.children).toMatchObject([{ type: 'html', value: input }]);
+      });
+
+      it('should not promote a self-closing plain tag', () => {
+        const tree = parseWithPlugin('<br />');
+
+        expect(tree.children).toMatchObject([{ type: 'html', value: '<br />' }]);
+      });
+    });
+
     describe('case 3: embedded closing tag with trailing content', () => {
       it('should preserve content after the closing tag in an HTML sibling', () => {
         const markdown = `<Outer>

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -8,7 +8,15 @@ import { pointAfter } from '../../../utils';
 import { tableTags } from '../tables/utils';
 import { terminateHtmlFlowBlocks } from '../terminate-html-flow-blocks';
 
-import { getInlineMdProcessor, hasExpressionAttr, isPascalCase } from './utils';
+import {
+  containsMarkdownConstruct,
+  findBalancedClosingTagIndex,
+  getInlineMdProcessor,
+  hasExpressionAttr,
+  isMarkdownPromotableHtmlTag,
+  isPascalCase,
+  NESTED_TABLE_RE,
+} from './utils';
 
 export { parseAttributes, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
 
@@ -120,6 +128,10 @@ const substituteNodeWithMdxNode = (parent: Parent, index: number, mdxNode: MdxJs
  * This transformer identifies these patterns and converts them to proper MDX JSX elements so they
  * can be accurately recognized and rendered later with their component definition code.
  *
+ * Note: The main goal is to promote PascalCase tags to MDX elements, but we want to promote
+ * normal HTML to MDX elements in some cases so they get the full custom parsing behavior.
+ * E.g. tags with JSX expressions, nested components, etc.
+ *
  * The mdx-component micromark tokenizer ensures that multi-line components are captured
  * as single HTML nodes, so this transformer only needs to handle two cases:
  *
@@ -170,6 +182,8 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
 
     const isPascal = isPascalCase(tag);
 
+    // ==== SPECIAL CASES TO PROMOTE NORMAL HTML TO MDX ELEMENTS ====
+
     // Lowercase inline tags with `{…}` attributes belong to
     // mdxishInlineComponentBlocks; leave them as html for that pass. PascalCase
     // components stay flow-level even when inline (ReadMe's component model).
@@ -183,7 +197,16 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
     const isTableStructuralTag = tag === 'table' || tableTags.has(tag);
     const hasNestedComponentTag =
       !selfClosing && !isTableStructuralTag && hasNestedGenericComponentTag(contentAfterTag);
-    if (!isPascal && !hasExpressionAttr(attributes) && !hasNestedExpressionAttr && !hasNestedComponentTag) return;
+
+    // Promotion: By default commonmark doesn't parse markdown in single line HTML tags (e.g. <div>**bold**</div>)
+    // To support that, we try to promote them to MDX elements so the markdown gets parsed
+    const isPlainLowercaseHtml =
+      !isPascal && !hasExpressionAttr(attributes) && !hasNestedExpressionAttr && !hasNestedComponentTag;
+    const plainClosingTagIndex =
+      isPlainLowercaseHtml && !selfClosing && isMarkdownPromotableHtmlTag(tag) && !NESTED_TABLE_RE.test(contentAfterTag)
+        ? findBalancedClosingTagIndex(contentAfterTag, tag)
+        : -1;
+    if (isPlainLowercaseHtml && plainClosingTagIndex < 0) return;
 
     const closingTagStr = `</${tag}>`;
 
@@ -207,14 +230,23 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
     }
 
     // Case 2: Self-contained block (closing tag in content)
-    if (contentAfterTag.includes(closingTagStr)) {
-      const closingTagIndex = contentAfterTag.lastIndexOf(closingTagStr);
+    const closingTagIndex = isPlainLowercaseHtml ? plainClosingTagIndex : contentAfterTag.lastIndexOf(closingTagStr);
+    if (closingTagIndex >= 0) {
       // Untrimmed so parseMdChildren can dedent before trimming.
       const componentInnerContent = contentAfterTag.substring(0, closingTagIndex);
       const contentAfterClose = contentAfterTag.substring(closingTagIndex + closingTagStr.length).trim();
-      let parsedChildren: MdxJsxFlowElement['children'] = componentInnerContent.trim()
-        ? (parseMdChildren(componentInnerContent, safeMode) as MdxJsxFlowElement['children'])
-        : [];
+      let parsedChildren: MdxJsxFlowElement['children'] = [];
+      if (componentInnerContent.trim()) {
+        try {
+          parsedChildren = parseMdChildren(componentInnerContent, safeMode) as MdxJsxFlowElement['children'];
+        } catch (error) {
+          // Plain HTML bodies can hold anything (e.g. stray braces the strict
+          // expression parser rejects) — keep the node raw instead of throwing.
+          if (isPlainLowercaseHtml) return;
+          throw error;
+        }
+      }
+      if (isPlainLowercaseHtml && !containsMarkdownConstruct(parsedChildren)) return;
       // Lowercase tags are usually inline; unwrap a sole paragraph so their
       // phrasing content isn't spuriously block-wrapped.
       if (!isPascal && parsedChildren.length === 1 && parsedChildren[0].type === 'paragraph') {

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -18,6 +18,7 @@ import { gemoji } from '../../../../lib/micromark/gemoji';
 import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
 import { magicBlock } from '../../../../lib/micromark/magic-block';
 import { mdxComponent } from '../../../../lib/micromark/mdx-component';
+import { walkTags } from '../tables/tag-walker';
 import { tableTags } from '../tables/utils';
 
 export type MdxAttributes = (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
@@ -101,12 +102,11 @@ export const toMdxJsxTextElement = (
 });
 
 // Raw-body tags (pre/script/style/textarea) must stay byte-exact; table
-// structure is owned by `mdxishTables` and figures by `mdxishJsxToMdast`,
-// both of which run later on raw html nodes.
-const NON_PROMOTABLE_PLAIN_TAGS = new Set<string>([...htmlRawNames, 'table', 'figure', 'figcaption']);
+// structure (`table` + `tableTags`) is owned by `mdxishTables` and figures by
+// `mdxishJsxToMdast`, both of which run later on raw html nodes.
+const NON_PROMOTABLE_PLAIN_TAGS = new Set<string>([...htmlRawNames, ...tableTags, 'table', 'figure', 'figcaption']);
 export const NESTED_TABLE_RE = /<table[\s>]/i;
-export const isMarkdownPromotableHtmlTag = (tag: string): boolean =>
-  !tableTags.has(tag) && !NON_PROMOTABLE_PLAIN_TAGS.has(tag);
+export const isMarkdownPromotableHtmlTag = (tag: string): boolean => !NON_PROMOTABLE_PLAIN_TAGS.has(tag);
 
 // Expression nodes count as plain so `<div>{1+1}</div>` keeps its current
 // literal-brace behavior; variables/glossary already resolve inside raw html.
@@ -129,15 +129,36 @@ export const containsMarkdownConstruct = (nodes: Node[]): boolean =>
       ('children' in node && Array.isArray(node.children) && containsMarkdownConstruct(node.children)),
   );
 
-// Depth-matching closing-tag finder: `lastIndexOf` mis-slices sibling
-// same-tag pairs like `<div>**a**</div><div>**b**</div>`.
+/**
+ * Index of the `</tag>` that balances the already-consumed opening tag (the
+ * caller starts us one level deep). `lastIndexOf` mis-slices sibling same-tag
+ * pairs like `<div>**a**</div><div>**b**</div>`, so we depth-match instead —
+ * delegating to `walkTags` (htmlparser2) so quoted attributes (`title="</div>"`),
+ * code spans, and legacy `<<VARIABLE>>` are handled for free. Returns -1 when
+ * the wrapper is left open.
+ */
 export function findBalancedClosingTagIndex(content: string, tag: string): number {
-  const tagTokenRe = new RegExp(`<${tag}(?=[\\s/>])[^>]*>|</${tag}>`, 'gi');
-  let depth = 1;
-  const closingMatch = [...content.matchAll(tagTokenRe)].find(match => {
-    if (match[0].startsWith('</')) depth -= 1;
-    else if (!match[0].endsWith('/>')) depth += 1;
-    return depth === 0;
+  const target = tag.toLowerCase();
+  const canonicalCloserLength = tag.length + 3; // `</tag>`
+  // The caller already stripped the opening tag, so re-attach one: htmlparser2
+  // drops an unmatched closer, and we want it balanced. Offsets shift by the
+  // prefix length.
+  const prefix = `<${tag}>`;
+  let depth = 0;
+  let closeIndex = -1;
+  walkTags(prefix + content, {
+    onOpen: ({ name, isSelfClosing, isStrayCloser }) => {
+      if (closeIndex >= 0 || isSelfClosing || isStrayCloser) return;
+      if (name.toLowerCase() === target) depth += 1;
+    },
+    onClose: ({ name, start, end, implicit }) => {
+      if (closeIndex >= 0 || implicit || name.toLowerCase() !== target) return;
+      // Only canonical `</tag>` closers — the caller slices by that length, so a
+      // whitespaced `</tag >` would misalign; leaving it unmatched keeps it raw.
+      if (end - start !== canonicalCloserLength) return;
+      depth -= 1;
+      if (depth === 0) closeIndex = start - prefix.length;
+    },
   });
-  return closingMatch?.index ?? -1;
+  return closeIndex;
 }

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -1,12 +1,14 @@
-import type { Html, PhrasingContent } from 'mdast';
+import type { Html, Node, PhrasingContent } from 'mdast';
 import type { MdxJsxAttribute, MdxJsxExpressionAttribute, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 
 import { mdxExpressionFromMarkdown } from 'mdast-util-mdx-expression';
 import { mdxExpression } from 'micromark-extension-mdx-expression';
+import { htmlRawNames } from 'micromark-util-html-tag-name';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 
+import { NodeTypes } from '../../../../enums';
 import { emptyTaskListItemFromMarkdown } from '../../../../lib/mdast-util/empty-task-list-item';
 import { gemojiFromMarkdown } from '../../../../lib/mdast-util/gemoji';
 import { legacyVariableFromMarkdown } from '../../../../lib/mdast-util/legacy-variable';
@@ -16,6 +18,7 @@ import { gemoji } from '../../../../lib/micromark/gemoji';
 import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
 import { magicBlock } from '../../../../lib/micromark/magic-block';
 import { mdxComponent } from '../../../../lib/micromark/mdx-component';
+import { tableTags } from '../tables/utils';
 
 export type MdxAttributes = (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
 
@@ -96,3 +99,45 @@ export const toMdxJsxTextElement = (
   children,
   ...(position ? { position } : {}),
 });
+
+// Raw-body tags (pre/script/style/textarea) must stay byte-exact; table
+// structure is owned by `mdxishTables` and figures by `mdxishJsxToMdast`,
+// both of which run later on raw html nodes.
+const NON_PROMOTABLE_PLAIN_TAGS = new Set<string>([...htmlRawNames, 'table', 'figure', 'figcaption']);
+export const NESTED_TABLE_RE = /<table[\s>]/i;
+export const isMarkdownPromotableHtmlTag = (tag: string): boolean =>
+  !tableTags.has(tag) && !NON_PROMOTABLE_PLAIN_TAGS.has(tag);
+
+// Expression nodes count as plain so `<div>{1+1}</div>` keeps its current
+// literal-brace behavior; variables/glossary already resolve inside raw html.
+const PLAIN_CONTENT_TYPES = new Set<string>([
+  'paragraph',
+  'text',
+  'html',
+  'mdxTextExpression',
+  'mdxFlowExpression',
+  NodeTypes.variable,
+  NodeTypes.glossary,
+]);
+
+// Promoting plain HTML is only worth bypassing rehype-raw's parse5 pass when
+// the body parses into an actual markdown construct.
+export const containsMarkdownConstruct = (nodes: Node[]): boolean =>
+  nodes.some(
+    node =>
+      !PLAIN_CONTENT_TYPES.has(node.type) ||
+      ('children' in node && Array.isArray(node.children) && containsMarkdownConstruct(node.children)),
+  );
+
+// Depth-matching closing-tag finder: `lastIndexOf` mis-slices sibling
+// same-tag pairs like `<div>**a**</div><div>**b**</div>`.
+export function findBalancedClosingTagIndex(content: string, tag: string): number {
+  const tagTokenRe = new RegExp(`<${tag}(?=[\\s/>])[^>]*>|</${tag}>`, 'gi');
+  let depth = 1;
+  const closingMatch = [...content.matchAll(tagTokenRe)].find(match => {
+    if (match[0].startsWith('</')) depth -= 1;
+    else if (!match[0].endsWith('/>')) depth += 1;
+    return depth === 0;
+  });
+  return closingMatch?.index ?? -1;
+}


### PR DESCRIPTION
| 🎫 Resolve [RM-17442](https://linear.app/readme-io/issue/RM-17442) |
| :-----------------: |

## 🎯 What does this PR do?

MDXish has never parsed markdown inside a simple HTML tag when the content shared a line with the opening tag, since it follows the default HTML rendering behaviour. The multi-line form (`<div>\n**bold**\n</div>`) already worked (`terminateHtmlFlowBlocks` splits it and is our workaround), but single-line tags get swallowed into one raw `html` node.

Change: I think the simplest & quickest fix is to make `mdxishMdxComponentBlocks` now promote a plain lowercase wrapper to an MDX element (re-parsing its body with the lenient inline processor), **when the body actually contains markdown**. This piggybacks the MDX parsing flow which already parses its content, and kind of follows what MDX already does (it converts all HTML to MDX elements). Plain HTML with no markdown stays a raw node, unchanged.

> [!NOTE]
> Currently the promotion checks most standard HTML tags, so there will be rendering differences for **customers from legacy**. We can maybe limit the tags we promote to mitigate that, but it's inevitable to have differences if we decide this be an issue.

```md
<!-- before: literal · after: bold -->
<div>**bold**</div>

<!-- headings, links, emphasis all parse -->
<h3>_Card Title_</h3>

<!-- works nested inside ReadMe components -->
<Callout icon="📘" theme="info">
<div>**bold** in callout</div>
</Callout>
```

## 🧪 QA tips

- [ ] Single-file source change in `mdx-blocks.ts` (+ shared helpers in `utils.ts`); no new transformer.
- [ ] Excluded from promotion so ownership is unchanged: tables/table tags, `figure`/`figcaption`, raw tags (`pre`/`script`/`style`), nested-table wrappers, unclosed tags, and `HTMLBlock`.
- [ ] Note: content beyond emphasis (links, headings, gemoji) now parses inside single-line tags too — that's intended.
- [ ] Full suite green; new coverage in `markdown-inside-single-line-html.test.ts` and `mdx-component-blocks.test.ts`.

## 📸 Screenshot or Loom

**Before:**

<img width="1219" height="666" alt="Screenshot 2026-07-15 at 8 11 20 pm" src="https://github.com/user-attachments/assets/646db6bd-fa2c-4c9a-99ea-e7ed325b8a72" />

**After:**

<img width="1226" height="652" alt="Screenshot 2026-07-15 at 8 11 51 pm" src="https://github.com/user-attachments/assets/910d10c0-0ad7-4db4-ac55-aa463e162aec" />

