### PR TITLE
fix: consistent spacing for components nested inside Accordions

### DIFF
--- a/components/Accordion/style.scss
+++ b/components/Accordion/style.scss
@@ -57,5 +57,9 @@
   &-content {
     color: var(--color-text-muted, #4f5a66);
     padding: 5px 15px 0 15px;
+
+    > * {
+      margin-bottom: var(--markdown-spacing, 15px);
+    }
   }
 }


### PR DESCRIPTION
| 🎫 Resolve RM-17472 |
| :-----------------: |

## 🎯 What does this PR do?

While QAing WYSIWYG components, we noticed that some consecutive components inside an Accordion (not at top level) didn't have vertical margins between them in View. Some components are spaced nicely like Callouts & Code, but not for Cards, Tables, etc.

The spacing between top-level blocks (which already works) comes from one rule in markdown-overrides (gfm.scss:397):
```
.markdown-body > * {
  margin-bottom: var(--markdown-spacing, 15px);
  margin-top: var(--markdown-spacing, 15px);
}
```
This spaces every direct child of .markdown-body, regardless of whether the component has its own margin. But nested containers like .Accordion-content don’t reproduce this rule, so nested children only get spacing if their root element is intrinsically margined (blockquote, pre, table, p, dl, .img) in [this code](https://github.com/readmeio/markdown/blob/940dedf07c81c205aab826697fbb92e957555c73/styles/gfm.scss#L271), and Callouts (blockquote), normal text use those tags, hence why they have spacing.

**Fix**: reproduce that same spacing inside `.Accordion-content` with a single `> * { margin-bottom }` rule, so every nested block — including custom components — spaces consistently. Keeping the rule scoped to Accordion only to minimise blast radius, and also covering different components.

Note MDX vs MDXish is irrelevant here.

## 🧪 QA tips

- [ ] Put a Table followed by a Cards block inside an Accordion → they now have a gap, and the last child has breathing room above the accordion's bottom border.
- [ ] Confirm Callout/Code inside an accordion are unchanged (no double spacing).
- [ ] Custom component inside Accordion should also have margins
- [ ] No nested margins.

## 📸 Screenshot or Loom

**Before**:

<img width="559" height="683" alt="Screenshot 2026-07-20 at 5 32 24 pm" src="https://github.com/user-attachments/assets/d06be3ea-d488-48a8-90fd-19be8ee662ee" />

**After**:

<img width="546" height="714" alt="Screenshot 2026-07-20 at 5 31 52 pm" src="https://github.com/user-attachments/assets/d637cfc4-6783-4cb7-98db-19aa8a148a81" />

