### PR TITLE
feat: add htmlToMarkdown for converting HTML fragments to markdown

### DIFF
--- a/__tests__/lib/htmlToMarkdown.test.ts
+++ b/__tests__/lib/htmlToMarkdown.test.ts
@@ -37,6 +37,14 @@ describe('htmlToMarkdown', () => {
     expect(result).not.toContain('secret');
   });
 
+  it('drops a titled iframe that the default handler would turn into a link', () => {
+    expect(htmlToMarkdown('<p>keep</p><iframe src="https://x.com" title="secret"></iframe>')).toBe('keep');
+  });
+
+  it('drops noscript content the default handler would keep', () => {
+    expect(htmlToMarkdown('<p>keep</p><noscript>secret</noscript>')).toBe('keep');
+  });
+
   it('strips html comments', () => {
     const result = htmlToMarkdown('<p>keep</p><!-- hidden -->');
     expect(result).toContain('keep');

--- a/__tests__/lib/htmlToMarkdown.test.ts
+++ b/__tests__/lib/htmlToMarkdown.test.ts
@@ -1,0 +1,45 @@
+import { htmlToMarkdown } from '../../lib';
+
+describe('htmlToMarkdown', () => {
+  it('returns an empty string for non-string or blank input', () => {
+    expect(htmlToMarkdown(undefined)).toBe('');
+    expect(htmlToMarkdown(null)).toBe('');
+    expect(htmlToMarkdown('')).toBe('');
+    expect(htmlToMarkdown('   ')).toBe('');
+    // @ts-expect-error guarding the Mongo `Mixed` reality where html may not be a string
+    expect(htmlToMarkdown(42)).toBe('');
+  });
+
+  it('converts basic block and inline HTML', () => {
+    expect(htmlToMarkdown('<h1>Title</h1>')).toBe('# Title');
+    expect(htmlToMarkdown('<p>Hello <strong>world</strong></p>')).toBe('Hello **world**');
+    expect(htmlToMarkdown('<a href="https://x.com">link</a>')).toBe('[link](https://x.com)');
+  });
+
+  it('uses `-` bullets and `_` emphasis', () => {
+    expect(htmlToMarkdown('<ul><li>one</li><li>two</li></ul>')).toBe('- one\n- two');
+    expect(htmlToMarkdown('<em>hi</em>')).toBe('_hi_');
+  });
+
+  it('converts an html table to a gfm markdown table', () => {
+    const html = '<table><thead><tr><th>a</th><th>b</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr></tbody></table>';
+    expect(htmlToMarkdown(html)).toBe('| a | b |\n| - | - |\n| 1 | 2 |');
+  });
+
+  it('converts strikethrough via remark-gfm', () => {
+    expect(htmlToMarkdown('a <del>b</del> c')).toBe('a ~~b~~ c');
+  });
+
+  it.each(['script', 'style', 'iframe', 'noscript', 'template'])('strips <%s> elements', tag => {
+    const html = `<p>keep</p><${tag}>secret</${tag}>`;
+    const result = htmlToMarkdown(html);
+    expect(result).toContain('keep');
+    expect(result).not.toContain('secret');
+  });
+
+  it('strips html comments', () => {
+    const result = htmlToMarkdown('<p>keep</p><!-- hidden -->');
+    expect(result).toContain('keep');
+    expect(result).not.toContain('hidden');
+  });
+});

--- a/index.tsx
+++ b/index.tsx
@@ -17,6 +17,7 @@ export {
   exports,
   FLOW_TYPES,
   hast,
+  htmlToMarkdown,
   INLINE_ONLY_PARENT_TYPES,
   run,
   mdast,

--- a/lib/htmlToMarkdown.ts
+++ b/lib/htmlToMarkdown.ts
@@ -8,9 +8,10 @@ import { unified } from 'unified';
  * Converts an HTML fragment to GitHub-flavored Markdown.
  *
  * `remark-gfm` is load-bearing: without it, `<table>` and `<del>` input throws
- * at serialization. `script`, `style`, `iframe`, `noscript`, and `template`
- * elements and HTML comments are dropped so raw markup never leaks into the
- * output.
+ * at serialization. `iframe` (default: becomes a link) and `noscript` (default:
+ * keeps its text) are dropped by the handlers so raw markup never leaks;
+ * `script`, `style`, and `template` already drop by default and are overridden
+ * defensively. HTML comments are dropped via `nodeHandlers`.
  */
 const processor = unified()
   .use(rehypeParse, { fragment: true })

--- a/lib/htmlToMarkdown.ts
+++ b/lib/htmlToMarkdown.ts
@@ -1,0 +1,40 @@
+import rehypeParse from 'rehype-parse';
+import rehypeRemark from 'rehype-remark';
+import remarkGfm from 'remark-gfm';
+import remarkStringify from 'remark-stringify';
+import { unified } from 'unified';
+
+/**
+ * Converts an HTML fragment to GitHub-flavored Markdown.
+ *
+ * `remark-gfm` is load-bearing: without it, `<table>` and `<del>` input throws
+ * at serialization. `script`, `style`, `iframe`, `noscript`, and `template`
+ * elements and HTML comments are dropped so raw markup never leaks into the
+ * output.
+ */
+const processor = unified()
+  .use(rehypeParse, { fragment: true })
+  .use(rehypeRemark, {
+    // A comment is a `comment` node, not an element, so it goes in
+    // `nodeHandlers` rather than `handlers`.
+    handlers: {
+      iframe: () => undefined,
+      noscript: () => undefined,
+      script: () => undefined,
+      style: () => undefined,
+      template: () => undefined,
+    },
+    nodeHandlers: { comment: () => undefined },
+  })
+  .use(remarkGfm)
+  .use(remarkStringify, { bullet: '-', emphasis: '_', fences: true });
+
+/**
+ * Returns the Markdown form of `html`, or an empty string when there is no
+ * usable input. Synchronous, so it can run inside non-async serializers.
+ */
+export default function htmlToMarkdown(html?: string | null): string {
+  if (typeof html !== 'string' || !html.trim()) return '';
+
+  return processor.processSync(html).toString().trim();
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,6 +5,7 @@ export { default as astProcessor, remarkPlugins } from './ast-processor';
 export { default as compile } from './compile';
 export { default as exports } from './exports';
 export { default as hast } from './hast';
+export { default as htmlToMarkdown } from './htmlToMarkdown';
 export { default as mdast } from './mdast';
 export { default as mdastV6 } from './mdastV6';
 export { default as mdx } from './mdx';


### PR DESCRIPTION
| 🎫 Resolve CX-3493 |
| :-----------------: |

## 🎯 What does this PR do?

Adds an `htmlToMarkdown` export that converts an HTML fragment to GitHub flavoured markdown. The hub's landing page `.md` serialiser needs to turn customer authored HTML blocks into markdown, and this library only converted the other way (markdown to HTML). The function is synchronous so the hub can call it from its serialiser without turning the whole path async. It drops `script`, `style`, `iframe`, `noscript`, `template`, and HTML comments so raw markup never reaches the output, and keeps gfm tables and strikethrough.

## 🧪 QA tips

- [ ] `import { htmlToMarkdown } from '@readme/markdown'` and check `htmlToMarkdown('<h1>Hi</h1>')` returns `# Hi`
- [ ] Confirm `<script>`, `<style>`, `<iframe>`, `<noscript>`, `<template>`, and `<!-- comments -->` are dropped while the surrounding text stays
- [ ] Confirm an HTML `<table>` becomes a gfm markdown table and `<del>` becomes `~~strikethrough~~`
- [ ] Confirm non string or blank input returns an empty string

## 📸 Screenshot or Loom

N/A, this is a library function with no UI.
