### PR TITLE
fix: ignore standalone carriage returns as hard breaks

### DIFF
--- a/__tests__/lib/compile.test.ts
+++ b/__tests__/lib/compile.test.ts
@@ -23,6 +23,18 @@ describe('compile', () => {
       const tree = compile(md, { hardBreaks: true });
       expect(tree).toMatch(/br/);
     });
+
+    it('converts CRLF line endings to hard breaks when enabled', () => {
+      const md = 'hello\r\nthere';
+      const tree = compile(md, { hardBreaks: true });
+      expect(tree).toMatch(/br/);
+    });
+
+    it('does not convert standalone carriage returns to hard breaks', () => {
+      const md = 'hello\rthere';
+      const tree = compile(md, { hardBreaks: true });
+      expect(tree).not.toMatch(/br/);
+    });
   });
 
   describe("{ format: 'md' }", () => {

--- a/__tests__/lib/mdxish/mdxish.test.ts
+++ b/__tests__/lib/mdxish/mdxish.test.ts
@@ -3,7 +3,7 @@ import type { Element, Root, Text } from 'hast';
 
 import { mdxish, mdxishAstProcessor } from '../../../lib/mdxish';
 import { extractText } from '../../../processor/transform/extract-text';
-import { findElementByTagName } from '../../helpers';
+import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
 
 describe('mdxish should render', () => {
   describe('invalid mdx syntax', () => {
@@ -396,6 +396,24 @@ Line 2`;
       expect((paragraph.children[0] as Text).value).toBe('Line 1');
       expect((paragraph.children[1] as Element).tagName).toBe('br');
       expect((paragraph.children[2] as Text).value).toBe('\nLine 2');
+    });
+
+    it('converts CRLF line endings into <br> elements', () => {
+      const tree = mdxish('Line 1\r\nLine 2');
+
+      expect(findAllElementsByTagName(tree, 'br')).toHaveLength(1);
+    });
+
+    it('does not convert standalone carriage returns into <br> elements', () => {
+      const tree = mdxish('Line 1\rLine 2');
+
+      expect(findAllElementsByTagName(tree, 'br')).toHaveLength(0);
+    });
+
+    it('does not double explicit breaks separated by standalone carriage returns', () => {
+      const tree = mdxish('Line 1\r<br />\r<br />Line 2');
+
+      expect(findAllElementsByTagName(tree, 'br')).toHaveLength(2);
     });
 
     it('handles multiple soft line breaks and retains lone \\n nodes', () => {

--- a/lib/compile.ts
+++ b/lib/compile.ts
@@ -5,11 +5,11 @@ import { compileSync as mdxCompileSync } from '@mdx-js/mdx';
 import deepmerge from 'deepmerge';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
-import remarkBreaks from 'remark-breaks';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 
 import MdxSyntaxError from '../errors/mdx-syntax-error';
+import hardBreaksPlugin from '../processor/plugin/hard-breaks';
 import { rehypeToc } from '../processor/plugin/toc';
 import {
   defaultTransforms,
@@ -47,7 +47,7 @@ const compile = (
   const remarkPlugins: PluggableList = [
     remarkFrontmatter,
     remarkGfm,
-    ...(hardBreaks ? [remarkBreaks] : []),
+    ...(hardBreaks ? [hardBreaksPlugin] : []),
     ...Object.values(transforms),
     [codeTabsTransformer, { copyButtons }],
     [

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -9,7 +9,6 @@ import { mdxJsxToMarkdown } from 'mdast-util-mdx-jsx';
 import { mdxjsEsmFromMarkdown } from 'mdast-util-mdxjs-esm';
 import { mdxjsEsm } from 'micromark-extension-mdxjs-esm';
 import rehypeRaw from 'rehype-raw';
-import remarkBreaks from 'remark-breaks';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
@@ -20,6 +19,7 @@ import { VFile } from 'vfile';
 
 import { mdxishCompilers } from '../processor/compile';
 import { rehypeFlattenTableCellParagraphs } from '../processor/plugin/flatten-table-cell-paragraphs';
+import hardBreaks from '../processor/plugin/hard-breaks';
 import { rehypeMdxishComponents } from '../processor/plugin/mdxish-components';
 import { mdxComponentHandlers } from '../processor/plugin/mdxish-handlers';
 import calloutTransformer from '../processor/transform/callouts';
@@ -276,7 +276,7 @@ export function mdxish(mdContent: string, opts: MdxishOpts = {}): Root {
 
   processor
     .use(safeMode ? undefined : evaluateExports) // Evaluate `export const/function` and stash scope on file.data.mdxishScope
-    .use(remarkBreaks) // Must precede evaluateExpressions to avoid splitting the \n in an evaluated template literal into a <br> node
+    .use(hardBreaks) // Must precede evaluateExpressions to avoid splitting the \n in an evaluated template literal into a <br> node
     .use(safeMode ? undefined : evaluateExpressions) // Evaluate self-contained MDX expressions (e.g. `{1+1}`)
     .use(safeMode ? undefined : evaluateStyleBlockExpressions) // Evaluate `<style>{`...`}</style>` template literals into plain CSS
     .use(variablesCodeResolver, { variables }) // Resolve <<...>> and {user.*} inside code and inline code nodes

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
         "rehype-slug": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "remark": "^15.0.1",
-        "remark-breaks": "^4.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.0",
         "remark-mdx": "^3.0.0",
@@ -23011,20 +23010,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/mdast-util-newline-to-break": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
-      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-find-and-replace": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -28861,21 +28846,6 @@
         "@types/mdast": "^4.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
-        "unified": "^11.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/remark-breaks": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
-      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/mdast": "^4.0.0",
-        "mdast-util-newline-to-break": "^2.0.0",
         "unified": "^11.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark": "^15.0.1",
-    "remark-breaks": "^4.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.0",
     "remark-mdx": "^3.0.0",

--- a/processor/plugin/hard-breaks.ts
+++ b/processor/plugin/hard-breaks.ts
@@ -1,0 +1,19 @@
+import type { Root } from 'mdast';
+import type { Plugin } from 'unified';
+
+import { findAndReplace } from 'mdast-util-find-and-replace';
+
+/**
+ * Converts LF and CRLF line endings into hard breaks while leaving standalone
+ * carriage returns as soft whitespace.
+ *
+ * Unlike `remark-breaks`, this does not promote a lone `\r` into a `<br>`.
+ * Standalone carriage returns can be left behind by generators that replace
+ * the LF in Windows line endings with an explicit `<br>`, producing input such
+ * as `\r<br>`. Treating both characters as hard breaks doubles the spacing.
+ */
+const hardBreaks: Plugin<[], Root> = () => tree => {
+  findAndReplace(tree, [/\r?\n/g, () => ({ type: 'break' })]);
+};
+
+export default hardBreaks;

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -30,7 +30,6 @@ import { gfmStrikethrough } from 'micromark-extension-gfm-strikethrough';
 import { htmlBlockNames } from 'micromark-util-html-tag-name';
 import rehypeParse from 'rehype-parse';
 import rehypeStringify from 'rehype-stringify';
-import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
 import remarkRehype from 'remark-rehype';
@@ -45,6 +44,7 @@ import { gemoji } from '../../../../lib/micromark/gemoji';
 import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
 import { looseHtmlEntity, looseHtmlEntityFromMarkdown } from '../../../../lib/micromark/loose-html-entities';
 import { STANDARD_HTML_TAGS } from '../../../../utils/common-html-words';
+import hardBreaks from '../../../plugin/hard-breaks';
 import { toAttributes } from '../../../utils';
 import normalizeEmphasisAST from '../normalize-malformed-md-syntax';
 
@@ -108,7 +108,7 @@ const textToBlock = (text: string): MdastNode[] => [{ children: textToInline(tex
 /**
  * Converts leading newlines in magic block content to `<br>` tags.
  * Leading newlines are stripped by remark-parse before they become soft break nodes,
- * so remark-breaks cannot handle them. We convert them to HTML `<br>` tags instead.
+ * so the hard-breaks plugin cannot handle them. We convert them to HTML `<br>` tags instead.
  */
 const ensureLeadingBreaks = (text: string): string => text.replace(/^\n+/, match => '<br>'.repeat(match.length));
 
@@ -122,7 +122,7 @@ const contentParser = unified()
   .data('micromarkExtensions', [gemoji(), legacyVariable(), looseHtmlEntity()])
   .data('fromMarkdownExtensions', [gemojiFromMarkdown(), legacyVariableFromMarkdown(), emptyTaskListItemFromMarkdown(), looseHtmlEntityFromMarkdown()])
   .use(remarkParse)
-  .use(remarkBreaks)
+  .use(hardBreaks)
   .use(remarkGfm)
   .use(normalizeEmphasisAST);
 


### PR DESCRIPTION
| 🎫 Resolve CX-3703 |
| :-----------------: |

## 🎯 What does this PR do?

- Stops standalone carriage returns (`\r`) from becoming hard breaks. This prevents `\r<br />` in OAS descriptions from rendering duplicate spacing.
- Keeps normal LF and Windows CRLF hard-break behavior unchanged across MDX, MDXish, and magic blocks.

## 🧪 QA tips

- [ ] Confirm `\n` and `\r\n` still render as hard breaks.
- [ ] Confirm standalone `\r` does not add a hard break.
- [ ] Confirm `\r<br />\r<br />` renders two breaks rather than four.

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->

<img width="538" height="496" alt="image" src="https://github.com/user-attachments/assets/e7b1744d-c0d4-41ca-94ec-ebe2f6f34346" />

<img width="734" height="173" alt="image" src="https://github.com/user-attachments/assets/0d611963-c2d7-4ca0-8f8d-427ea8ff519c" />
