### PR TITLE
feat(mdxish): disable 4+ code conversion commonmark behaviour

### DIFF
--- a/__tests__/lib/mdxish/indented-code-disabled.test.ts
+++ b/__tests__/lib/mdxish/indented-code-disabled.test.ts
@@ -1,0 +1,91 @@
+import { toHtml } from 'hast-util-to-html';
+
+import { mdast } from '../../../index';
+import { mdxish } from '../../../lib';
+import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
+
+// Test for mdxish disabling CommonMark's indented-code construct, matching MDX
+// (`micromark-extension-mdx-md`): 4+ column indentation is readability
+// formatting, never code. Code requires an explicit fence.
+describe('indented code blocks are disabled (CX-3739)', () => {
+  it('renders a top-level 4-space-indented block as prose, not code', () => {
+    const md = 'intro paragraph\n\n    const literal = 1;\n\nafter paragraph';
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'code')).toBeNull();
+    expect(findAllElementsByTagName(ast, 'p')).toHaveLength(3);
+    expect(findAllElementsByTagName(ast, 'p')[1]).toMatchObject({
+      children: [{ type: 'text', value: 'const literal = 1;' }],
+    });
+  });
+
+  it('renders a tab-indented block as prose, not code', () => {
+    const md = 'intro paragraph\n\n\tconst literal = 1;';
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findAllElementsByTagName(ast, 'p')[1]).toMatchObject({
+      children: [{ type: 'text', value: 'const literal = 1;' }],
+    });
+  });
+
+  it('still renders an explicit fence as code', () => {
+    const md = 'intro paragraph\n\n```js\nconst literal = 1;\n```';
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'code')).toMatchObject({
+      properties: { className: ['language-js'] },
+      children: [{ type: 'text', value: 'const literal = 1;\n' }],
+    });
+  });
+
+  it('still renders a fence indented as list-item continuation as code', () => {
+    const md = '1. Install the CLI:\n\n    ```shell\n    npm install -g acme\n    ```';
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'li')).not.toBeNull();
+    expect(findElementByTagName(ast, 'code')).toMatchObject({
+      properties: { className: ['language-shell'] },
+      children: [{ type: 'text', value: 'npm install -g acme\n' }],
+    });
+  });
+
+  it('renders a 4+ column island inside a re-parsed component body as prose', () => {
+    // Component bodies re-parse through buildInlineMdProcessor, which carries
+    // its own micromark extension list — this covers that second wiring site.
+    const md = `<Accordion title="Details">
+  Intro line
+
+      deeply indented line
+</Accordion>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'code')).toBeNull();
+    expect(toHtml(ast)).toContain('deeply indented line');
+  });
+
+  it('renders an indented island inside a blockquote as prose', () => {
+    const md = '> quoted intro\n>\n>     indented under quote';
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    const blockquote = findElementByTagName(ast, 'blockquote');
+    expect(toHtml(blockquote!)).toContain('indented under quote');
+  });
+
+  it('matches MDX, which also parses the indented block as a paragraph', () => {
+    const md = 'intro paragraph\n\n    const literal = 1;\n\nafter paragraph';
+
+    const tree = mdast(md, { missingComponents: 'ignore' });
+
+    expect(tree.children.map(child => child.type)).toStrictEqual(['paragraph', 'paragraph', 'paragraph']);
+  });
+});

--- a/__tests__/lib/mdxish/indented-code-disabled.test.ts
+++ b/__tests__/lib/mdxish/indented-code-disabled.test.ts
@@ -88,4 +88,47 @@ describe('indented code blocks are disabled (CX-3739)', () => {
 
     expect(tree.children.map(child => child.type)).toStrictEqual(['paragraph', 'paragraph', 'paragraph']);
   });
+
+  // With indented code disabled, an indented line is ordinary markdown, so inline
+  // emphasis parses and escaped markers stay literal — exactly as at column 0, and
+  // identically in both engines. Covers `*`/`_` and their escapes.
+  describe('indented prose still parses inline markdown, not code', () => {
+    it.each([
+      ['asterisk', '*this*'],
+      ['underscore', '_this_'],
+    ])('renders an indented %s emphasis as <em> (mdxish)', (_name, marker) => {
+      const ast = mdxish(`intro\n\n    look at ${marker} word\n\nafter`);
+
+      expect(findElementByTagName(ast, 'pre')).toBeNull();
+      expect(findElementByTagName(ast, 'em')).toMatchObject({ children: [{ type: 'text', value: 'this' }] });
+    });
+
+    it('honors escaped emphasis markers in indented prose (mdxish)', () => {
+      const ast = mdxish('intro\n\n    literal \\*stars\\* and \\_unders\\_\n\nafter');
+
+      expect(findElementByTagName(ast, 'pre')).toBeNull();
+      expect(findElementByTagName(ast, 'em')).toBeNull();
+      expect(toHtml(ast)).toContain('literal *stars* and _unders_');
+    });
+
+    it('matches MDX: indented emphasis parses as emphasis, not code', () => {
+      const tree = mdast('intro\n\n    look at *this* word', { missingComponents: 'ignore' });
+
+      expect(tree.children.map(child => child.type)).toStrictEqual(['paragraph', 'paragraph']);
+      expect(tree.children[1]).toMatchObject({
+        children: [
+          { type: 'text', value: 'look at ' },
+          { type: 'emphasis', children: [{ type: 'text', value: 'this' }] },
+          { type: 'text', value: ' word' },
+        ],
+      });
+    });
+
+    it('matches MDX: escaped markers in indented prose stay literal', () => {
+      const tree = mdast('intro\n\n    literal \\*stars\\*', { missingComponents: 'ignore' });
+
+      expect(tree.children.map(child => child.type)).toStrictEqual(['paragraph', 'paragraph']);
+      expect(tree.children[1]).toMatchObject({ children: [{ type: 'text', value: 'literal *stars*' }] });
+    });
+  });
 });

--- a/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
@@ -101,9 +101,9 @@ describe('markdown inside indented plain HTML blocks', () => {
     expect(findAllElementsByTagName(ast, 'a')).toHaveLength(2);
   });
 
-  it('keeps content indented 4+ columns relative to its nested wrapper as an indented code block', () => {
-    // Relative indentation is preserved when component bodies are dedented, so
-    // content 4+ columns deeper than the surrounding tags still parses as code.
+  it('renders content indented 4+ columns inside a nested wrapper as prose, not code (CX-3739)', () => {
+    // Indented code blocks are disabled (matching MDX), so deep readability
+    // indentation never becomes code — code requires an explicit fence.
     const md = `<Column>
   <div>
 
@@ -114,7 +114,8 @@ describe('markdown inside indented plain HTML blocks', () => {
 
     const ast = mdxish(md);
 
-    expect(findElementByTagName(ast, 'code')).not.toBeNull();
+    expect(findElementByTagName(ast, 'code')).toBeNull();
+    expect(toHtml(ast)).toContain("const literal = 'code';");
   });
 
   it('does not treat deeply indented content as code when nested under unindented HTML', () => {

--- a/__tests__/regression/__snapshots__/equivalence.test.ts.snap
+++ b/__tests__/regression/__snapshots__/equivalence.test.ts.snap
@@ -246,6 +246,22 @@ exports[`MDX↔MDXish equivalence > htmlblock-in-table 1`] = `
 }
 `;
 
+exports[`MDX↔MDXish equivalence > indented-content-is-not-code 1`] = `
+{
+  "changes": [
+    {
+      "kind": "tag",
+      "left": "details",
+      "path": "/details[1]",
+      "right": "div",
+      "severity": "structural",
+    },
+  ],
+  "severity": "structural",
+  "status": "differ",
+}
+`;
+
 exports[`MDX↔MDXish equivalence > indented-foreign-html-tags 1`] = `
 {
   "changes": [

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -213,6 +213,64 @@ exports[`Render engine regressions tests > htmlblock-in-table (mdxish) 1`] = `
 <div class="readme-tailwind"><div class="rdmd-table"><div class="rdmd-table-inner"><table><tbody><tr><td><strong>bold</strong> still works</td><td><div class="rdmd-html"><div style="color: red;">Hello</div></div></td></tr></tbody></table></div></div></div>"
 `;
 
+exports[`Render engine regressions tests > indented-content-is-not-code (mdx) 1`] = `
+"<div class="card"><p>Block two — indented 6 spaces after a blank line, so it renders as a raw code block instead of HTML.</p></div>
+<details class="Accordion"><summary class="Accordion-title"><i class="Accordion-toggleIcon fa fa-regular fa-chevron-right"></i><i class="Accordion-icon fa-duotone fa-solid fa-info-circle"></i></summary><div class="Accordion-content"><ol start="4">
+<li>
+<p><strong>Get All Files from Path</strong></p>
+</li>
+<li>
+<p><strong>Suppressname lookup</strong>:
+<em><code class="rdmd-code lang-undefined theme-undefined">\\\\&lt;full_server_NetBIOS_name&gt;\\path\\to\\file.ext</code></em></p>
+</li>
+</ol><ul>
+<li>Wildcards are supported in file names as follows:<!-- -->
+<ul>
+<li><strong>Suppress name lookup</strong> must be enabled.</li>
+</ul>
+</li>
+</ul><ol start="6">
+<li><strong>Use Authentication</strong></li>
+</ol></div></details>
+<p>Fenced code still works, including when indented inside a list:</p>
+<ol>
+<li>
+<p>Install the CLI:</p>
+<div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="bash">Bash</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-shell theme-undefined" data-lang="shell">npm install</code></pre></div></div>
+</li>
+</ol>"
+`;
+
+exports[`Render engine regressions tests > indented-content-is-not-code (mdxish) 1`] = `
+"      <div class="card">
+        <p>Block two — indented 6 spaces after a blank line, so it renders as a raw code block instead of HTML.</p>
+      </div>
+<div class="readme-tailwind"><details class="Accordion"><summary class="Accordion-title"><i class="Accordion-toggleIcon fa fa-regular fa-chevron-right"></i><i class="Accordion-icon fa-duotone fa-solid fa-info-circle"></i></summary><div class="Accordion-content"><ol start="4">
+<li>
+<p><strong>Get All Files from Path</strong></p>
+</li>
+<li>
+<p><strong>Suppressname lookup</strong>:<br/>
+<em><code class="rdmd-code lang-undefined theme-undefined">\\\\&lt;full_server_NetBIOS_name&gt;\\path\\to\\file.ext</code></em></p>
+</li>
+</ol><ul>
+<li>Wildcards are supported in file names as follows:
+<ul>
+<li><strong>Suppress name lookup</strong> must be enabled.</li>
+</ul>
+</li>
+</ul><ol start="6">
+<li><strong>Use Authentication</strong></li>
+</ol></div></details></div>
+<p>Fenced code still works, including when indented inside a list:</p>
+<ol>
+<li>
+<p>Install the CLI:</p>
+<div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="bash">Bash</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-shell theme-undefined" data-lang="shell">npm install</code></pre></div></div>
+</li>
+</ol>"
+`;
+
 exports[`Render engine regressions tests > indented-foreign-html-tags (mdx) 1`] = `
 "<h2 class="heading heading-2 header-scroll"><div class="heading-anchor anchor waypoint" id="platform-resources"></div><div class="heading-text">Platform resources</div><a aria-label="Skip link to Platform resources" class="heading-anchor-icon fa fa-regular fa-anchor" href="#platform-resources"></a></h2>
 <div class="wrike-cards-grid"><a href="/docs/overview" class="wrike-nav-card"><div class="wrike-card-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#0A615A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"></path><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"></path></svg></div><div class="wrike-card-title">Guides</div><div class="wrike-card-desc">Step-by-step tutorials for authentication, webhooks, custom integrations, and common recipes.</div><div class="wrike-card-link">Read the guides <span class="wrike-arrow">→</span></div></a><a href="/reference" class="wrike-nav-card"><div class="wrike-card-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#0A615A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg></div><div class="wrike-card-title">Random 7</div><div class="wrike-card-desc">Random 8</div><div class="wrike-card-link">View Random 9<span class="wrike-arrow">→</span></div></a><a href="/docs/random-10" class="wrike-nav-card"><div class="wrike-card-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#0A615A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2"></rect><path d="M9 9h6v6H9z"></path><path d="M9 1v3"></path><path d="M15 1v3"></path><path d="M9 20v3"></path><path d="M15 20v3"></path><path d="M20 9h3"></path><path d="M20 15h3"></path><path d="M1 9h3"></path><path d="M1 15h3"></path></svg></div><div class="wrike-card-title">Random 5</div><div class="wrike-card-desc">Random 4</div><div class="wrike-card-link">Set up Random 6<span class="wrike-arrow">→</span></div></a><a href="/docs/datahub-overview" class="wrike-nav-card"><div class="wrike-card-icon"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#0A615A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="5" rx="9" ry="3"></ellipse><path d="M21 12c0 1.66-4 3-9 3s-9-1.34-9-3"></path><path d="M3 5v14c0 1.66 4 3 9 3s9-1.34 9-3V5"></path></svg></div><div class="wrike-card-title">Random 1</div><div class="wrike-card-desc">Random 2</div><div class="wrike-card-link">Explore Random 3<span class="wrike-arrow">→</span></div></a></div>"

--- a/__tests__/regression/fixtures/indented-content-is-not-code/README.md
+++ b/__tests__/regression/fixtures/indented-content-is-not-code/README.md
@@ -1,0 +1,31 @@
+# `indented-content-is-not-code` Fixture
+
+CommonMark's indented-code-block rule (4+ columns → literal `<pre>` code) is
+disabled in MDXish, matching MDX (`micromark-extension-mdx-md`), where indented
+code does not exist and code must be fenced. This fixture locks in the two
+customer shapes from CX-3739:
+
+- A top-level `<div>` card indented 6 spaces, which rendered as one raw code
+  block instead of HTML.
+- An `<Accordion>` body whose 4+-column list items (a hand-numbered ordered
+  list with nested bullets) fragmented into `CodeTabs` code blocks.
+
+It also carries a fenced-code-inside-a-list case to pin that explicit fences —
+the only remaining way to produce code — keep working at list-continuation
+indentation.
+
+Strict MDX renders this body as well (MDX has never had indented code), so the
+snapshots double as an engine-parity check for the disabled rule.
+
+## Source bugs
+
+- CX-3739 — indented raw HTML renders as a code block under MDXish
+
+## What flips this fixture
+
+Re-enabling the `codeIndented` construct (removing `disableIndentedCode` in
+`processor/utils.ts` from the parser in `lib/mdxish.ts` or the component-body
+re-parser in `processor/transform/mdxish/components/utils.ts`), or changes to
+how `<Accordion>` bodies are dedented and re-parsed
+(`safeDeindent`/`parseMdChildren` in
+`processor/transform/mdxish/components/mdx-blocks.ts`).

--- a/__tests__/regression/fixtures/indented-content-is-not-code/body.md
+++ b/__tests__/regression/fixtures/indented-content-is-not-code/body.md
@@ -1,0 +1,25 @@
+      <div className="card">
+        <p>Block two — indented 6 spaces after a blank line, so it renders as a raw code block instead of HTML.</p>
+      </div>
+
+
+
+<Accordion icon="fa-info-circle">
+  4. **Get All Files from Path**
+
+  5. **Suppressname lookup**:
+     *`\\<full_server_NetBIOS_name>\path\to\file.ext`*
+
+    * Wildcards are supported in file names as follows:
+      * **Suppress name lookup** must be enabled.
+
+6. **Use Authentication**
+</Accordion>
+
+Fenced code still works, including when indented inside a list:
+
+1. Install the CLI:
+
+   ```bash
+   npm install
+   ```

--- a/__tests__/regression/fixtures/indented-content-is-not-code/context.json
+++ b/__tests__/regression/fixtures/indented-content-is-not-code/context.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "defaults": [],
+    "user": {}
+  },
+  "glossary": []
+}

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -60,7 +60,7 @@ import { terminateHtmlFlowBlocks } from '../processor/transform/mdxish/terminate
 import variablesCodeResolver from '../processor/transform/mdxish/variables-code';
 import variablesTextTransformer from '../processor/transform/mdxish/variables-text';
 import tailwindTransformer from '../processor/transform/tailwind';
-import { jsxAcornParser } from '../processor/utils';
+import { disableIndentedCode, jsxAcornParser } from '../processor/utils';
 
 import { emptyTaskListItemFromMarkdown } from './mdast-util/empty-task-list-item';
 import { gemojiFromMarkdown } from './mdast-util/gemoji';
@@ -166,6 +166,7 @@ export function mdxishAstProcessor(mdContent: string, opts: MdxishOpts = {}) {
   const mdxExprTextOnly: Extension = mdxExpressionLenient();
 
   const micromarkExts = [
+    disableIndentedCode,
     jsxTable(),
     magicBlock(),
     mdxComponent(),

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -21,6 +21,7 @@ import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
 import { magicBlock } from '../../../../lib/micromark/magic-block';
 import { mdxComponent } from '../../../../lib/micromark/mdx-component';
 import { NON_REPARSED_BODY_TAGS } from '../../../../utils/common-html-words';
+import { disableIndentedCode } from '../../../utils';
 import { walkTags } from '../tables/tag-walker';
 import { tableTags } from '../tables/utils';
 
@@ -31,7 +32,7 @@ const buildInlineMdProcessor = (safeMode: boolean) => {
   // body (e.g. a `<Callout>`) is captured as one html node. Without it, blank
   // lines between rows let CommonMark HTML block type 6 fragment the table and
   // its rows spill out as text / indented code blocks (CX-3705).
-  const micromarkExts = [jsxTable(), mdxComponent(), gemoji(), legacyVariable(), magicBlock()];
+  const micromarkExts = [disableIndentedCode, jsxTable(), mdxComponent(), gemoji(), legacyVariable(), magicBlock()];
   const fromMarkdownExts = [
     jsxTableFromMarkdown(),
     mdxComponentFromMarkdown(),

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -7,6 +7,7 @@ import type {
   MdxJsxAttributeValueExpression,
   MdxJsxAttributeValueExpressionData,
 } from 'mdast-util-mdx-jsx';
+import type { Extension } from 'micromark-util-types';
 import type { Point } from 'unist';
 
 import { Parser } from 'acorn';
@@ -21,6 +22,14 @@ import mdast from '../lib/mdast';
  * to parse expressions containing JSX.
  */
 export const jsxAcornParser = Parser.extend(acornJsx());
+
+/**
+ * Disables CommonMark's indented-code-block construct (4+ spaces)
+ * The micromark tokenizers use follow the CommonMark specification: https://spec.commonmark.org/0.28/#indented-code-blocks
+ * So any lines indented 4+ spaces are considered as a code block,
+ * which is unexpected from users that used MDX before.
+ */
+export const disableIndentedCode = { disable: { null: ['codeIndented'] } } satisfies Extension;
 
 /**
  * Evaluate a JavaScript expression source and return its value.


### PR DESCRIPTION
| 🎫 Resolve CX-3739, CX-3736, RM-17654 |
| :-----------------: |

## 🎯 What does this PR do?

One of the bigger source of issues for MDXish is that it uses the commonmark indentation rule which causes 4+ indented lines to be parsed as code, which MDX didn’t cause and has caused several complaints.  

At this point, it might be worth just turning that behaviour off since the MDX behaviour is the more excpected one & there’s rarer cases of it being used in real docs

- **The fix:** turn the rule off at the parser via a `disableIndentedCode` micromark extension, in both the main parser and the component-body re-parser.
- **Scope:** Had a look if this could have solved previous HTML line indent problems and this doesn't retroactively delete the earlier mitigations — most also guard blank-line HTML fragmentation, a separate & but related problem. However, there are a few parts of the MDX tokenizer that is no longer needed (~50 lines) so we can make it a bit simpler, will do in a follow up PR
- **Tradeoff:** deliberately breaks from legacy rdmd — bare 4-space indented code no longer renders as code (renders as prose, like RMDX already does). But at this point I think engine parity + killing this bug class is worth losing a rarely-intended legacy behavior

**Note:** This PR focuses on adding the behaviour on the top level doc & component unified pipelines. There's a few others that would be good to add to cover some edge cases as well, but not as high priority and I think can be done in a follow up PR to spread the risks.

## 🧪 QA tips

- [ ] Render the `__tests__/regression/fixtures/indented-content-is-not-code/` body: indented `<div>` renders as HTML, `<Accordion>` list items as nested lists — no `<pre>`/CodeTabs.
- [ ] Fenced code unaffected, including fences indented inside list items.
- [ ] Expected change: a doc using bare 4-space indentation for code now renders it as prose.
- [ ] Unit coverage in `__tests__/lib/mdxish/indented-code-disabled.test.ts`; fixture snapshots double as an MDX↔MDXish parity check.

## 📸 Screenshot or Loom

- Before/after in the `indented-content-is-not-code` fixture snapshots: the indented `<div>` previously serialized as `<pre><code>`, now as literal HTML.