### PR TITLE
feat: allow Card to take a LinkComponent

### DIFF
--- a/__tests__/components/Cards.test.tsx
+++ b/__tests__/components/Cards.test.tsx
@@ -40,6 +40,35 @@ describe('Cards', () => {
       expect(container.querySelector('.Card-arrow')).toBeInTheDocument();
     });
 
+    it('renders the link with LinkComponent when one is given', () => {
+      const LinkComponent = ({
+        children,
+        className,
+        href,
+        target,
+      }: React.PropsWithChildren<{ className?: string; href?: string; target?: string }>) => (
+        <a className={className} href={`/ai-ml${href}`} target={target}>
+          {children}
+        </a>
+      );
+      const { container } = render(
+        <CardsGrid>
+          <Card href="/docs/f" LinkComponent={LinkComponent} title="Link">Linked</Card>
+        </CardsGrid>,
+      );
+      expect(container.querySelector('a.Card')).toHaveAttribute('href', '/ai-ml/docs/f');
+    });
+
+    it('ignores LinkComponent when there is no href', () => {
+      const LinkComponent = ({ children }: React.PropsWithChildren) => <a href="/nope">{children}</a>;
+      const { container } = render(
+        <CardsGrid>
+          <Card LinkComponent={LinkComponent} title="Static">Static</Card>
+        </CardsGrid>,
+      );
+      expect(container.querySelector('div.Card')).toBeInTheDocument();
+    });
+
     it('renders Card as a div when no href', () => {
       const { container } = render(
         <CardsGrid>

--- a/components/Cards/index.tsx
+++ b/components/Cards/index.tsx
@@ -6,6 +6,8 @@ import './style.scss';
 
 interface CardProps
   extends React.PropsWithChildren<{
+    // Optional link component wrapper so that the link can be formatted & processed by the parent
+    LinkComponent?: React.ElementType;
     badge?: string;
     href?: string;
     icon?: string;
@@ -15,8 +17,18 @@ interface CardProps
     title?: string;
   }> {}
 
-export const Card = ({ badge, children, href, kind = 'card', icon, iconColor, target, title }: CardProps) => {
-  const Tag = href ? 'a' : 'div';
+export const Card = ({
+  badge,
+  children,
+  href,
+  kind = 'card',
+  icon,
+  iconColor,
+  LinkComponent = 'a',
+  target,
+  title,
+}: CardProps) => {
+  const Tag = href ? LinkComponent : 'div';
 
   return (
     <Tag className={`Card Card_${kind}`} href={href} target={target}>


### PR DESCRIPTION
| 🎫 Resolve [CX-3711](https://linear.app/readme-io/issue/CX-3711/links-on-card-component-stopped-working) |
| :-----------------: |

## 🎯 What does this PR do?

The ticket claims we use to support this but I'm not sure we did since Cards links have always just prepended the URL, and `docs/slug` links would always just double up the section and not work. Offering this PR as a solution to that feature though.

- Adds an optional `LinkComponent` prop to `<Card>`, so a consumer can supply the element used to render the card's link. Defaults to `a`, so nothing changes on its own.
- This allows the readme side to utilise `useExpandCustomProtocol` to Card links
- This is the markdown half. The Hub passes its router-aware link in readmeio/readme#19773, which needs a release of this first.


## 🧪 QA tips

- [ ] Cards with no `href` still render as a `div`; existing raw-href behavior is unchanged without the new prop.

