### PR TITLE
fix(mdxish): parse code samples nested in <ol>/<li>/<details>

### DIFF
--- a/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
@@ -30,6 +30,18 @@ describe('markdown inside single-line plain HTML tags', () => {
     expect(html).not.toContain('**');
   });
 
+  it('promotes a nested {…}-attr tag unwrapped from a sole paragraph', () => {
+    const ast = mdxish('<div>hello <span attr={x}>**bold**</span></div>');
+    const html = toHtml(ast);
+
+    expect(findElementByTagName(ast, 'span')).toMatchObject({
+      tagName: 'span',
+      children: [{ tagName: 'strong', children: [{ type: 'text', value: 'bold' }] }],
+    });
+    expect(html).not.toContain('**');
+    expect(html).not.toContain('{x}');
+  });
+
   it('preserves plain HTML attributes on the promoted wrapper', () => {
     const ast = mdxish('<div class="card-title">**a**</div>');
     const html = toHtml(ast);

--- a/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
@@ -18,6 +18,18 @@ describe('markdown inside single-line plain HTML tags', () => {
     expect(html).not.toContain('**');
   });
 
+  it('promotes a sibling wrapper that follows a wrapper with trailing content', () => {
+    // The first wrapper's trailing "t" is spliced in as a sibling mid-walk, shifting
+    // the second wrapper down. The transformer must still reach and promote it so its
+    // markdown parses instead of leaking as literal `**` (regression: the traversal
+    // used to stop early after a splice).
+    const ast = mdxish('- <div>**a**</div>t\n\n  <div>**b**</div>');
+    const html = toHtml(ast);
+
+    expect(findAllElementsByTagName(ast, 'strong')).toHaveLength(2);
+    expect(html).not.toContain('**');
+  });
+
   it('preserves plain HTML attributes on the promoted wrapper', () => {
     const ast = mdxish('<div class="card-title">**a**</div>');
     const html = toHtml(ast);

--- a/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
+++ b/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
@@ -160,6 +160,39 @@ const x = 1;
     expect(toHtml(ast)).toContain('const x = 1;');
   });
 
+  it('preserves HTML lists with 4+ column indents', () => {
+    const md = `<ul>
+  <li>
+    <div>
+       <p>**bold ul**</p>
+    </div>
+
+    <ul>
+
+      <li>
+
+        <p>**super nested ul**</p>
+      </li>
+    </ul>
+  </li>
+</ul>
+
+<ol>
+  <li>
+    <div>
+       <p>**bold ol**</p>
+    </div>
+  </li>
+</ol>`;
+
+    const ast = mdxish(md);
+    const html = toHtml(ast);
+
+    expect(html).toContain('<strong>bold ul</strong>');
+    expect(html).toContain('<strong>bold ol</strong>');
+    expect(html).toContain('<strong>super nested ul</strong>');
+  });
+
   it('claims a nested wrapper so a 4+ column markdown island parses, not fragments (RM-17560)', () => {
     // 6-col nesting indent would let CommonMark swallow the island as indented code;
     // being nested (prior body content), the block is claimed and its body re-parsed.
@@ -185,6 +218,107 @@ const x = 1;
     expect(code).not.toBeNull();
     expect(toHtml(ast)).toContain('const x = 1;');
     expect(toHtml(ast)).not.toContain('&#x3C;/details>');
+  });
+
+  it('claims a 4+ col island in a single 4-space-indented wrapper, no nesting (RM-17560)', () => {
+    const md = `<div class="card">
+    <p>Install the CLI:</p>
+
+    \`\`\`bash
+    npm install -g acme
+    \`\`\`
+</div>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'code')).toMatchObject({
+      properties: { className: ['language-bash'] },
+      children: [{ type: 'text', value: 'npm install -g acme\n' }],
+    });
+    expect(toHtml(ast)).not.toContain('```');
+  });
+
+  it('claims a 4+ col island under 2-space-nested layout tags (RM-17560)', () => {
+    const md = `<section>
+  <article>
+    <p>Release notes</p>
+
+    ### What's new
+
+    - Faster builds
+    - **Bug fixes**
+  </article>
+</section>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'h3')).toMatchObject({ children: [{ type: 'text', value: "What's new" }] });
+    const items = findAllElementsByTagName(ast, 'li');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({ children: [{ type: 'text', value: 'Faster builds' }] });
+    expect(items[1]).toMatchObject({
+      children: [{ tagName: 'strong', children: [{ type: 'text', value: 'Bug fixes' }] }],
+    });
+    expect(toHtml(ast)).not.toContain('###');
+  });
+
+  it('claims a 4+ col prose + fence island in a <details> without a list wrapper (RM-17560)', () => {
+    const md = `<details>
+    <summary>How do I authenticate?</summary>
+
+    Pass your key in the \`Authorization\` header:
+
+    \`\`\`http
+    Authorization: Bearer <token>
+    \`\`\`
+</details>`;
+
+    const ast = mdxish(md);
+    const details = findElementByTagName(ast, 'details');
+
+    expect(findElementByTagName(details!, 'summary')).toMatchObject({
+      children: [{ type: 'text', value: 'How do I authenticate?' }],
+    });
+    // The prose parses as a paragraph with inline code, not as part of a code block.
+    expect(findElementByTagName(details!, 'p')).toMatchObject({
+      children: [
+        { type: 'text', value: 'Pass your key in the ' },
+        { tagName: 'code', children: [{ type: 'text', value: 'Authorization' }] },
+        { type: 'text', value: ' header:' },
+      ],
+    });
+    expect(findElementByTagName(details!, 'pre')).toMatchObject({
+      children: [
+        {
+          tagName: 'code',
+          properties: { className: ['language-http'] },
+          children: [{ type: 'text', value: 'Authorization: Bearer <token>\n' }],
+        },
+      ],
+    });
+    expect(toHtml(ast)).not.toContain('```');
+  });
+
+  it('keeps the CommonMark fallback for a deep island inside <figure> (non-promotable)', () => {
+    // The transformer keeps figure bodies raw for figure reassembly, so the 4+ col
+    // island claim must not fire
+    const md = `<figure>
+  <figcaption>cap</figcaption>
+
+      ### Heading
+
+      \`\`\`js
+      const x = 1;
+      \`\`\`
+</figure>`;
+
+    const ast = mdxish(md);
+
+    const figure = findElementByTagName(ast, 'figure');
+    expect(figure).not.toBeNull();
+    expect(findElementByTagName(figure!, 'figcaption')).toMatchObject({
+      children: [{ type: 'text', value: 'cap' }],
+    });
   });
 
   it('allows blank lines inside a brace expression body (e.g. a .map() callback)', () => {

--- a/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
+++ b/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
@@ -160,6 +160,33 @@ const x = 1;
     expect(toHtml(ast)).toContain('const x = 1;');
   });
 
+  it('claims a nested wrapper so a 4+ column markdown island parses, not fragments (RM-17560)', () => {
+    // 6-col nesting indent would let CommonMark swallow the island as indented code;
+    // being nested (prior body content), the block is claimed and its body re-parsed.
+    const md = `<ol>
+  <li>
+    <details>
+      <summary>x</summary>
+
+      ### Heading
+
+      \`\`\`js
+      const x = 1;
+      \`\`\`
+    </details>
+  </li>
+</ol>`;
+
+    const ast = mdxish(md);
+
+    // The heading and code parse; the closing tag never leaks into the code.
+    expect(findElementByTagName(ast, 'h3')).toMatchObject({ children: [{ type: 'text', value: 'Heading' }] });
+    const code = findElementByTagName(findElementByTagName(ast, 'details')!, 'code');
+    expect(code).not.toBeNull();
+    expect(toHtml(ast)).toContain('const x = 1;');
+    expect(toHtml(ast)).not.toContain('&#x3C;/details>');
+  });
+
   it('allows blank lines inside a brace expression body (e.g. a .map() callback)', () => {
     const md = `<div className="grid">
   {[1, 2].map((item, i) => {

--- a/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
+++ b/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
@@ -300,8 +300,9 @@ const x = 1;
   });
 
   it('keeps the CommonMark fallback for a deep island inside <figure> (non-promotable)', () => {
-    // The transformer keeps figure bodies raw for figure reassembly, so the 4+ col
-    // island claim must not fire
+    // Note: In this example the indented content would still be parsed as code
+    // Since this looks like an edge case, we'll leave it as is first since it
+    // requires a bigger refactor.
     const md = `<figure>
   <figcaption>cap</figcaption>
 

--- a/__tests__/lib/render-mdxish/markdown-in-html.test.tsx
+++ b/__tests__/lib/render-mdxish/markdown-in-html.test.tsx
@@ -141,4 +141,37 @@ describe.each(['mdxish', 'mdx'] as const)('markdown nested in HTML (%s engine)',
     // The indented markdown must never fall through to an indented code block
     expect(container.querySelector('pre')).toBeNull();
   });
+
+  it('renders a fenced code sample + heading inside <ol>/<li>/<details> (RM-17560)', () => {
+    // Deep HTML nesting indents the body 6 cols (past CommonMark's indented-code
+    // threshold); both engines must still parse the heading + fenced code, not swallow them.
+    const { container } = renderMarkdown(`<ol>
+  <li>
+    <details>
+      <summary>Authorization request</summary>
+
+      ### Authorization request
+
+      \`\`\`json
+      {
+          "MESSAGE_TYPE": "0100"
+      }
+      \`\`\`
+    </details>
+  </li>
+</ol>`);
+
+    // A collapsed <details> hides its body from the a11y tree — assert presence, not visibility.
+    const details = container.querySelector('details');
+    expect(details).not.toBeNull();
+    expect(details!.querySelector('summary')?.textContent).toContain('Authorization request');
+    expect(within(details!).getByRole('heading', { level: 3, name: /Authorization request/, hidden: true })).toBeInTheDocument();
+
+    const code = details!.querySelector('pre code');
+    expect(code).not.toBeNull();
+    expect(code!.textContent).toContain('"MESSAGE_TYPE": "0100"');
+    // The fence markers and the closing tag must not leak into the code block.
+    expect(code!.textContent).not.toContain('```');
+    expect(code!.textContent).not.toContain('</details>');
+  });
 });

--- a/__tests__/regression/__snapshots__/equivalence.test.ts.snap
+++ b/__tests__/regression/__snapshots__/equivalence.test.ts.snap
@@ -421,6 +421,12 @@ exports[`MDX↔MDXish equivalence > indented-foreign-html-tags 1`] = `
 }
 `;
 
+exports[`MDX↔MDXish equivalence > indented-markdown-islands-in-html 1`] = `
+{
+  "status": "match",
+}
+`;
+
 exports[`MDX↔MDXish equivalence > jsx-attribute-entities 1`] = `
 {
   "changes": [

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -284,6 +284,70 @@ exports[`Render engine regressions tests > indented-foreign-html-tags (mdxish) 1
 </div>"
 `;
 
+exports[`Render engine regressions tests > indented-markdown-islands-in-html (mdx) 1`] = `
+"<ol><li><details><summary>Authorization request</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="1-authorization-request"></div><div class="heading-text">1. Authorization request</div><a aria-label="Skip link to 1. Authorization request" class="heading-anchor-icon fa fa-regular fa-anchor" href="#1-authorization-request"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">0100 Request</button><button type="button" value="json">0100 Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+    &quot;MESSAGE_TYPE&quot;: {
+        &quot;Message_Type&quot;: &quot;0100&quot;,
+        &quot;Message_Desc&quot;: &quot;Authorisation Request&quot;
+    },
+    &quot;SUMMARY&quot;: {
+        &quot;TID&quot;: &quot;2237374892345000118&quot;,
+        &quot;Network&quot;: &quot;MC&quot;,
+    }
+}</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+    &quot;Message_Type&quot;: &quot;0110&quot;,
+}</code></pre></div></div></details></li><li><details><summary>ATM withdrawal and reversal</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="2-atm-withdrawal-and-reversal"></div><div class="heading-text">2. ATM withdrawal and reversal</div><a aria-label="Skip link to 2. ATM withdrawal and reversal" class="heading-anchor-icon fa fa-regular fa-anchor" href="#2-atm-withdrawal-and-reversal"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">Request</button><button type="button" value="json">Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+    &quot;MESSAGE_TYPE&quot;: {
+        &quot;Message_Type&quot;: &quot;0400&quot;,
+        &quot;Message_Desc&quot;: &quot;Reversal Request&quot;
+    },
+    &quot;ISO_MSG&quot;: {
+        &quot;DE48&quot;: {
+            &quot;1&quot;: &quot;Z&quot;,
+            &quot;80&quot;: &quot;TV&quot;
+        },
+    },
+    &quot;RULES&quot;: []
+
+}</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+    &quot;DE11&quot;: &quot;000071&quot;,
+    &quot;DE2&quot;: &quot;818654321&quot;,
+}</code></pre></div></div></details></li></ol>"
+`;
+
+exports[`Render engine regressions tests > indented-markdown-islands-in-html (mdxish) 1`] = `
+"<ol><li><details>
+  <summary>Authorization request</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="1-authorization-request"></div><div class="heading-text">1. Authorization request</div><a aria-label="Skip link to 1. Authorization request" class="heading-anchor-icon fa fa-regular fa-anchor" href="#1-authorization-request"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">0100 Request</button><button type="button" value="json">0100 Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+    &quot;MESSAGE_TYPE&quot;: {
+        &quot;Message_Type&quot;: &quot;0100&quot;,
+        &quot;Message_Desc&quot;: &quot;Authorisation Request&quot;
+    },
+    &quot;SUMMARY&quot;: {
+        &quot;TID&quot;: &quot;2237374892345000118&quot;,
+        &quot;Network&quot;: &quot;MC&quot;,
+    }
+}</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+    &quot;Message_Type&quot;: &quot;0110&quot;,
+}</code></pre></div></div></details></li><li><details>
+  <summary>ATM withdrawal and reversal</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="2-atm-withdrawal-and-reversal"></div><div class="heading-text">2. ATM withdrawal and reversal</div><a aria-label="Skip link to 2. ATM withdrawal and reversal" class="heading-anchor-icon fa fa-regular fa-anchor" href="#2-atm-withdrawal-and-reversal"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">Request</button><button type="button" value="json">Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+    &quot;MESSAGE_TYPE&quot;: {
+        &quot;Message_Type&quot;: &quot;0400&quot;,
+        &quot;Message_Desc&quot;: &quot;Reversal Request&quot;
+    },
+    &quot;ISO_MSG&quot;: {
+        &quot;DE48&quot;: {
+            &quot;1&quot;: &quot;Z&quot;,
+            &quot;80&quot;: &quot;TV&quot;
+        },
+    },
+    &quot;RULES&quot;: []
+
+}</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+    &quot;DE11&quot;: &quot;000071&quot;,
+    &quot;DE2&quot;: &quot;818654321&quot;,
+}</code></pre></div></div></details></li></ol>"
+`;
+
 exports[`Render engine regressions tests > jsx-attribute-entities (mdx) 1`] = `
 "<h1 class="heading heading-1 header-scroll"><div class="heading-anchor anchor waypoint" id="jsx-attribute-entities"></div><div class="heading-text">JSX attribute entities</div><a aria-label="Skip link to JSX attribute entities" class="heading-anchor-icon fa fa-regular fa-anchor" href="#jsx-attribute-entities"></a></h1>
 <blockquote class="callout callout_warn" theme="🚧"><span class="callout-icon">🚧</span><p>Numeric-entity emoji in <code class="rdmd-code lang-undefined theme-undefined">icon</code> should decode to the construction sign.</p></blockquote>

--- a/__tests__/regression/fixtures/indented-markdown-islands-in-html/README.md
+++ b/__tests__/regression/fixtures/indented-markdown-islands-in-html/README.md
@@ -1,0 +1,24 @@
+# `indented-markdown-islands-in-html` Fixture
+
+Markdown islands (headings, fenced code) sitting 4+ columns deep inside nested
+plain HTML block tags, separated from the tags by blank lines. The trigger is
+structural, not tag-specific: any CommonMark type-6 wrapper chain whose nesting
+indent reaches 4 columns puts the island past the indented-code threshold, so
+everything after the blank line — fence markers, headings, prose — collapsed
+into one literal `<pre>` code block, with closing tags leaking into it.
+
+This body is a stripped-down version of the RM-17560 customer doc:
+`<ol>/<li>/<details>/<summary>` at 6-column depth with titled `json` fences.
+
+## Source bugs
+
+- RM-17560 — code samples in `<details>` (inside `<ol>/<li>`) rendered as one
+  literal indented-code block in MDXish
+
+## What flips this fixture
+
+Changes to the `mdxComponent` tokenizer's plain-block-claim continuation
+(`plainClaimLineStart` / the 4-column island rule in
+`lib/micromark/mdx-component/syntax.ts`), the bottom-up promotion recursion in
+`processor/transform/mdxish/components/mdx-blocks.ts` (`parseMdChildren` /
+`promoteComponentBlocks`), or `safeDeindent`'s shared-indent stripping.

--- a/__tests__/regression/fixtures/indented-markdown-islands-in-html/body.md
+++ b/__tests__/regression/fixtures/indented-markdown-islands-in-html/body.md
@@ -1,0 +1,58 @@
+<ol>
+  <li>
+    <details>
+      <summary>Authorization request</summary>
+
+      ### 1. Authorization request
+
+      ```json 0100 Request
+      {
+          "MESSAGE_TYPE": {
+              "Message_Type": "0100",
+              "Message_Desc": "Authorisation Request"
+          },
+          "SUMMARY": {
+              "TID": "2237374892345000118",
+              "Network": "MC",
+          }
+      }
+      ```
+      ```json 0100 Response
+      {
+          "Message_Type": "0110",
+      }
+      ```
+    </details>
+  </li>
+
+  <li>
+    <details>
+      <summary>ATM withdrawal and reversal</summary>
+
+      ### 2. ATM withdrawal and reversal
+
+      ```json Request
+      {
+          "MESSAGE_TYPE": {
+              "Message_Type": "0400",
+              "Message_Desc": "Reversal Request"
+          },
+          "ISO_MSG": {
+              "DE48": {
+                  "1": "Z",
+                  "80": "TV"
+              },
+          },
+          "RULES": []
+
+      }
+      ```
+      ```json Response
+      {
+          "DE11": "000071",
+          "DE2": "818654321",
+      }
+      ```
+    </details>
+  </li>
+</ol>

--- a/__tests__/regression/fixtures/indented-markdown-islands-in-html/context.json
+++ b/__tests__/regression/fixtures/indented-markdown-islands-in-html/context.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "defaults": [],
+    "user": {}
+  },
+  "glossary": []
+}

--- a/lib/micromark/mdx-component/continuation-checks.ts
+++ b/lib/micromark/mdx-component/continuation-checks.ts
@@ -1,0 +1,95 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import type { Code, Construct, Effects, State, TokenizeContext } from 'micromark-util-types';
+
+import { asciiAlpha, markdownLineEnding, markdownSpace } from 'micromark-util-character';
+import { codes, types } from 'micromark-util-symbol';
+
+/**
+ * Partial constructs the `mdxComponent` tokenizer runs via `effects.check` to
+ * decide whether the next line continues the block. They live here (not in
+ * `syntax.ts`) because they hold none of `createTokenize`'s closure state — each
+ * is a self-contained, single-line lookahead.
+ */
+
+function tokenizeNonLazyContinuationStart(this: TokenizeContext, effects: Effects, ok: State, nok: State) {
+  // eslint-disable-next-line @typescript-eslint/no-this-alias
+  const self = this;
+
+  return start;
+
+  function start(code: Code): State | undefined {
+    if (markdownLineEnding(code)) {
+      effects.enter(types.lineEnding);
+      effects.consume(code);
+      effects.exit(types.lineEnding);
+      return after;
+    }
+    return nok(code);
+  }
+
+  function after(code: Code): State | undefined {
+    if (self.parser.lazy[self.now().line]) {
+      return nok(code);
+    }
+    return ok(code);
+  }
+}
+
+// A markup-only line opens with a tag (`<x`/`</x`) and ends (ignoring trailing
+// spaces) at a `>`. That distinguishes a structural continuation like
+// `<span>b</span></div>` from a paragraph like `<b>Note:</b> read *this*`.
+function tokenizeMarkupOnlyContinuation(effects: Effects, ok: State, nok: State) {
+  let lastNonSpace: Code = null;
+
+  return start;
+
+  function start(code: Code): State | undefined {
+    // Caller guarantees we are at `<` at the (already de-indented) line start.
+    effects.enter(types.data);
+    effects.consume(code);
+    return afterLessThan;
+  }
+
+  function afterLessThan(code: Code): State | undefined {
+    if (code === codes.slash) {
+      effects.consume(code);
+      return afterSlash;
+    }
+    return afterSlash(code);
+  }
+
+  // The `<` (or `</`) must introduce a real tag, not a stray `<` in prose.
+  function afterSlash(code: Code): State | undefined {
+    if (asciiAlpha(code)) {
+      lastNonSpace = code;
+      effects.consume(code);
+      return scanToLineEnd;
+    }
+    effects.exit(types.data);
+    return nok(code);
+  }
+
+  function scanToLineEnd(code: Code): State | undefined {
+    if (code === null || markdownLineEnding(code)) {
+      effects.exit(types.data);
+      return lastNonSpace === codes.greaterThan ? ok(code) : nok(code);
+    }
+    if (!markdownSpace(code)) lastNonSpace = code;
+    effects.consume(code);
+    return scanToLineEnd;
+  }
+}
+
+// A line ending whose next line isn't a lazy paragraph continuation. Checked so a
+// component body's blank/continuation lines aren't stolen by an interrupted paragraph.
+export const nonLazyContinuationStart: Construct = {
+  tokenize: tokenizeNonLazyContinuationStart,
+  partial: true,
+};
+
+// Lookahead for `plainClaimLineStart`: is this line markup-only, or a paragraph
+// that merely starts with a tag? Run via `effects.check` so it never consumes.
+export const markupOnlyContinuation: Construct = {
+  tokenize: tokenizeMarkupOnlyContinuation,
+  partial: true,
+};

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -5,7 +5,7 @@ import { markdownLineEnding, markdownSpace } from 'micromark-util-character';
 import { htmlBlockNames, htmlRawNames } from 'micromark-util-html-tag-name';
 import { codes, types } from 'micromark-util-symbol';
 
-import { HTML_TABLE_STRUCTURE_TAGS, HTML_VOID_ELEMENTS } from '../../../utils/common-html-words';
+import { HTML_FIGURE_TAGS, HTML_TABLE_STRUCTURE_TAGS, HTML_VOID_ELEMENTS } from '../../../utils/common-html-words';
 import { INLINE_COMPONENT_TAGS, TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
 
 import { markupOnlyContinuation, nonLazyContinuationStart } from './continuation-checks';
@@ -926,9 +926,10 @@ function createTokenize(mode: 'flow' | 'text') {
       if (pendingBlankLine) {
         // A 4+ col island nested under other tags is cosmetic nesting indent, not code:
         // keep claiming so promotion dedents + re-parses it as markdown (RM-17560).
-        if (plainClaimIndentColumns >= 4 && sawPlainBlockBodyContent) {
-          pendingBlankLine = false;
-          return bodyLineStart(code);
+        // Figure tags are excluded — the transformer keeps their bodies raw, so a
+        // claimed island would never be re-parsed and would leak as literal text.
+        if (plainClaimIndentColumns >= 4 && sawPlainBlockBodyContent && !HTML_FIGURE_TAGS.has(tagName)) {
+          return plainClaimContinue(code);
         }
         // Otherwise only a markup-only tag line continues; markdown/prose falls back to
         // CommonMark so it parses and rehype-raw re-nests it into the wrapper.

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -1,12 +1,14 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import type { Code, Construct, Effects, Extension, Resolver, State, TokenizeContext } from 'micromark-util-types';
 
-import { asciiAlpha, markdownLineEnding, markdownSpace } from 'micromark-util-character';
+import { markdownLineEnding, markdownSpace } from 'micromark-util-character';
 import { htmlBlockNames, htmlRawNames } from 'micromark-util-html-tag-name';
 import { codes, types } from 'micromark-util-symbol';
 
 import { HTML_TABLE_STRUCTURE_TAGS, HTML_VOID_ELEMENTS } from '../../../utils/common-html-words';
 import { INLINE_COMPONENT_TAGS, TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
+
+import { markupOnlyContinuation, nonLazyContinuationStart } from './continuation-checks';
 
 declare module 'micromark-util-types' {
   interface TokenTypeMap {
@@ -27,18 +29,6 @@ const htmlFlowTagNames = new Set([...htmlRawNames, ...htmlBlockNames]);
 const plainBlockClaimTagNames = new Set(
   [...htmlBlockNames].filter(tag => !HTML_TABLE_STRUCTURE_TAGS.has(tag) && !HTML_VOID_ELEMENTS.has(tag)),
 );
-
-const nonLazyContinuationStart: Construct = {
-  tokenize: tokenizeNonLazyContinuationStart,
-  partial: true,
-};
-
-// Lookahead for `plainClaimLineStart`: is this line markup-only, or a paragraph
-// that merely starts with a tag? Run via `effects.check` so it never consumes.
-const markupOnlyContinuation: Construct = {
-  tokenize: tokenizeMarkupOnlyContinuation,
-  partial: true,
-};
 
 function resolveToMdxComponent(events: Parameters<Resolver>[0]) {
   let index = events.length;
@@ -106,6 +96,18 @@ function createTokenize(mode: 'flow' | 'text') {
     // `plainClaimLineStart`: after a blank line it may only continue on a tag line.
     let isPlainBlockClaim = false;
     let pendingBlankLine = false;
+    // Leading indent columns of the current plain-claim line, reset per line; ≥4 is
+    // where CommonMark would fragment the island as indented code. Tabs advance to the
+    // next 4-column stop — the same rule `expandIndentToColumns`
+    // (processor/transform/mdxish/indentation.ts) applies, kept in sync by hand since
+    // this side works on a `Code` stream, not a string. NB: do NOT swap this for
+    // `self.now().column`; micromark bumps the point column by 1 per `horizontalTab`
+    // code (the trailing `virtualSpace` codes don't move it), so it measures a tab as
+    // 1 column, reviving the tab-under-measurement bug this math exists to avoid.
+    let plainClaimIndentColumns = 0;
+    // True once a non-blank line follows the opener: a deep island below it is nested
+    // (cosmetic indent), not top-of-body indented code.
+    let sawPlainBlockBodyContent = false;
 
     // Code span tracking
     let codeSpanOpenSize = 0;
@@ -507,6 +509,8 @@ function createTokenize(mode: 'flow' | 'text') {
 
       if (code !== codes.space && code !== codes.horizontalTab) {
         openerLineHasContent = true;
+        // Continuation content marks a later deep island as nested, not indented code.
+        if (!onOpenerLine) sawPlainBlockBodyContent = true;
       }
 
       if (code === codes.backslash) {
@@ -876,7 +880,10 @@ function createTokenize(mode: 'flow' | 'text') {
         return inBodyBraceExpr(code);
       }
 
-      if (isPlainBlockClaim) return plainClaimLineStart(code);
+      if (isPlainBlockClaim) {
+        plainClaimIndentColumns = 0;
+        return plainClaimLineStart(code);
+      }
       return bodyLineStart(code);
     }
 
@@ -907,6 +914,7 @@ function createTokenize(mode: 'flow' | 'text') {
     function plainClaimLineStart(code: Code): State | undefined {
       // Leading whitespace only → treat as a blank line, matching CommonMark.
       if (code === codes.space || code === codes.horizontalTab) {
+        plainClaimIndentColumns += code === codes.horizontalTab ? 4 - (plainClaimIndentColumns % 4) : 1;
         effects.consume(code);
         return plainClaimLineStart;
       }
@@ -915,10 +923,15 @@ function createTokenize(mode: 'flow' | 'text') {
         effects.exit('mdxComponentData');
         return bodyContinuationStart(code);
       }
-      // Across a blank line the block only continues onto a markup-only line; a
-      // paragraph that merely starts with a tag must fall back so its markdown
-      // parses and rehype-raw re-nests it into the wrapper.
       if (pendingBlankLine) {
+        // A 4+ col island nested under other tags is cosmetic nesting indent, not code:
+        // keep claiming so promotion dedents + re-parses it as markdown (RM-17560).
+        if (plainClaimIndentColumns >= 4 && sawPlainBlockBodyContent) {
+          pendingBlankLine = false;
+          return bodyLineStart(code);
+        }
+        // Otherwise only a markup-only tag line continues; markdown/prose falls back to
+        // CommonMark so it parses and rehype-raw re-nests it into the wrapper.
         if (code !== codes.lessThan) return nok(code);
         return effects.check(markupOnlyContinuation, plainClaimContinue, nok)(code);
       }
@@ -940,75 +953,6 @@ function createTokenize(mode: 'flow' | 'text') {
       return ok(code);
     }
   };
-}
-
-function tokenizeNonLazyContinuationStart(this: TokenizeContext, effects: Effects, ok: State, nok: State) {
-  // eslint-disable-next-line @typescript-eslint/no-this-alias
-  const self = this;
-
-  return start;
-
-  function start(code: Code): State | undefined {
-    if (markdownLineEnding(code)) {
-      effects.enter(types.lineEnding);
-      effects.consume(code);
-      effects.exit(types.lineEnding);
-      return after;
-    }
-    return nok(code);
-  }
-
-  function after(code: Code): State | undefined {
-    if (self.parser.lazy[self.now().line]) {
-      return nok(code);
-    }
-    return ok(code);
-  }
-}
-
-// A markup-only line opens with a tag (`<x`/`</x`) and ends (ignoring trailing
-// spaces) at a `>`. That distinguishes a structural continuation like
-// `<span>b</span></div>` from a paragraph like `<b>Note:</b> read *this*`.
-function tokenizeMarkupOnlyContinuation(effects: Effects, ok: State, nok: State) {
-  let lastNonSpace: Code = null;
-
-  return start;
-
-  function start(code: Code): State | undefined {
-    // Caller guarantees we are at `<` at the (already de-indented) line start.
-    effects.enter(types.data);
-    effects.consume(code);
-    return afterLessThan;
-  }
-
-  function afterLessThan(code: Code): State | undefined {
-    if (code === codes.slash) {
-      effects.consume(code);
-      return afterSlash;
-    }
-    return afterSlash(code);
-  }
-
-  // The `<` (or `</`) must introduce a real tag, not a stray `<` in prose.
-  function afterSlash(code: Code): State | undefined {
-    if (asciiAlpha(code)) {
-      lastNonSpace = code;
-      effects.consume(code);
-      return scanToLineEnd;
-    }
-    effects.exit(types.data);
-    return nok(code);
-  }
-
-  function scanToLineEnd(code: Code): State | undefined {
-    if (code === null || markdownLineEnding(code)) {
-      effects.exit(types.data);
-      return lastNonSpace === codes.greaterThan ? ok(code) : nok(code);
-    }
-    if (!markdownSpace(code)) lastNonSpace = code;
-    effects.consume(code);
-    return scanToLineEnd;
-  }
 }
 
 /**

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -5,7 +5,7 @@ import { markdownLineEnding, markdownSpace } from 'micromark-util-character';
 import { htmlBlockNames, htmlRawNames } from 'micromark-util-html-tag-name';
 import { codes, types } from 'micromark-util-symbol';
 
-import { HTML_FIGURE_TAGS, HTML_TABLE_STRUCTURE_TAGS, HTML_VOID_ELEMENTS } from '../../../utils/common-html-words';
+import { HTML_TABLE_STRUCTURE_TAGS, HTML_VOID_ELEMENTS, NON_REPARSED_BODY_TAGS } from '../../../utils/common-html-words';
 import { INLINE_COMPONENT_TAGS, TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
 
 import { markupOnlyContinuation, nonLazyContinuationStart } from './continuation-checks';
@@ -29,6 +29,13 @@ const htmlFlowTagNames = new Set([...htmlRawNames, ...htmlBlockNames]);
 const plainBlockClaimTagNames = new Set(
   [...htmlBlockNames].filter(tag => !HTML_TABLE_STRUCTURE_TAGS.has(tag) && !HTML_VOID_ELEMENTS.has(tag)),
 );
+
+// Both are 4 columns per CommonMark, but they mean different things: a tab advances
+// to the next multiple of TAB_STOP_WIDTH, and INDENTED_CODE_MIN_COLUMNS is the depth
+// at which a line would fragment into indented code. Named separately so the two
+// concepts don't read as one incidental literal.
+const TAB_STOP_WIDTH = 4;
+const INDENTED_CODE_MIN_COLUMNS = 4;
 
 function resolveToMdxComponent(events: Parameters<Resolver>[0]) {
   let index = events.length;
@@ -914,7 +921,8 @@ function createTokenize(mode: 'flow' | 'text') {
     function plainClaimLineStart(code: Code): State | undefined {
       // Leading whitespace only → treat as a blank line, matching CommonMark.
       if (code === codes.space || code === codes.horizontalTab) {
-        plainClaimIndentColumns += code === codes.horizontalTab ? 4 - (plainClaimIndentColumns % 4) : 1;
+        plainClaimIndentColumns +=
+          code === codes.horizontalTab ? TAB_STOP_WIDTH - (plainClaimIndentColumns % TAB_STOP_WIDTH) : 1;
         effects.consume(code);
         return plainClaimLineStart;
       }
@@ -926,9 +934,13 @@ function createTokenize(mode: 'flow' | 'text') {
       if (pendingBlankLine) {
         // A 4+ col island nested under other tags is cosmetic nesting indent, not code:
         // keep claiming so promotion dedents + re-parses it as markdown (RM-17560).
-        // Figure tags are excluded — the transformer keeps their bodies raw, so a
-        // claimed island would never be re-parsed and would leak as literal text.
-        if (plainClaimIndentColumns >= 4 && sawPlainBlockBodyContent && !HTML_FIGURE_TAGS.has(tagName)) {
+        // Tags whose bodies stay raw are excluded — a claimed island there would never
+        // be re-parsed and would leak as literal text.
+        if (
+          plainClaimIndentColumns >= INDENTED_CODE_MIN_COLUMNS &&
+          sawPlainBlockBodyContent &&
+          !NON_REPARSED_BODY_TAGS.has(tagName)
+        ) {
           return plainClaimContinue(code);
         }
         // Otherwise only a markup-only tag line continues; markdown/prose falls back to

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -267,8 +267,10 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
       if (isPlainLowercaseHtml && !containsMarkdownConstruct(parsedChildren)) return;
       // Lowercase tags are usually inline; unwrap a sole paragraph so their
       // phrasing content isn't spuriously block-wrapped.
+      let unwrappedSoleParagraph = false;
       if (!isPascal && parsedChildren.length === 1 && parsedChildren[0].type === 'paragraph') {
         parsedChildren = (parsedChildren[0] as Parent).children as MdxJsxFlowElement['children'];
+        unwrappedSoleParagraph = true;
       }
       const componentNode = createComponentNode({
         tag,
@@ -289,6 +291,12 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
           : node.position,
       });
       substituteNodeWithMdxNode(parent, index, componentNode);
+
+      // The unwrap reparented the children out of their paragraph, so re-walk them
+      // since the children HTML may contain promotable syntax (e.g. `{…}`-attr tags)
+      if (unwrappedSoleParagraph) {
+        stack.push(componentNode as Parent);
+      }
 
       // Trailing content after the close becomes siblings; parseMdChildren has
       // already promoted any components nested inside both sides, so the promoted

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -80,8 +80,9 @@ const parseMdChildren = (value: string, safeMode: boolean): RootContent[] => {
 };
 
 // Splices trailing content in as sibling nodes. parseMdChildren has already
-// promoted any components nested among them (bottom-up), so — unlike the
-// old lazy walk — the parent needs no re-queue for them to be processed.
+// promoted any components nested among them (bottom-up); the main loop's
+// index-based walk then reaches these spliced siblings and the original children
+// they shift down, so no parent re-queue is needed.
 const parseSibling = (parent: Parent, index: number, sibling: string, safeMode: boolean) => {
   const siblingNodes = parseMdChildren(sibling, safeMode) as Node[];
   if (siblingNodes.length > 0) {
@@ -173,8 +174,7 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
     const node = parent.children[index];
     if (!node) return;
     // Descend into container nodes (lists, blockquotes, …) so their html children
-    // are reached. This is the stack's only job now — component bodies are promoted
-    // eagerly by parseMdChildren, so promoted subtrees never need re-queuing.
+    // are reached.
     if ('children' in node && Array.isArray(node.children)) {
       stack.push(node as Parent);
     }
@@ -299,13 +299,15 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
     }
   };
 
-  // Depth-first so nodes keep their source order.
+  // Depth-first so nodes keep their source order. Index-based (not forEach) and
+  // re-reading length each step: parseSibling splices siblings in mid-iteration, and
+  // those — plus the original children they shift down — must all stay eligible.
   while (stack.length) {
     const parent = stack.pop();
     if (parent?.children) {
-      parent.children.forEach((_child, index) => {
+      for (let index = 0; index < parent.children.length; index += 1) {
         processChildNode(parent, index);
-      });
+      }
     }
   }
 

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -72,16 +72,20 @@ function safeDeindent(text: string): string {
  */
 const parseMdChildren = (value: string, safeMode: boolean): RootContent[] => {
   const parsed = getInlineMdProcessor({ safeMode }).parse(terminateHtmlFlowBlocks(safeDeindent(value).trim()));
+  // Promote nested wrappers bottom-up so an outer wrapper sees markdown buried in a
+  // child claimed whole (e.g. `<li>` in `<ol>`) before its containsMarkdownConstruct check (RM-17560).
+  // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutually recursive; hoisted decl, safe at runtime
+  promoteComponentBlocks(parsed as Parent, safeMode, null);
   return parsed.children || [];
 };
 
-// Parses trailing content into sibling nodes and re-queues the parent so any
-// components among them get processed.
-const parseSibling = (stack: Parent[], parent: Parent, index: number, sibling: string, safeMode: boolean) => {
+// Splices trailing content in as sibling nodes. parseMdChildren has already
+// promoted any components nested among them (bottom-up), so — unlike the
+// old lazy walk — the parent needs no re-queue for them to be processed.
+const parseSibling = (parent: Parent, index: number, sibling: string, safeMode: boolean) => {
   const siblingNodes = parseMdChildren(sibling, safeMode) as Node[];
   if (siblingNodes.length > 0) {
     (parent.children as Node[]).splice(index + 1, 0, ...siblingNodes);
-    stack.push(parent);
   }
 };
 
@@ -161,15 +165,16 @@ const substituteNodeWithMdxNode = (parent: Parent, index: number, mdxNode: MdxJs
  * The opening tag, content, and closing tag are all captured in one HTML node
  * (guaranteed by the mdx-component tokenizer).
  */
-const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opts = {}) => (tree, file) => {
+function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string | null): Parent {
   const stack: Parent[] = [tree];
-  const safeMode = !!opts.safeMode;
-  const source: string | null = file?.value ? String(file.value) : null;
   const parseOpts: ParseAttributesOptions = { preserveExpressionsAsText: safeMode };
 
   const processChildNode = (parent: Parent, index: number) => {
     const node = parent.children[index];
     if (!node) return;
+    // Descend into container nodes (lists, blockquotes, …) so their html children
+    // are reached. This is the stack's only job now — component bodies are promoted
+    // eagerly by parseMdChildren, so promoted subtrees never need re-queuing.
     if ('children' in node && Array.isArray(node.children)) {
       stack.push(node as Parent);
     }
@@ -237,7 +242,7 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
 
       const remainingContent = contentAfterTag.trim();
       if (remainingContent) {
-        parseSibling(stack, parent, index, remainingContent, safeMode);
+        parseSibling(parent, index, remainingContent, safeMode);
       }
       return;
     }
@@ -285,11 +290,11 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
       });
       substituteNodeWithMdxNode(parent, index, componentNode);
 
-      // Re-queue whichever side may hold further components.
+      // Trailing content after the close becomes siblings; parseMdChildren has
+      // already promoted any components nested inside both sides, so the promoted
+      // subtree itself needs no re-queue.
       if (contentAfterClose) {
-        parseSibling(stack, parent, index, contentAfterClose, safeMode);
-      } else if (componentNode.children.length > 0) {
-        stack.push(componentNode as Parent);
+        parseSibling(parent, index, contentAfterClose, safeMode);
       }
     }
   };
@@ -305,6 +310,11 @@ const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opt
   }
 
   return tree;
+}
+
+const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opts = {}) => (tree, file) => {
+  const source: string | null = file?.value ? String(file.value) : null;
+  return promoteComponentBlocks(tree, !!opts.safeMode, source);
 };
 
 export default mdxishMdxComponentBlocks;

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -82,11 +82,13 @@ const parseMdChildren = (value: string, safeMode: boolean): RootContent[] => {
 // Splices trailing content in as sibling nodes. parseMdChildren has already
 // promoted any components nested among them (bottom-up); the main loop's
 // index-based walk then reaches these spliced siblings and the original children
-// they shift down, so no parent re-queue is needed.
-const parseSibling = (parent: Parent, index: number, sibling: string, safeMode: boolean) => {
+// they shift down, so no parent re-queue is needed. Each spliced subtree is marked
+// `promoted` so the walk doesn't redundantly re-descend into it (its html is gone).
+const parseSibling = (parent: Parent, index: number, sibling: string, safeMode: boolean, promoted: WeakSet<Node>) => {
   const siblingNodes = parseMdChildren(sibling, safeMode) as Node[];
   if (siblingNodes.length > 0) {
     (parent.children as Node[]).splice(index + 1, 0, ...siblingNodes);
+    siblingNodes.forEach(siblingNode => promoted.add(siblingNode));
   }
 };
 
@@ -169,13 +171,16 @@ const substituteNodeWithMdxNode = (parent: Parent, index: number, mdxNode: MdxJs
 function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string | null): Parent {
   const stack: Parent[] = [tree];
   const parseOpts: ParseAttributesOptions = { preserveExpressionsAsText: safeMode };
+  // Subtrees a nested parseMdChildren already promoted wholesale (spliced siblings):
+  // re-descending them finds no html to promote, so skip them.
+  const promoted = new WeakSet<Node>();
 
   const processChildNode = (parent: Parent, index: number) => {
     const node = parent.children[index];
     if (!node) return;
     // Descend into container nodes (lists, blockquotes, …) so their html children
-    // are reached.
-    if ('children' in node && Array.isArray(node.children)) {
+    // are reached — unless the subtree was already promoted upstream.
+    if ('children' in node && Array.isArray(node.children) && !promoted.has(node)) {
       stack.push(node as Parent);
     }
 
@@ -242,7 +247,7 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
 
       const remainingContent = contentAfterTag.trim();
       if (remainingContent) {
-        parseSibling(parent, index, remainingContent, safeMode);
+        parseSibling(parent, index, remainingContent, safeMode, promoted);
       }
       return;
     }
@@ -272,23 +277,25 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
         parsedChildren = (parsedChildren[0] as Parent).children as MdxJsxFlowElement['children'];
         unwrappedSoleParagraph = true;
       }
+      // Without trailing content the whole node position is correct. With it, end
+      // precisely at the closing tag — preferring source offsets when available (the
+      // node's value strips blockquote/list prefixes), else the consumed span.
+      let endPosition = node.position;
+      if (contentAfterClose) {
+        endPosition = source
+          ? positionEndingAtClosingTagInSource(node.position, closingTagStr, source)
+          : positionEndingAtConsumed(
+              node.position,
+              value,
+              leadingWhitespace + openingTagEnd + closingTagIndex + closingTagStr.length,
+            );
+      }
       const componentNode = createComponentNode({
         tag,
         attributes,
         children: parsedChildren,
         startPosition: node.position,
-        // With trailing content, end precisely at the closing tag. Prefer source
-        // offsets when available (the node's value strips blockquote/list
-        // prefixes); otherwise fall back to the whole node position.
-        endPosition: contentAfterClose
-          ? source
-            ? positionEndingAtClosingTagInSource(node.position, closingTagStr, source)
-            : positionEndingAtConsumed(
-                node.position,
-                value,
-                leadingWhitespace + openingTagEnd + closingTagIndex + closingTagStr.length,
-              )
-          : node.position,
+        endPosition,
       });
       substituteNodeWithMdxNode(parent, index, componentNode);
 
@@ -302,7 +309,7 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
       // already promoted any components nested inside both sides, so the promoted
       // subtree itself needs no re-queue.
       if (contentAfterClose) {
-        parseSibling(parent, index, contentAfterClose, safeMode);
+        parseSibling(parent, index, contentAfterClose, safeMode, promoted);
       }
     }
   };

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -20,7 +20,7 @@ import { jsxTable } from '../../../../lib/micromark/jsx-table';
 import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
 import { magicBlock } from '../../../../lib/micromark/magic-block';
 import { mdxComponent } from '../../../../lib/micromark/mdx-component';
-import { HTML_FIGURE_TAGS } from '../../../../utils/common-html-words';
+import { NON_REPARSED_BODY_TAGS } from '../../../../utils/common-html-words';
 import { walkTags } from '../tables/tag-walker';
 import { tableTags } from '../tables/utils';
 
@@ -112,7 +112,7 @@ export const toMdxJsxTextElement = (
 // Raw-body tags (pre/script/style/textarea) must stay byte-exact; table
 // structure (`table` + `tableTags`) is owned by `mdxishTables` and figures by
 // `mdxishJsxToMdast`, both of which run later on raw html nodes.
-const NON_PROMOTABLE_PLAIN_TAGS = new Set<string>([...htmlRawNames, ...tableTags, 'table', ...HTML_FIGURE_TAGS]);
+const NON_PROMOTABLE_PLAIN_TAGS = new Set<string>([...htmlRawNames, ...tableTags, 'table', ...NON_REPARSED_BODY_TAGS]);
 export const NESTED_TABLE_RE = /<table[\s>]/i;
 export const isMarkdownPromotableHtmlTag = (tag: string): boolean => !NON_PROMOTABLE_PLAIN_TAGS.has(tag);
 

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -20,6 +20,7 @@ import { jsxTable } from '../../../../lib/micromark/jsx-table';
 import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
 import { magicBlock } from '../../../../lib/micromark/magic-block';
 import { mdxComponent } from '../../../../lib/micromark/mdx-component';
+import { HTML_FIGURE_TAGS } from '../../../../utils/common-html-words';
 import { walkTags } from '../tables/tag-walker';
 import { tableTags } from '../tables/utils';
 
@@ -111,7 +112,7 @@ export const toMdxJsxTextElement = (
 // Raw-body tags (pre/script/style/textarea) must stay byte-exact; table
 // structure (`table` + `tableTags`) is owned by `mdxishTables` and figures by
 // `mdxishJsxToMdast`, both of which run later on raw html nodes.
-const NON_PROMOTABLE_PLAIN_TAGS = new Set<string>([...htmlRawNames, ...tableTags, 'table', 'figure', 'figcaption']);
+const NON_PROMOTABLE_PLAIN_TAGS = new Set<string>([...htmlRawNames, ...tableTags, 'table', ...HTML_FIGURE_TAGS]);
 export const NESTED_TABLE_RE = /<table[\s>]/i;
 export const isMarkdownPromotableHtmlTag = (tag: string): boolean => !NON_PROMOTABLE_PLAIN_TAGS.has(tag);
 

--- a/utils/common-html-words.ts
+++ b/utils/common-html-words.ts
@@ -111,11 +111,14 @@ export const HTML_TABLE_STRUCTURE_TAGS = new Set([
 ]);
 
 /**
- * Figure tags. Their bodies are owned by the figure reassembly transform
- * (`mdxishJsxToMdast`), which expects raw html nodes, so the markdown pipeline
- * must neither re-parse their bodies nor claim markdown islands inside them.
+ * Tags whose bodies a later mdxish transform keeps raw and never re-parses as
+ * markdown. Both layers depend on this property, not on the tags being figures:
+ * the transformer treats them as non-promotable, and the tokenizer must not claim
+ * markdown islands inside them (a claimed island would never be re-parsed and would
+ * leak as literal text). Currently just the figure tags, whose bodies are owned by
+ * the figure reassembly transform (`mdxishJsxToMdast`).
  */
-export const HTML_FIGURE_TAGS = new Set(['figure', 'figcaption']);
+export const NON_REPARSED_BODY_TAGS = new Set(['figure', 'figcaption']);
 
 /**
  * The two HTML "foreign content" namespaces: SVG and MathML. Their descendants

--- a/utils/common-html-words.ts
+++ b/utils/common-html-words.ts
@@ -111,6 +111,13 @@ export const HTML_TABLE_STRUCTURE_TAGS = new Set([
 ]);
 
 /**
+ * Figure tags. Their bodies are owned by the figure reassembly transform
+ * (`mdxishJsxToMdast`), which expects raw html nodes, so the markdown pipeline
+ * must neither re-parse their bodies nor claim markdown islands inside them.
+ */
+export const HTML_FIGURE_TAGS = new Set(['figure', 'figcaption']);
+
+/**
  * The two HTML "foreign content" namespaces: SVG and MathML. Their descendants
  * (`<path>`, `<mrow>`, …) are namespaced XML, not HTML tags or components. A closed
  * set per the HTML spec, so transforms can treat these roots as opaque islands.


### PR DESCRIPTION
| 🎫 Resolve [RM-17560](https://linear.app/readme-io/issue/RM-17560/code-samples-in-details-tags-break-in-mdxish) | 🤖 Prepared with `/prep-pr` |
| :---: | :---: |

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

Fenced code samples and headings nested inside deeply-indented plain HTML wrappers (`<ol>` → `<li>` → `<details>`) rendered as a broken indented-code block in MDXish, while MDX rendered them correctly. The cosmetic nesting indent (6 columns) tripped CommonMark's 4-column indented-code rule, swallowing the heading, the ` ``` ` fence markers, and even the `</details>` closer.

**Fix (two parts):**

- **Tokenizer** (`lib/micromark/mdx-component/syntax.ts`): a plain-block claim now keeps claiming across a blank line when the markdown island is 4+ columns deep **and** nested under prior body content — instead of bailing to CommonMark, which mis-parses it as indented code.
- **Transform** (`processor/transform/mdxish/components/mdx-blocks.ts`): component bodies are promoted **bottom-up**, so an outer wrapper sees the markdown surfaced from a child that was claimed whole (e.g. `<li>` inside `<ol>`) before its `containsMarkdownConstruct` gate runs.

**Cleanup (from review):**

- Consolidated on the eager promotion recursion and removed the now-redundant lazy stack re-queue (verified: load-bearing on `next`, fully redundant here).
- Extracted the two self-contained partial tokenizers into `continuation-checks.ts`, bringing `syntax.ts` back under 1,000 lines.

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ] Verify the attached raw markdown in RM-17560 renders correctly with the mdxish engine

## 📸 Screenshot or Loom

| Before | After | 
| --- | --- |
| <img width="5132" height="2736" alt="CleanShot 2026-07-20 at 11 32 01@2x" src="https://github.com/user-attachments/assets/e9e0bba4-8ae0-42b1-8a16-1402a1716c1e" /> | <img width="5120" height="2314" alt="CleanShot 2026-07-20 at 11 31 17@2x" src="https://github.com/user-attachments/assets/349d9b05-348b-4fb5-90e2-ee0fd468bba7" /> |

