### PR TITLE
fix(mdxish): keep tab-indented HTML from fragmenting into code blocks

### DIFF
--- a/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
@@ -125,9 +125,55 @@ describe('markdown inside indented plain HTML blocks', () => {
   </Card>
 </Cards>`;
 
-    const ast = mdxish(md);    
+    const ast = mdxish(md);
     const html = toHtml(ast);
     expect(html).toContain('Account balances, position changes, and transaction activity updated instantly');
     expect(findElementByTagName(ast, 'code')).toBeNull();
+  });
+
+  // A tab counts as 1 char but 4 CommonMark columns, so tab-indented bodies used to
+  // slip past the dedent's column gate and fragment into indented-code blocks.
+  it('does not wrap tab-indented nested HTML siblings in code blocks', () => {
+    const md = [
+      '<div class="top-image-text-section">',
+      '\t<div class="top-text-container">',
+      '\t\t<div style="font-size: 18px;"><h2>Try Akamai products for free</h2></div>',
+      '\t\t<p style="font-size: 16px;"><a class="dev-center-link" href="https://example.com/trials">Create an account</a> and explore for free.</p>',
+      '\t</div>',
+      '\t<div class="top-image-container">',
+      '\t\t<div>',
+      '\t\t\t<img src="https://example.com/img.jpg">',
+      '\t\t</div>',
+      '\t</div>',
+      '</div>',
+    ].join('\n');
+
+    const ast = mdxish(md);
+    const html = toHtml(ast);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'code')).toBeNull();
+
+    // Both sibling wrappers survive rather than one collapsing into a code block.
+    expect(findAllElementsByTagName(ast, 'div').filter(el =>
+      Array.isArray(el.properties.className)
+        ? el.properties.className.includes('top-image-container')
+        : el.properties.className === 'top-image-container',
+    )).toHaveLength(1);
+
+    expect(html).toContain('Try Akamai products for free</h2>');
+    expect(findElementByTagName(ast, 'a')).toMatchObject({ properties: { href: 'https://example.com/trials' } });
+    expect(findElementByTagName(ast, 'img')).toMatchObject({ properties: { src: 'https://example.com/img.jpg' } });
+  });
+
+  it('dedents a tab-indented <div> body so single-tab-deep markdown still parses', () => {
+    const md = ['<div className="simple-list">', '\t<h2>Learn By Example</h2>', '\t<p>Use the <a href="https://example.com">API Simulator</a>.</p>', '</div>'].join('\n');
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'code')).toBeNull();
+    expect(findElementByTagName(ast, 'h2')).not.toBeNull();
+    expect(findElementByTagName(ast, 'a')).toMatchObject({ properties: { href: 'https://example.com' } });
   });
 });

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -123,7 +123,7 @@ function preprocessContent(
 
   // Runs first so `jsxTable` sees a literal `</table>` (and the HTML-line
   // classification in `terminateHtmlFlowBlocks` is accurate)
-  let result = normalizeClosingTagWhitespace(content); 
+  let result = normalizeClosingTagWhitespace(content);
   result = normalizeTableSeparator(result);
   result = terminateHtmlFlowBlocks(result);
   result = closeSelfClosingHtmlTags(result);

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -5,6 +5,7 @@ import type { Plugin } from 'unified';
 import { GENERIC_MDX_COMPONENT_EXCLUDED_TAGS } from '../../../../lib/constants';
 import { type ParseAttributesOptions, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
 import { pointAfter } from '../../../utils';
+import { expandIndentToColumns, leadingIndent } from '../indentation';
 import { tableTags } from '../tables/utils';
 import { terminateHtmlFlowBlocks } from '../terminate-html-flow-blocks';
 
@@ -34,25 +35,34 @@ const hasNestedGenericComponentTag = (content: string): boolean =>
 
 /**
  * Strip the shared leading indentation from a component body so readability indentation
- * isn't parsed as indented code (4+ spaces), e.g. `  <p>` / `   text` -> `<p>` / ` text`.
+ * isn't parsed as indented code (4+ columns), e.g. `  <p>` / `   text` -> `<p>` / ` text`.
  * Relative indentation is kept, so content genuinely 4+ columns deeper stays code. We
  * only strip when a line actually reaches 4 columns; otherwise the body is left as-is so
  * its leading whitespace survives as text nodes (mixed component + HTML content needs it).
+ *
+ * Indentation is measured in CommonMark columns (tab = up to 4), matching how the parser
+ * decides indented code. A char count (tab = 1) under-measures tab-indented bodies, so
+ * they slip past the 4-column gate and their nested content fragments into code blocks.
  */
 function safeDeindent(text: string): string {
   const lines = text.split('\n');
   const nonEmptyLines = lines.filter(line => line.trim().length > 0);
   if (nonEmptyLines.length === 0) return text;
 
-  // Indent counts characters (tab = 1), unlike indentWidth's CommonMark columns
-  // (tab = 4) in terminate-html-flow-blocks.
-  const indents = nonEmptyLines.map(line => line.match(/^(\s*)/)?.[1].length ?? 0);
+  const indents = nonEmptyLines.map(line => expandIndentToColumns(leadingIndent(line)).length);
   const minIndent = Math.min(...indents);
   const maxIndent = Math.max(...indents);
 
-  const stripAmount = maxIndent > 3 ? minIndent : 0;
-  if (stripAmount === 0) return text;
-  return lines.map(line => line.slice(stripAmount)).join('\n');
+  if (maxIndent < 4 || minIndent === 0) return text;
+
+  // Expand each line's leading run to spaces before slicing so a shared indent of mixed
+  // tabs/spaces (and partial-tab remainders) strips cleanly while relative depth survives.
+  return lines
+    .map(line => {
+      const indent = leadingIndent(line);
+      return expandIndentToColumns(indent).slice(minIndent) + line.slice(indent.length);
+    })
+    .join('\n');
 }
 
 /**

--- a/processor/transform/mdxish/indentation.ts
+++ b/processor/transform/mdxish/indentation.ts
@@ -1,0 +1,26 @@
+/**
+ * CommonMark indentation helpers, shared by the mdxish preprocessors so tab- and
+ * space-indented content is measured (and sliced) on one scale.
+ *
+ * CommonMark's indented-code threshold is 4 *columns*, and a tab is a 4-column tab
+ * stop — not a fixed 4 characters. Counting characters (tab = 1) under-measures
+ * tab-indented lines, letting them slip past the 4-column gate so their content
+ * fragments into code blocks. Keeping one implementation here stops the two callers
+ * from drifting on what "4 columns" means.
+ */
+
+/** The run of leading spaces/tabs on a line. */
+export const leadingIndent = (line: string): string => line.match(/^[ \t]*/)?.[0] ?? '';
+
+/**
+ * Expand a leading-whitespace run to spaces using CommonMark's 4-column tab stops,
+ * so a run of mixed tabs/spaces can be measured by length and sliced by column.
+ */
+export function expandIndentToColumns(indent: string): string {
+  return indent
+    .split('')
+    .reduce((columns, char) => columns + (char === '\t' ? ' '.repeat(4 - (columns.length % 4)) : ' '), '');
+}
+
+/** Indentation width of a line in CommonMark columns (a tab advances to the next 4-column stop). */
+export const indentWidth = (line: string): number => expandIndentToColumns(leadingIndent(line)).length;

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -3,6 +3,8 @@ import { htmlRawNames } from 'micromark-util-html-tag-name';
 import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
 import { HTML_TABLE_STRUCTURE_TAGS } from '../../../utils/common-html-words';
 
+import { indentWidth } from './indentation';
+
 const STANDALONE_HTML_LINE_REGEX = /^(<[a-z][^<>]*>|<\/[a-z][^<>]*>)+\s*$/;
 
 const HTML_LINE_WITH_CONTENT_REGEX = /^<[a-z][^<>]*>.*<\/[a-z][^<>]*>(?:[^<]*)$/;
@@ -33,12 +35,6 @@ function countRawContentTags(line: string): { closes: number; opens: number }[] 
     opens: (line.match(open) ?? []).length,
     closes: (line.match(close) ?? []).length,
   }));
-}
-
-// Indentation width in columns, counting a tab as 4 per CommonMark.
-function indentWidth(line: string): number {
-  const leading = line.match(/^[ \t]*/)?.[0] ?? '';
-  return leading.replace(/\t/g, '    ').length;
 }
 
 interface RawContentFacts {


### PR DESCRIPTION
| 🎫 Resolve [CX-3721](https://linear.app/readme-io/issue/CX-3721/new-renderer-breaks-inline-styled-content-on-akamai-docs) | 🤖 Prepared with `/prep-pr` |
| :-----------------: | :-------------------------: |

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

Tab-indented HTML was fragmenting into `<pre><code>` blocks under the new (mdxish) renderer. Regression from [#1554](https://github.com/readmeio/markdown/pull/1554).

**Cause:** `safeDeindent` measured a component body's leading indentation by **character** count (tab = 1), but CommonMark's indented-code threshold is 4 **columns** and a literal tab advances up to 4. Tab-indented bodies therefore under-measured, slipped past the 4-column dedent gate, and their nested content collapsed into code blocks.

**Fix:**
- Extract one column-accurate implementation (`leadingIndent` / `expandIndentToColumns` / `indentWidth`) into `processor/transform/mdxish/indentation.ts`.
- Consume it from both `safeDeindent` and `terminateHtmlFlowBlocks`, replacing the latter's near-duplicate local `indentWidth` so the two callers can't drift on what "4 columns" means.
- `safeDeindent` now expands each line's leading run to spaces before slicing, so a shared indent of mixed tabs/spaces strips cleanly while genuine 4+-column-deep code still survives.

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ] Paste the some tab indented HTML into the mdxish renderer and confirm it renders as nested `<div>`s with no `<pre>`/`<code>` blocks. Example:
```
<div class="top-image-text-section">
	<div class="top-text-container">
		<div style="font-size: 18px;"><h2>Try products for free</h2></div>
		<p style="font-size: 16px;">Create an account and explor cloud computing, cybersecurity, and content-delivery products and services for free.</p>
	</div>
  	<div class="top-image-container">
		<div>
			<img src="https://t4.ftcdn.net/jpg/00/10/29/99/360_F_10299968_1z4xdoUIBgeQ4GVKqsf1sg9sot3Qe6RV.jpg">
		</div>
	</div>
</div>
```

## 📸 Screenshot or Loom

| Before | After | 
| --- | --- |
| <img width="2596" height="1856" alt="CleanShot 2026-07-16 at 10 50 22@2x" src="https://github.com/user-attachments/assets/e5a19330-d993-4d5d-9c23-3dfade92172f" /> | <img width="2584" height="1856" alt="CleanShot 2026-07-16 at 10 49 31@2x" src="https://github.com/user-attachments/assets/e8b3eabe-ba4c-4eba-a091-2d9c61db2362" /> |

