### PR TITLE
chore(mdxish): unify sub-pipelines & remove dead indentation logic

### DIFF
--- a/.claude/context/MDXish/Processor Overview.md
+++ b/.claude/context/MDXish/Processor Overview.md
@@ -18,7 +18,7 @@ It applies seven transforms in sequence (the function carries a matching docstri
    Fixes malformed GFM table separator rows — e.g. misplaced alignment colons like `|: ---` → `| :---`. Without this, remarkGfm would fail to recognize the table.
 1. **`collapseForeignContentBlankLines()`**
 
-   Collapses blank lines inside `<svg>`/`<math>` islands. A blank line inside foreign content would otherwise fragment it — the children spill out of the island, where parse5 drops the orphaned foreign tags (#1545).
+   Collapses blank lines inside `<svg>`/`<math>` islands. A blank line inside foreign content would otherwise fragment it — the children spill out as an indented code block once a wrapper re-parses its deindented body (#1545).
 1. **`terminateHtmlFlowBlocks()`**
 
    Inserts blank lines after standalone HTML elements (like `<div>...</div>`) when the next line is regular markdown. CommonMark's HTML flow rules only terminate on blank lines, so without this, the parser would swallow subsequent markdown content into the HTML block token.
@@ -251,8 +251,6 @@ A tokenizer registers itself under one or more **constructs**, keyed by the char
 - **text** — inline constructs that appear inside a paragraph or other text.
 
 A construct may set `concrete: true` to keep container markers (`>` for blockquotes, `-`/`*` for list items) from interrupting it mid-body. Registration **order matters**: micromark tries the last-registered extension first, so the pipeline splices or prepends constructs to win the race for a shared trigger character — e.g. `jsxComment` is prepended so it claims `{/* … */}` before other `{`-openers, and the MDX expression extension is registered *text-only* (`mdxExpressionLenient()`, no flow construct) so a line-leading `{` can't hijack a block that owns it.
-
-The pipeline also **disables** one core CommonMark construct: `disableIndentedCode` (@processor/utils.ts) turns off indented code blocks, matching MDX (`micromark-extension-mdx-md`). Content indented 4+ columns parses as ordinary markdown/HTML at any depth, and code requires an explicit fence (CX-3739). Both the main parser and the component-body re-parser (`getInlineMdProcessor`) register it.
 
 ### Example: magic blocks
 

--- a/.claude/context/MDXish/Processor Overview.md
+++ b/.claude/context/MDXish/Processor Overview.md
@@ -18,7 +18,7 @@ It applies seven transforms in sequence (the function carries a matching docstri
    Fixes malformed GFM table separator rows — e.g. misplaced alignment colons like `|: ---` → `| :---`. Without this, remarkGfm would fail to recognize the table.
 1. **`collapseForeignContentBlankLines()`**
 
-   Collapses blank lines inside `<svg>`/`<math>` islands. A blank line inside foreign content would otherwise fragment it — the children spill out as an indented code block once a wrapper re-parses its deindented body (#1545).
+   Collapses blank lines inside `<svg>`/`<math>` islands. A blank line inside foreign content would otherwise fragment it — the children spill out of the island, where parse5 drops the orphaned foreign tags (#1545).
 1. **`terminateHtmlFlowBlocks()`**
 
    Inserts blank lines after standalone HTML elements (like `<div>...</div>`) when the next line is regular markdown. CommonMark's HTML flow rules only terminate on blank lines, so without this, the parser would swallow subsequent markdown content into the HTML block token.
@@ -251,6 +251,8 @@ A tokenizer registers itself under one or more **constructs**, keyed by the char
 - **text** — inline constructs that appear inside a paragraph or other text.
 
 A construct may set `concrete: true` to keep container markers (`>` for blockquotes, `-`/`*` for list items) from interrupting it mid-body. Registration **order matters**: micromark tries the last-registered extension first, so the pipeline splices or prepends constructs to win the race for a shared trigger character — e.g. `jsxComment` is prepended so it claims `{/* … */}` before other `{`-openers, and the MDX expression extension is registered *text-only* (`mdxExpressionLenient()`, no flow construct) so a line-leading `{` can't hijack a block that owns it.
+
+The pipeline also **disables** one core CommonMark construct: `disableIndentedCode` (@processor/utils.ts) turns off indented code blocks, matching MDX (`micromark-extension-mdx-md`). Content indented 4+ columns parses as ordinary markdown/HTML at any depth, and code requires an explicit fence (CX-3739). Both the main parser and the component-body re-parser (`getInlineMdProcessor`) register it.
 
 ### Example: magic blocks
 

--- a/__tests__/lib/mdxish/indented-code-disabled.test.ts
+++ b/__tests__/lib/mdxish/indented-code-disabled.test.ts
@@ -81,6 +81,62 @@ describe('indented code blocks are disabled (CX-3739)', () => {
     expect(toHtml(blockquote!)).toContain('indented under quote');
   });
 
+  // Magic-block bodies re-parse through `contentParser`/`markdownToHtml` in the
+  // transformer, each carrying its own micromark extension list — this covers
+  // that third wiring site.
+  describe('inside magic block bodies', () => {
+    const callout = (body: string) =>
+      `[block:callout]\n{ "type": "info", "title": "Heads up", "body": "${body}" }\n[/block]`;
+
+    it('renders a 4-space-indented callout body line as prose', () => {
+      const ast = mdxish(callout('Intro line.\\n\\n    const literal = 1;'));
+
+      expect(findElementByTagName(ast, 'pre')).toBeNull();
+      expect(findElementByTagName(ast, 'code')).toBeNull();
+      const paragraphs = findAllElementsByTagName(ast, 'p');
+      expect(paragraphs).toHaveLength(2);
+      expect(paragraphs[1]).toMatchObject({ children: [{ type: 'text', value: 'const literal = 1;' }] });
+    });
+
+    it('renders a tab-indented callout body line as prose', () => {
+      const ast = mdxish(callout('Intro line.\\n\\n\\tconst literal = 2;'));
+
+      expect(findElementByTagName(ast, 'pre')).toBeNull();
+      expect(findAllElementsByTagName(ast, 'p')[1]).toMatchObject({
+        children: [{ type: 'text', value: 'const literal = 2;' }],
+      });
+    });
+
+    it('parses an indented markdown construct in a callout body, not code', () => {
+      const ast = mdxish(callout('Steps:\\n\\n    1. first step\\n    2. second step'));
+
+      expect(findElementByTagName(ast, 'pre')).toBeNull();
+      expect(findElementByTagName(ast, 'ol')).not.toBeNull();
+      expect(findAllElementsByTagName(ast, 'li')).toHaveLength(2);
+    });
+
+    it('still renders an explicit fence in a callout body as code', () => {
+      const ast = mdxish(callout('Intro.\\n\\n```js\\nconst x = 1;\\n```'));
+
+      expect(findElementByTagName(ast, 'code')).toMatchObject({
+        properties: { className: ['language-js'] },
+        children: [{ type: 'text', value: 'const x = 1;\n' }],
+      });
+    });
+
+    it('renders an indented image-caption continuation line as prose', () => {
+      const md =
+        '[block:image]\n{ "images": [ { "image": ["https://x/y.png", "y.png"], "caption": "Cap line.\\n\\n    indented caption tail" } ] }\n[/block]';
+
+      const ast = mdxish(md);
+
+      const figcaption = findElementByTagName(ast, 'figcaption');
+      expect(figcaption).not.toBeNull();
+      expect(toHtml(figcaption!)).toContain('indented caption tail');
+      expect(toHtml(figcaption!)).not.toContain('<pre>');
+    });
+  });
+
   it('matches MDX, which also parses the indented block as a paragraph', () => {
     const md = 'intro paragraph\n\n    const literal = 1;\n\nafter paragraph';
 

--- a/__tests__/lib/mdxish/indented-code-disabled.test.ts
+++ b/__tests__/lib/mdxish/indented-code-disabled.test.ts
@@ -135,6 +135,21 @@ describe('indented code blocks are disabled (CX-3739)', () => {
       expect(toHtml(figcaption!)).toContain('indented caption tail');
       expect(toHtml(figcaption!)).not.toContain('<pre>');
     });
+
+    // The api-header title parser adds its own construct disables. It used to
+    // replace the shared base config rather than extend it, so it was the one
+    // sub-parser still turning an indented line into code (CX-3708).
+    it.each([
+      ['4-space-indented', '    Indented Title'],
+      ['tab-indented', '\\tTabbed Title'],
+    ])('renders a %s api-header title as text, not code', (_label, title) => {
+      const ast = mdxish(`[block:api-header]\n{ "title": "${title}", "level": 2 }\n[/block]`);
+
+      const heading = findElementByTagName(ast, 'h2');
+      expect(heading).not.toBeNull();
+      expect(toHtml(heading!)).not.toContain('<code>');
+      expect(findElementByTagName(ast, 'pre')).toBeNull();
+    });
   });
 
   it('matches MDX, which also parses the indented block as a paragraph', () => {

--- a/__tests__/lib/mdxish/indented-code-disabled.test.ts
+++ b/__tests__/lib/mdxish/indented-code-disabled.test.ts
@@ -88,47 +88,4 @@ describe('indented code blocks are disabled (CX-3739)', () => {
 
     expect(tree.children.map(child => child.type)).toStrictEqual(['paragraph', 'paragraph', 'paragraph']);
   });
-
-  // With indented code disabled, an indented line is ordinary markdown, so inline
-  // emphasis parses and escaped markers stay literal — exactly as at column 0, and
-  // identically in both engines. Covers `*`/`_` and their escapes.
-  describe('indented prose still parses inline markdown, not code', () => {
-    it.each([
-      ['asterisk', '*this*'],
-      ['underscore', '_this_'],
-    ])('renders an indented %s emphasis as <em> (mdxish)', (_name, marker) => {
-      const ast = mdxish(`intro\n\n    look at ${marker} word\n\nafter`);
-
-      expect(findElementByTagName(ast, 'pre')).toBeNull();
-      expect(findElementByTagName(ast, 'em')).toMatchObject({ children: [{ type: 'text', value: 'this' }] });
-    });
-
-    it('honors escaped emphasis markers in indented prose (mdxish)', () => {
-      const ast = mdxish('intro\n\n    literal \\*stars\\* and \\_unders\\_\n\nafter');
-
-      expect(findElementByTagName(ast, 'pre')).toBeNull();
-      expect(findElementByTagName(ast, 'em')).toBeNull();
-      expect(toHtml(ast)).toContain('literal *stars* and _unders_');
-    });
-
-    it('matches MDX: indented emphasis parses as emphasis, not code', () => {
-      const tree = mdast('intro\n\n    look at *this* word', { missingComponents: 'ignore' });
-
-      expect(tree.children.map(child => child.type)).toStrictEqual(['paragraph', 'paragraph']);
-      expect(tree.children[1]).toMatchObject({
-        children: [
-          { type: 'text', value: 'look at ' },
-          { type: 'emphasis', children: [{ type: 'text', value: 'this' }] },
-          { type: 'text', value: ' word' },
-        ],
-      });
-    });
-
-    it('matches MDX: escaped markers in indented prose stay literal', () => {
-      const tree = mdast('intro\n\n    literal \\*stars\\*', { missingComponents: 'ignore' });
-
-      expect(tree.children.map(child => child.type)).toStrictEqual(['paragraph', 'paragraph']);
-      expect(tree.children[1]).toMatchObject({ children: [{ type: 'text', value: 'literal *stars*' }] });
-    });
-  });
 });

--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -505,6 +505,20 @@ ${JSON.stringify(
         expect(html).toContain('<em>foo</em>');
       });
 
+      it('renders a 4-space-indented cell line as prose, not a code block (CX-3739)', () => {
+        const html = getCellHtml('Detail.\n\n    const value = 1;');
+        expect(html).not.toContain('<pre>');
+        expect(html).not.toContain('<code>');
+        expect(html).toContain('const value = 1;');
+      });
+
+      it('does not render an indented leading dash as a bullet list in a cell', () => {
+        const html = getCellHtml('Intro\n\n    - foo');
+        expect(html).not.toContain('<ul>');
+        expect(html).not.toContain('<li>');
+        expect(html).toContain('- foo');
+      });
+
       it('renders block-level HTML as list when it appears inline after text (e.g. "Note: <ul><li>...</li></ul>")', () => {
         const input =
           'Note the following: <ul><li>A **Live** status means the domain is externally accessible (HTTP request passes)</li><li>A **Not Live** status means the domain is not exposed and cannot be reached from the internet (HTTP request fails)</li></ul>';

--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -505,20 +505,6 @@ ${JSON.stringify(
         expect(html).toContain('<em>foo</em>');
       });
 
-      it('renders a 4-space-indented cell line as prose, not a code block (CX-3739)', () => {
-        const html = getCellHtml('Detail.\n\n    const value = 1;');
-        expect(html).not.toContain('<pre>');
-        expect(html).not.toContain('<code>');
-        expect(html).toContain('const value = 1;');
-      });
-
-      it('does not render an indented leading dash as a bullet list in a cell', () => {
-        const html = getCellHtml('Intro\n\n    - foo');
-        expect(html).not.toContain('<ul>');
-        expect(html).not.toContain('<li>');
-        expect(html).toContain('- foo');
-      });
-
       it('renders block-level HTML as list when it appears inline after text (e.g. "Note: <ul><li>...</li></ul>")', () => {
         const input =
           'Note the following: <ul><li>A **Live** status means the domain is externally accessible (HTTP request passes)</li><li>A **Not Live** status means the domain is not exposed and cannot be reached from the internet (HTTP request fails)</li></ul>';

--- a/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
@@ -5,7 +5,7 @@ import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
 
 // Markdown inside plain lowercase HTML must parse even when indented for
 // readability — at top level and nested inside custom components (whose bodies are
-// re-parsed). Guards HTML-flow swallowing and 4+-column indented-code fallout.
+// re-parsed). Guards HTML-flow swallowing and deep-indent fragmentation fallout.
 describe('markdown inside indented plain HTML blocks', () => {
   it('parses indented markdown in a <div> nested inside <Columns>/<Column>', () => {
     const md = `<Columns layout="auto">
@@ -86,6 +86,21 @@ describe('markdown inside indented plain HTML blocks', () => {
     expect(findElementByTagName(ast, 'pre')).toBeNull();
     expect(findElementByTagName(ast, 'h2')).not.toBeNull();
     expect(findElementByTagName(ast, 'a')).toMatchObject({ properties: { href: 'https://example.com' } });
+  });
+
+  it('parses markdown directly after a deeply indented (4+ col) opening tag', () => {
+    const md = `<div>
+    <section>
+    ## Deep heading
+    </section>
+</div>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'h2')).toMatchObject({
+      children: [{ type: 'text', value: 'Deep heading' }],
+    });
   });
 
   it('keeps deeply indented (4+ columns) HTML lines inside a wrapper as HTML (#1344)', () => {

--- a/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
@@ -98,7 +98,11 @@ describe('markdown inside indented plain HTML blocks', () => {
     const ast = mdxish(md);
 
     expect(findElementByTagName(ast, 'pre')).toBeNull();
-    expect(findElementByTagName(ast, 'h2')).toMatchObject({
+
+    // The heading must re-nest inside the wrapper, not float out beside it.
+    const section = findElementByTagName(ast, 'section');
+    expect(section).not.toBeNull();
+    expect(findElementByTagName(section!, 'h2')).toMatchObject({
       children: [{ type: 'text', value: 'Deep heading' }],
     });
   });

--- a/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
@@ -5,7 +5,7 @@ import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
 
 // Markdown inside plain lowercase HTML must parse even when indented for
 // readability — at top level and nested inside custom components (whose bodies are
-// re-parsed). Guards HTML-flow swallowing and deep-indent fragmentation fallout.
+// re-parsed). Guards HTML-flow swallowing and 4+-column indented-code fallout.
 describe('markdown inside indented plain HTML blocks', () => {
   it('parses indented markdown in a <div> nested inside <Columns>/<Column>', () => {
     const md = `<Columns layout="auto">
@@ -86,21 +86,6 @@ describe('markdown inside indented plain HTML blocks', () => {
     expect(findElementByTagName(ast, 'pre')).toBeNull();
     expect(findElementByTagName(ast, 'h2')).not.toBeNull();
     expect(findElementByTagName(ast, 'a')).toMatchObject({ properties: { href: 'https://example.com' } });
-  });
-
-  it('parses markdown directly after a deeply indented (4+ col) opening tag', () => {
-    const md = `<div>
-    <section>
-    ## Deep heading
-    </section>
-</div>`;
-
-    const ast = mdxish(md);
-
-    expect(findElementByTagName(ast, 'pre')).toBeNull();
-    expect(findElementByTagName(ast, 'h2')).toMatchObject({
-      children: [{ type: 'text', value: 'Deep heading' }],
-    });
   });
 
   it('keeps deeply indented (4+ columns) HTML lines inside a wrapper as HTML (#1344)', () => {

--- a/__tests__/lib/mdxish/mdxish-extensions.test.ts
+++ b/__tests__/lib/mdxish/mdxish-extensions.test.ts
@@ -1,0 +1,172 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import remarkParse from 'remark-parse';
+import { unified } from 'unified';
+
+import {
+  MDXISH_CONTENT_FEATURES,
+  MDXISH_DISABLED_CONSTRUCTS,
+  disableConstructs,
+  mdxishExtensions,
+  type MdxishFeature,
+} from '../../../lib/micromark/mdxish-extensions';
+
+// The builder is the single source of truth for MDXish extension registration
+// (CX-3708). Its two jobs are (1) always applying the base construct config and
+// (2) owning the ordering, which is load-bearing for the `flow` + `<` race.
+describe('mdxishExtensions', () => {
+  describe('base construct config', () => {
+    it('registers the disabled constructs even with no features', () => {
+      const { micromarkExtensions } = mdxishExtensions([]);
+
+      expect(micromarkExtensions).toStrictEqual([{ disable: { null: ['codeIndented'] } }]);
+    });
+
+    it('appends extra disables on top of the base set instead of replacing it', () => {
+      expect(disableConstructs(['list', 'headingAtx'])).toStrictEqual({
+        disable: { null: ['codeIndented', 'list', 'headingAtx'] },
+      });
+    });
+
+    it('keeps the base set intact when a caller mutates the array it passed', () => {
+      const extra = ['list'];
+      disableConstructs(extra);
+      extra.push('thematicBreak');
+
+      expect(MDXISH_DISABLED_CONSTRUCTS).toStrictEqual(['codeIndented']);
+      expect(disableConstructs()).toStrictEqual({ disable: { null: ['codeIndented'] } });
+    });
+  });
+
+  describe('ordering', () => {
+    const parseWith = (features: MdxishFeature[], doc: string) => {
+      const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(features);
+      return unified()
+        .data('micromarkExtensions', micromarkExtensions)
+        .data('fromMarkdownExtensions', fromMarkdownExtensions)
+        .use(remarkParse)
+        .parse(doc);
+    };
+
+    // micromark's combineExtensions prepends per (hook, code), so a later array
+    // position is tried FIRST. `htmlBlockComponent` has to outrank `mdxComponent`
+    // — `mdxComponent` claims any PascalCase tag outside
+    // TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS, and `HTMLBlock` is not in it.
+    const HTML_BLOCK = '<HTMLBlock>{`\n<div>raw</div>\n`}</HTMLBlock>';
+
+    it('lets htmlBlockComponent win the `<` race for <HTMLBlock>', () => {
+      const tree = parseWith(['jsxTable', 'mdxComponent', 'htmlBlockComponent'], HTML_BLOCK);
+
+      // htmlBlockComponent claims the whole block as one `html` node; if
+      // mdxComponent won instead this would be an mdxJsxFlowElement.
+      expect(tree.children).toHaveLength(1);
+      expect(tree.children[0].type).toBe('html');
+    });
+
+    it('claims <HTMLBlock> the same way regardless of how the caller lists features', () => {
+      const backwards = parseWith(['htmlBlockComponent', 'mdxComponent', 'jsxTable'], HTML_BLOCK);
+
+      expect(backwards.children[0].type).toBe('html');
+    });
+
+    it('ignores duplicate feature entries', () => {
+      const once = mdxishExtensions(['gemoji']);
+      const twice = mdxishExtensions(['gemoji', 'gemoji']);
+
+      expect(twice.micromarkExtensions).toHaveLength(once.micromarkExtensions.length);
+    });
+  });
+
+  describe('feature selection', () => {
+    it('only registers the requested features', () => {
+      const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(['gemoji', 'legacyVariable']);
+
+      // base disable + the two requested syntax extensions
+      expect(micromarkExtensions).toHaveLength(3);
+      expect(fromMarkdownExtensions).toHaveLength(2);
+    });
+
+    it('registers a fromMarkdown-only feature without adding a syntax extension', () => {
+      const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(['emptyTaskListItem']);
+
+      expect(micromarkExtensions).toHaveLength(1); // base disable only
+      expect(fromMarkdownExtensions).toHaveLength(1);
+    });
+
+    it('returns fresh arrays per call so a caller spreading onto them is isolated', () => {
+      const first = mdxishExtensions(['gemoji']);
+      first.micromarkExtensions.push({});
+
+      expect(mdxishExtensions(['gemoji']).micromarkExtensions).toHaveLength(2);
+    });
+  });
+
+  describe('safeMode', () => {
+    const EXPRESSION_FEATURES: MdxishFeature[] = ['jsxComment', 'mdxExpressionLenient', 'mdxjsEsm'];
+
+    it('drops every expression-producing extension', () => {
+      const open = mdxishExtensions(MDXISH_CONTENT_FEATURES);
+      const safe = mdxishExtensions(MDXISH_CONTENT_FEATURES, { safeMode: true });
+
+      expect(safe.micromarkExtensions).toHaveLength(open.micromarkExtensions.length - EXPRESSION_FEATURES.length);
+    });
+
+    it('leaves the non-expression extensions untouched', () => {
+      const safe = mdxishExtensions(['gemoji', 'legacyVariable', 'jsxComment'], { safeMode: true });
+
+      // base disable + gemoji + legacyVariable; jsxComment dropped
+      expect(safe.micromarkExtensions).toHaveLength(3);
+    });
+
+    it('still applies the base construct config', () => {
+      const { micromarkExtensions } = mdxishExtensions(MDXISH_CONTENT_FEATURES, { safeMode: true });
+
+      expect(micromarkExtensions[0]).toStrictEqual({ disable: { null: ['codeIndented'] } });
+    });
+  });
+});
+
+// The drift this refactor exists to stop is a sub-parser whose hand-maintained
+// extension array the shared config never reaches (CX-3705, CX-3739). Sub-parsers
+// are still free to register their own subset — what they may not do is opt out of
+// the base construct config, so that's what this asserts.
+describe('extension registration is centralised (CX-3708)', () => {
+  const ROOT = path.resolve(__dirname, '../../..');
+  const SEARCH_DIRS = ['lib', 'processor'];
+
+  const walk = (dir: string): string[] =>
+    fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) return entry.name === '__tests__' ? [] : walk(full);
+      return entry.isFile() && entry.name.endsWith('.ts') ? [full] : [];
+    });
+
+  /** Files that register micromark extensions in code (not just in a doc comment). */
+  const registrationSites = SEARCH_DIRS.flatMap(dir => walk(path.join(ROOT, dir)))
+    .map(file => ({ path: path.relative(ROOT, file), source: fs.readFileSync(file, 'utf8') }))
+    .filter(({ source }) =>
+      source
+        .split('\n')
+        .some(line => line.includes(".data('micromarkExtensions'") && !/^\s*(?:\*|\/\/)/.test(line)),
+    );
+
+  it('finds every known sub-parser', () => {
+    expect(registrationSites.map(site => site.path).sort()).toStrictEqual([
+      'lib/mdxish.ts',
+      'lib/mdxishTags.ts',
+      'lib/stripComments.ts',
+      'processor/transform/mdxish/components/utils.ts',
+      'processor/transform/mdxish/magic-blocks/magic-block-transformer.ts',
+      'processor/transform/mdxish/tables/mdxish-tables.ts',
+    ]);
+  });
+
+  it('routes every sub-parser through the shared base construct config', () => {
+    const offenders = registrationSites
+      .filter(({ source }) => !source.includes('mdxishExtensions(') && !source.includes('disableConstructs('))
+      .map(site => site.path);
+
+    expect(offenders).toStrictEqual([]);
+  });
+});

--- a/__tests__/lib/mdxish/mdxish-extensions.test.ts
+++ b/__tests__/lib/mdxish/mdxish-extensions.test.ts
@@ -12,8 +12,8 @@ import {
 } from '../../../lib/micromark/mdxish-extensions';
 
 // The builder is the single source of truth for MDXish extension registration
-// (CX-3708). Its two jobs are (1) always applying the base construct config and
-// (2) owning the ordering, which is load-bearing for the `flow` + `<` race.
+// Its two jobs are (1) always applying the base construct config and (2) owning
+// the ordering, so a call site can't register the `<` tokenizers out of order.
 describe('mdxishExtensions', () => {
   describe('base construct config', () => {
     it('registers the disabled constructs even with no features', () => {

--- a/__tests__/lib/mdxish/mdxish-extensions.test.ts
+++ b/__tests__/lib/mdxish/mdxish-extensions.test.ts
@@ -176,9 +176,9 @@ describe('extension registration is centralised (CX-3708)', () => {
     expect(unused).toStrictEqual([]);
   });
 
-  it('leaves stripComments as the only sub-parser off the FEATURES map', () => {
+  it('declares every sub-parser in the FEATURES map', () => {
     const offMap = registrationSites.filter(({ source }) => !source.includes('FEATURES.')).map(site => site.path);
 
-    expect(offMap).toStrictEqual(['lib/stripComments.ts']);
+    expect(offMap).toStrictEqual([]);
   });
 });

--- a/__tests__/lib/mdxish/mdxish-extensions.test.ts
+++ b/__tests__/lib/mdxish/mdxish-extensions.test.ts
@@ -5,8 +5,7 @@ import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 
 import {
-  MDXISH_CONTENT_FEATURES,
-  MDXISH_DISABLED_CONSTRUCTS,
+  FEATURES,
   disableConstructs,
   mdxishExtensions,
   type MdxishFeature,
@@ -34,7 +33,6 @@ describe('mdxishExtensions', () => {
       disableConstructs(extra);
       extra.push('thematicBreak');
 
-      expect(MDXISH_DISABLED_CONSTRUCTS).toStrictEqual(['codeIndented']);
       expect(disableConstructs()).toStrictEqual({ disable: { null: ['codeIndented'] } });
     });
   });
@@ -106,8 +104,8 @@ describe('mdxishExtensions', () => {
     const EXPRESSION_FEATURES: MdxishFeature[] = ['jsxComment', 'mdxExpressionLenient', 'mdxjsEsm'];
 
     it('drops every expression-producing extension', () => {
-      const open = mdxishExtensions(MDXISH_CONTENT_FEATURES);
-      const safe = mdxishExtensions(MDXISH_CONTENT_FEATURES, { safeMode: true });
+      const open = mdxishExtensions(FEATURES.document);
+      const safe = mdxishExtensions(FEATURES.document, { safeMode: true });
 
       expect(safe.micromarkExtensions).toHaveLength(open.micromarkExtensions.length - EXPRESSION_FEATURES.length);
     });
@@ -120,7 +118,7 @@ describe('mdxishExtensions', () => {
     });
 
     it('still applies the base construct config', () => {
-      const { micromarkExtensions } = mdxishExtensions(MDXISH_CONTENT_FEATURES, { safeMode: true });
+      const { micromarkExtensions } = mdxishExtensions(FEATURES.document, { safeMode: true });
 
       expect(micromarkExtensions[0]).toStrictEqual({ disable: { null: ['codeIndented'] } });
     });
@@ -146,9 +144,7 @@ describe('extension registration is centralised (CX-3708)', () => {
   const registrationSites = SEARCH_DIRS.flatMap(dir => walk(path.join(ROOT, dir)))
     .map(file => ({ path: path.relative(ROOT, file), source: fs.readFileSync(file, 'utf8') }))
     .filter(({ source }) =>
-      source
-        .split('\n')
-        .some(line => line.includes(".data('micromarkExtensions'") && !/^\s*(?:\*|\/\/)/.test(line)),
+      source.split('\n').some(line => line.includes(".data('micromarkExtensions'") && !/^\s*(?:\*|\/\/)/.test(line)),
     );
 
   it('finds every known sub-parser', () => {
@@ -168,5 +164,21 @@ describe('extension registration is centralised (CX-3708)', () => {
       .map(site => site.path);
 
     expect(offenders).toStrictEqual([]);
+  });
+
+  // Every sub-parser but `stripComments` declares its set in FEATURES, so adding
+  // a tokenizer means deciding for each row. A preset nobody reads means a site
+  // was migrated away or renamed and the map went stale.
+  it('has a consumer for every entry in the FEATURES map', () => {
+    const sources = registrationSites.map(site => site.source).join('\n');
+    const unused = Object.keys(FEATURES).filter(preset => !sources.includes(`FEATURES.${preset}`));
+
+    expect(unused).toStrictEqual([]);
+  });
+
+  it('leaves stripComments as the only sub-parser off the FEATURES map', () => {
+    const offMap = registrationSites.filter(({ source }) => !source.includes('FEATURES.')).map(site => site.path);
+
+    expect(offMap).toStrictEqual(['lib/stripComments.ts']);
   });
 });

--- a/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
+++ b/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
@@ -194,9 +194,9 @@ const x = 1;
     expect(html).toContain('<strong>super nested ul</strong>');
   });
 
-  it('parses a 4+ column markdown island inside a nested wrapper, not fragments (RM-17560)', () => {
-    // The island falls back to CommonMark at the blank line and parses as markdown
-    // (indented code is disabled); rehype-raw re-nests it into the wrapper fragments.
+  it('claims a nested wrapper so a 4+ column markdown island parses, not fragments (RM-17560)', () => {
+    // 6-col nesting indent would let CommonMark swallow the island as indented code;
+    // being nested (prior body content), the block is claimed and its body re-parsed.
     const md = `<ol>
   <li>
     <details>
@@ -221,7 +221,7 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('&#x3C;/details>');
   });
 
-  it('parses a 4+ col island in a single 4-space-indented wrapper, no nesting (RM-17560)', () => {
+  it('claims a 4+ col island in a single 4-space-indented wrapper, no nesting (RM-17560)', () => {
     const md = `<div class="card">
     <p>Install the CLI:</p>
 
@@ -239,7 +239,7 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('```');
   });
 
-  it('parses a 4+ col island under 2-space-nested layout tags (RM-17560)', () => {
+  it('claims a 4+ col island under 2-space-nested layout tags (RM-17560)', () => {
     const md = `<section>
   <article>
     <p>Release notes</p>
@@ -263,7 +263,7 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('###');
   });
 
-  it('parses a 4+ col prose + fence island in a <details> without a list wrapper (RM-17560)', () => {
+  it('claims a 4+ col prose + fence island in a <details> without a list wrapper (RM-17560)', () => {
     const md = `<details>
     <summary>How do I authenticate?</summary>
 
@@ -300,10 +300,10 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('```');
   });
 
-  it('parses a deep island inside <figure> via the CommonMark fallback', () => {
-    // Figure bodies aren't re-parsed by promotion, but the island still renders:
-    // it falls back at the blank line and parses as markdown (indented code is
-    // disabled), landing between the figure's raw fragments.
+  it('keeps the CommonMark fallback for a deep island inside <figure> (non-promotable)', () => {
+    // Note: In this example the indented content would still be parsed as code
+    // Since this looks like an edge case, we'll leave it as is first since it
+    // requires a bigger refactor.
     const md = `<figure>
   <figcaption>cap</figcaption>
 
@@ -321,11 +321,6 @@ const x = 1;
     expect(findElementByTagName(figure!, 'figcaption')).toMatchObject({
       children: [{ type: 'text', value: 'cap' }],
     });
-    expect(findElementByTagName(ast, 'h3')).toMatchObject({
-      children: [{ type: 'text', value: 'Heading' }],
-    });
-    expect(toHtml(ast)).toContain('const x = 1;');
-    expect(toHtml(ast)).not.toContain('```');
   });
 
   it('allows blank lines inside a brace expression body (e.g. a .map() callback)', () => {

--- a/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
+++ b/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
@@ -194,9 +194,9 @@ const x = 1;
     expect(html).toContain('<strong>super nested ul</strong>');
   });
 
-  it('claims a nested wrapper so a 4+ column markdown island parses, not fragments (RM-17560)', () => {
-    // 6-col nesting indent would let CommonMark swallow the island as indented code;
-    // being nested (prior body content), the block is claimed and its body re-parsed.
+  it('parses a 4+ column markdown island inside a nested wrapper, not fragments (RM-17560)', () => {
+    // The island falls back to CommonMark at the blank line and parses as markdown
+    // (indented code is disabled); rehype-raw re-nests it into the wrapper fragments.
     const md = `<ol>
   <li>
     <details>
@@ -221,7 +221,7 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('&#x3C;/details>');
   });
 
-  it('claims a 4+ col island in a single 4-space-indented wrapper, no nesting (RM-17560)', () => {
+  it('parses a 4+ col island in a single 4-space-indented wrapper, no nesting (RM-17560)', () => {
     const md = `<div class="card">
     <p>Install the CLI:</p>
 
@@ -239,7 +239,7 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('```');
   });
 
-  it('claims a 4+ col island under 2-space-nested layout tags (RM-17560)', () => {
+  it('parses a 4+ col island under 2-space-nested layout tags (RM-17560)', () => {
     const md = `<section>
   <article>
     <p>Release notes</p>
@@ -263,7 +263,7 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('###');
   });
 
-  it('claims a 4+ col prose + fence island in a <details> without a list wrapper (RM-17560)', () => {
+  it('parses a 4+ col prose + fence island in a <details> without a list wrapper (RM-17560)', () => {
     const md = `<details>
     <summary>How do I authenticate?</summary>
 
@@ -300,10 +300,10 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('```');
   });
 
-  it('keeps the CommonMark fallback for a deep island inside <figure> (non-promotable)', () => {
-    // Note: In this example the indented content would still be parsed as code
-    // Since this looks like an edge case, we'll leave it as is first since it
-    // requires a bigger refactor.
+  it('parses a deep island inside <figure> via the CommonMark fallback', () => {
+    // Figure bodies aren't re-parsed by promotion, but the island still renders:
+    // it falls back at the blank line and parses as markdown (indented code is
+    // disabled), landing between the figure's raw fragments.
     const md = `<figure>
   <figcaption>cap</figcaption>
 
@@ -321,6 +321,11 @@ const x = 1;
     expect(findElementByTagName(figure!, 'figcaption')).toMatchObject({
       children: [{ type: 'text', value: 'cap' }],
     });
+    expect(findElementByTagName(ast, 'h3')).toMatchObject({
+      children: [{ type: 'text', value: 'Heading' }],
+    });
+    expect(toHtml(ast)).toContain('const x = 1;');
+    expect(toHtml(ast)).not.toContain('```');
   });
 
   it('allows blank lines inside a brace expression body (e.g. a .map() callback)', () => {

--- a/__tests__/lib/mdxish/type-7-html-block-blank-lines.test.ts
+++ b/__tests__/lib/mdxish/type-7-html-block-blank-lines.test.ts
@@ -7,8 +7,9 @@ import { mdxish, compile, run } from '../../../lib';
 import { findAllElementsByTagName, findElementByTagName, roundTripMdxish } from '../../helpers';
 
 // Type-7 tags (a, span, button, …) end their HTML block at a blank line, fragmenting
-// 4+ column children into indented code. The mdxComponent tokenizer claims them like
-// type-6 plain blocks, but only when the opener sits alone on its line.
+// the wrapper so its children don't re-nest into one element. The mdxComponent
+// tokenizer claims them like type-6 plain blocks, but only when the opener sits
+// alone on its line.
 describe('block-wrapper claims for type-7 wrapper tags', () => {
   const wrapperTags = [
     'a',
@@ -113,7 +114,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       });
     });
 
-    it('claims a tab-indented island sitting directly after the opener blank line', () => {
+    it('renders a tab-indented island sitting directly after the opener blank line', () => {
       const md = '<button class="tabbed">\n\n\t<h3>Tab-indented heading</h3>\n\t<p>Indented with a real tab.</p>\n</button>';
 
       const ast = mdxish(md);
@@ -128,7 +129,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       });
     });
 
-    it('claims a top-of-body prose island at 4+ columns instead of fragmenting it', () => {
+    it('renders a top-of-body prose island at 4+ columns instead of fragmenting it', () => {
       const md = `<span class="badge">
 
     some indented text
@@ -140,7 +141,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       expect(toHtml(findElementByTagName(ast, 'span')!)).toContain('some indented text');
     });
 
-    it('claims a top-of-body island in an unknown lowercase tag', () => {
+    it('renders a top-of-body island in an unknown lowercase tag', () => {
       const md = `<placeholder>
 
     some indented text
@@ -152,7 +153,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       expect(toHtml(findElementByTagName(ast, 'placeholder')!)).toContain('some indented text');
     });
 
-    it('claims a top-of-body titled fence island so it parses as a code sample (RM-17560 shape)', () => {
+    it('parses a top-of-body titled fence island as a code sample (RM-17560 shape)', () => {
       const md = `<a href="sample" class="content-card">
 
       \`\`\`json 0100 Request

--- a/__tests__/lib/mdxish/type-7-html-block-blank-lines.test.ts
+++ b/__tests__/lib/mdxish/type-7-html-block-blank-lines.test.ts
@@ -7,9 +7,8 @@ import { mdxish, compile, run } from '../../../lib';
 import { findAllElementsByTagName, findElementByTagName, roundTripMdxish } from '../../helpers';
 
 // Type-7 tags (a, span, button, …) end their HTML block at a blank line, fragmenting
-// the wrapper so its children don't re-nest into one element. The mdxComponent
-// tokenizer claims them like type-6 plain blocks, but only when the opener sits
-// alone on its line.
+// 4+ column children into indented code. The mdxComponent tokenizer claims them like
+// type-6 plain blocks, but only when the opener sits alone on its line.
 describe('block-wrapper claims for type-7 wrapper tags', () => {
   const wrapperTags = [
     'a',
@@ -114,7 +113,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       });
     });
 
-    it('renders a tab-indented island sitting directly after the opener blank line', () => {
+    it('claims a tab-indented island sitting directly after the opener blank line', () => {
       const md = '<button class="tabbed">\n\n\t<h3>Tab-indented heading</h3>\n\t<p>Indented with a real tab.</p>\n</button>';
 
       const ast = mdxish(md);
@@ -129,7 +128,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       });
     });
 
-    it('renders a top-of-body prose island at 4+ columns instead of fragmenting it', () => {
+    it('claims a top-of-body prose island at 4+ columns instead of fragmenting it', () => {
       const md = `<span class="badge">
 
     some indented text
@@ -141,7 +140,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       expect(toHtml(findElementByTagName(ast, 'span')!)).toContain('some indented text');
     });
 
-    it('renders a top-of-body island in an unknown lowercase tag', () => {
+    it('claims a top-of-body island in an unknown lowercase tag', () => {
       const md = `<placeholder>
 
     some indented text
@@ -153,7 +152,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       expect(toHtml(findElementByTagName(ast, 'placeholder')!)).toContain('some indented text');
     });
 
-    it('parses a top-of-body titled fence island as a code sample (RM-17560 shape)', () => {
+    it('claims a top-of-body titled fence island so it parses as a code sample (RM-17560 shape)', () => {
       const md = `<a href="sample" class="content-card">
 
       \`\`\`json 0100 Request

--- a/__tests__/lib/mdxishTags.test.ts
+++ b/__tests__/lib/mdxishTags.test.ts
@@ -207,4 +207,28 @@ This is phrasing: <Inline />
       expect(mdxishTags(mdx)).toStrictEqual(['Component', 'NestedComponent', 'SubNestedComponent']);
     });
   });
+
+  describe('deeply indented components', () => {
+    it('captures a 4+ column indented component at the top level', () => {
+      const mdx = '      <MyComponent />';
+  
+      expect(mdxishTags(mdx)).toStrictEqual(['MyComponent']);
+    });
+
+    it('captures a 4+ column indented component nested in a parent component', () => {
+      const mdx = `
+<ParentComponent>
+              <MyComponent />
+</ParentComponent>
+
+        <ComponentOne>
+          <ComponentTwo>
+            Hello
+          </ComponentTwo>
+        </ComponentOne>
+`;
+
+      expect(mdxishTags(mdx)).toStrictEqual(['ParentComponent', 'MyComponent', 'ComponentOne', 'ComponentTwo']);
+    });
+  });
 });

--- a/__tests__/lib/stripComments.test.ts
+++ b/__tests__/lib/stripComments.test.ts
@@ -310,6 +310,16 @@ end"`);
     expect(output).toBe(input);
   });
 
+  it('preserves indented prose as prose, not a fenced code block, in mdxish mode', async () => {
+    // Without disabling indented code, the round-trip would re-emit the indented
+    // line as a ```-fenced block, which then renders as code (CX-3739).
+    const input = 'Intro.\n\n    indented prose line\n\n<!-- c -->\nAfter.';
+
+    const output = await stripComments(input, { mdxish: true });
+    expect(output).toBe('Intro.\n\nindented prose line\n\nAfter.');
+    expect(output).not.toContain('```');
+  });
+
   it('does not escape custom components with array/object expression props in mdxish mode', async () => {
     // Component should not be escaped when stripping comments, and whitespace preserved
     const input = `<DosAndDonts

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -375,12 +375,8 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
 `;
 
 exports[`Render engine regressions tests > indented-markdown-islands-in-html (mdxish) 1`] = `
-"<ol>
-  <li>
-    <details>
-      <summary>Authorization request</summary>
-<h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="1-authorization-request"></div><div class="heading-text">1. Authorization request</div><a aria-label="Skip link to 1. Authorization request" class="heading-anchor-icon fa fa-regular fa-anchor" href="#1-authorization-request"></a></h3>
-<div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">0100 Request</button><button type="button" value="json">0100 Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+"<ol><li><details>
+  <summary>Authorization request</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="1-authorization-request"></div><div class="heading-text">1. Authorization request</div><a aria-label="Skip link to 1. Authorization request" class="heading-anchor-icon fa fa-regular fa-anchor" href="#1-authorization-request"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">0100 Request</button><button type="button" value="json">0100 Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;MESSAGE_TYPE&quot;: {
         &quot;Message_Type&quot;: &quot;0100&quot;,
         &quot;Message_Desc&quot;: &quot;Authorisation Request&quot;
@@ -391,14 +387,8 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
     }
 }</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;Message_Type&quot;: &quot;0110&quot;,
-}</code></pre></div></div>
-    </details>
-  </li>
-  <li>
-    <details>
-      <summary>ATM withdrawal and reversal</summary>
-<h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="2-atm-withdrawal-and-reversal"></div><div class="heading-text">2. ATM withdrawal and reversal</div><a aria-label="Skip link to 2. ATM withdrawal and reversal" class="heading-anchor-icon fa fa-regular fa-anchor" href="#2-atm-withdrawal-and-reversal"></a></h3>
-<div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">Request</button><button type="button" value="json">Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+}</code></pre></div></div></details></li><li><details>
+  <summary>ATM withdrawal and reversal</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="2-atm-withdrawal-and-reversal"></div><div class="heading-text">2. ATM withdrawal and reversal</div><a aria-label="Skip link to 2. ATM withdrawal and reversal" class="heading-anchor-icon fa fa-regular fa-anchor" href="#2-atm-withdrawal-and-reversal"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">Request</button><button type="button" value="json">Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;MESSAGE_TYPE&quot;: {
         &quot;Message_Type&quot;: &quot;0400&quot;,
         &quot;Message_Desc&quot;: &quot;Reversal Request&quot;
@@ -414,10 +404,7 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
 }</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;DE11&quot;: &quot;000071&quot;,
     &quot;DE2&quot;: &quot;818654321&quot;,
-}</code></pre></div></div>
-    </details>
-  </li>
-</ol>
+}</code></pre></div></div></details></li></ol>
 <div class="content-card-container">
   
   <a class="content-card" href="invoices" target="" title="">

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -375,8 +375,12 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
 `;
 
 exports[`Render engine regressions tests > indented-markdown-islands-in-html (mdxish) 1`] = `
-"<ol><li><details>
-  <summary>Authorization request</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="1-authorization-request"></div><div class="heading-text">1. Authorization request</div><a aria-label="Skip link to 1. Authorization request" class="heading-anchor-icon fa fa-regular fa-anchor" href="#1-authorization-request"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">0100 Request</button><button type="button" value="json">0100 Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+"<ol>
+  <li>
+    <details>
+      <summary>Authorization request</summary>
+<h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="1-authorization-request"></div><div class="heading-text">1. Authorization request</div><a aria-label="Skip link to 1. Authorization request" class="heading-anchor-icon fa fa-regular fa-anchor" href="#1-authorization-request"></a></h3>
+<div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">0100 Request</button><button type="button" value="json">0100 Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;MESSAGE_TYPE&quot;: {
         &quot;Message_Type&quot;: &quot;0100&quot;,
         &quot;Message_Desc&quot;: &quot;Authorisation Request&quot;
@@ -387,8 +391,14 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
     }
 }</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;Message_Type&quot;: &quot;0110&quot;,
-}</code></pre></div></div></details></li><li><details>
-  <summary>ATM withdrawal and reversal</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="2-atm-withdrawal-and-reversal"></div><div class="heading-text">2. ATM withdrawal and reversal</div><a aria-label="Skip link to 2. ATM withdrawal and reversal" class="heading-anchor-icon fa fa-regular fa-anchor" href="#2-atm-withdrawal-and-reversal"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">Request</button><button type="button" value="json">Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+}</code></pre></div></div>
+    </details>
+  </li>
+  <li>
+    <details>
+      <summary>ATM withdrawal and reversal</summary>
+<h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="2-atm-withdrawal-and-reversal"></div><div class="heading-text">2. ATM withdrawal and reversal</div><a aria-label="Skip link to 2. ATM withdrawal and reversal" class="heading-anchor-icon fa fa-regular fa-anchor" href="#2-atm-withdrawal-and-reversal"></a></h3>
+<div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">Request</button><button type="button" value="json">Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;MESSAGE_TYPE&quot;: {
         &quot;Message_Type&quot;: &quot;0400&quot;,
         &quot;Message_Desc&quot;: &quot;Reversal Request&quot;
@@ -404,7 +414,10 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
 }</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;DE11&quot;: &quot;000071&quot;,
     &quot;DE2&quot;: &quot;818654321&quot;,
-}</code></pre></div></div></details></li></ol>
+}</code></pre></div></div>
+    </details>
+  </li>
+</ol>
 <div class="content-card-container">
   
   <a class="content-card" href="invoices" target="" title="">

--- a/__tests__/regression/fixtures/indented-markdown-islands-in-html/README.md
+++ b/__tests__/regression/fixtures/indented-markdown-islands-in-html/README.md
@@ -2,10 +2,13 @@
 
 Markdown islands (headings, fenced code) sitting 4+ columns deep inside nested
 plain HTML block tags, separated from the tags by blank lines. The trigger is
-structural, not tag-specific: any CommonMark type-6 wrapper chain whose nesting
-indent reaches 4 columns puts the island past the indented-code threshold, so
-everything after the blank line — fence markers, headings, prose — collapsed
-into one literal `<pre>` code block, with closing tags leaking into it.
+structural, not tag-specific: any CommonMark type-6 wrapper chain ends at the
+blank line, so everything after it — fence markers, headings, prose — used to
+collapse into one literal `<pre>` code block (indented code is disabled now,
+see `indented-content-is-not-code`), with closing tags leaking into it. Today
+the islands parse as markdown; this fixture locks in that they render fully
+(headings, CodeTabs) with the wrapper's raw fragments in balanced order, so
+the browser DOM re-nests them.
 
 This body is a stripped-down version of the RM-17560 customer doc:
 `<ol>/<li>/<details>/<summary>` at 6-column depth with titled `json` fences.
@@ -27,10 +30,16 @@ sits alone on its line (see `isBlockWrapperClaimTagName` in `syntax.ts`).
 
 ## What flips this fixture
 
-Changes to the `mdxComponent` tokenizer's plain-block-claim continuation
-(`plainClaimLineStart` / the 4-column island rule in
-`lib/micromark/mdx-component/syntax.ts`), the block-wrapper claim for
-non-type-6 wrapper tags (`isBlockWrapperClaimTagName` /
-`blockWrapperOpenerRest` in the same file), the bottom-up promotion recursion
-in `processor/transform/mdxish/components/mdx-blocks.ts` (`parseMdChildren` /
+Re-enabling the `codeIndented` construct (`disableIndentedCode` in
+`processor/utils.ts`), changes to the `mdxComponent` tokenizer's
+plain-block-claim continuation (`plainClaimLineStart`) or the block-wrapper
+claim for non-type-6 wrapper tags (`isBlockWrapperClaimTagName` /
+`blockWrapperOpenerRest`) in `lib/micromark/mdx-component/syntax.ts`, the
+bottom-up promotion recursion in
+`processor/transform/mdxish/components/mdx-blocks.ts` (`parseMdChildren` /
 `promoteComponentBlocks`), or `safeDeindent`'s shared-indent stripping.
+
+The snapshot shape changed when the post-blank 4-column island bypass was
+removed from `plainClaimLineStart`: islands now fall back to CommonMark and
+render between the wrapper's raw fragments instead of being re-nested in the
+HAST. The two shapes were verified DOM-equivalent through parse5.

--- a/__tests__/regression/fixtures/indented-markdown-islands-in-html/README.md
+++ b/__tests__/regression/fixtures/indented-markdown-islands-in-html/README.md
@@ -2,13 +2,10 @@
 
 Markdown islands (headings, fenced code) sitting 4+ columns deep inside nested
 plain HTML block tags, separated from the tags by blank lines. The trigger is
-structural, not tag-specific: any CommonMark type-6 wrapper chain ends at the
-blank line, so everything after it — fence markers, headings, prose — used to
-collapse into one literal `<pre>` code block (indented code is disabled now,
-see `indented-content-is-not-code`), with closing tags leaking into it. Today
-the islands parse as markdown; this fixture locks in that they render fully
-(headings, CodeTabs) with the wrapper's raw fragments in balanced order, so
-the browser DOM re-nests them.
+structural, not tag-specific: any CommonMark type-6 wrapper chain whose nesting
+indent reaches 4 columns puts the island past the indented-code threshold, so
+everything after the blank line — fence markers, headings, prose — collapsed
+into one literal `<pre>` code block, with closing tags leaking into it.
 
 This body is a stripped-down version of the RM-17560 customer doc:
 `<ol>/<li>/<details>/<summary>` at 6-column depth with titled `json` fences.
@@ -30,16 +27,10 @@ sits alone on its line (see `isBlockWrapperClaimTagName` in `syntax.ts`).
 
 ## What flips this fixture
 
-Re-enabling the `codeIndented` construct (`disableIndentedCode` in
-`processor/utils.ts`), changes to the `mdxComponent` tokenizer's
-plain-block-claim continuation (`plainClaimLineStart`) or the block-wrapper
-claim for non-type-6 wrapper tags (`isBlockWrapperClaimTagName` /
-`blockWrapperOpenerRest`) in `lib/micromark/mdx-component/syntax.ts`, the
-bottom-up promotion recursion in
-`processor/transform/mdxish/components/mdx-blocks.ts` (`parseMdChildren` /
+Changes to the `mdxComponent` tokenizer's plain-block-claim continuation
+(`plainClaimLineStart` / the 4-column island rule in
+`lib/micromark/mdx-component/syntax.ts`), the block-wrapper claim for
+non-type-6 wrapper tags (`isBlockWrapperClaimTagName` /
+`blockWrapperOpenerRest` in the same file), the bottom-up promotion recursion
+in `processor/transform/mdxish/components/mdx-blocks.ts` (`parseMdChildren` /
 `promoteComponentBlocks`), or `safeDeindent`'s shared-indent stripping.
-
-The snapshot shape changed when the post-blank 4-column island bypass was
-removed from `plainClaimLineStart`: islands now fall back to CommonMark and
-render between the wrapper's raw fragments instead of being re-nested in the
-HAST. The two shapes were verified DOM-equivalent through parse5.

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -399,6 +399,7 @@ Just one line.
     // The fallback processor omits mdxjs (which bundles the codeIndented disable),
     // so it registers `disableIndentedCode` to match the primary path. Indented
     // cell content stays prose; only the explicit fence becomes a code node.
+    // Keeps `malformed`'s duplicated </td></tr> so this stays on the fallback path.
     it('keeps a fence as the only code node while an indented sibling line stays prose', () => {
       const withIndentedTail = `<table>
 <thead>
@@ -427,7 +428,7 @@ Just one line.
 
       const html = toHtml(mdxish(withIndentedTail));
       expect(html).toContain('indented tail line');
-      expect(html).not.toContain('<pre><code value="indented');
+      expect(html).not.toMatch(/<pre>\s*<code[^>]*>[^<]*indented tail line/);
     });
   });
 

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -395,6 +395,40 @@ Just one line.
       expect(html).toContain('2.16.0.0/13');
       expect(html).not.toContain('```');
     });
+
+    // The fallback processor omits mdxjs (which bundles the codeIndented disable),
+    // so it registers `disableIndentedCode` to match the primary path. Indented
+    // cell content stays prose; only the explicit fence becomes a code node.
+    it('keeps a fence as the only code node while an indented sibling line stays prose', () => {
+      const withIndentedTail = `<table>
+<thead>
+<th>IPv4</th>
+</thead>
+<tbody>
+<tr>
+<td>
+
+\`\`\`
+2.16.0.0/13
+\`\`\`
+
+    indented tail line
+
+</td>
+</tr>
+</td>
+</tr>
+</tbody>
+</table>`;
+
+      const codes = collectNodes(astProcessor(withIndentedTail), 'code');
+      expect(codes).toHaveLength(1);
+      expect(codes[0]).toMatchObject({ type: 'code', value: '2.16.0.0/13' });
+
+      const html = toHtml(mdxish(withIndentedTail));
+      expect(html).toContain('indented tail line');
+      expect(html).not.toContain('<pre><code value="indented');
+    });
   });
 
   describe('given unclosed tags inside cells that is not MDX valid', () => {

--- a/__tests__/transformers/terminate-html-flow-blocks.test.ts
+++ b/__tests__/transformers/terminate-html-flow-blocks.test.ts
@@ -193,6 +193,50 @@ text at column 0`;
 text at column 0`);
     });
 
+    // The next three shapes reach 4+ columns; indented code is disabled, so the
+    // freed line parses as markdown rather than turning into a code block.
+    it('inserts blank line before a tab-indented (4-column) markdown line', () => {
+      const input = `<div>
+\tTabbed line
+</div>`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+\tTabbed line
+</div>`);
+    });
+
+    it('inserts blank line after a tab-indented lone opening tag followed by markdown', () => {
+      const input = `\t<div>
+text at column 0`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`\t<div>
+
+text at column 0`);
+    });
+
+    it('inserts blank line after a lone opening tag when the next line is markdown at 4+ columns', () => {
+      const input = `<div>
+      indented line
+      with some text after
+
+      should be freed as markdown
+</div>
+      `;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+      indented line
+      with some text after
+
+      should be freed as markdown
+</div>
+      `);
+    });
+
     it('inserts blank line when HTML line has text content between and after tags', () => {
       const input = `<div><p>Inner text</p></div>Outer text
 [block:callout]
@@ -246,33 +290,6 @@ Hello
 
     it('does not insert blank line after last line', () => {
       const input = '<div></div>';
-
-      expect(terminateHtmlFlowBlocks(input)).toBe(input);
-    });
-
-    it('does not insert blank line if next line starts with a tab', () => {
-      const input = `<div>
-\tTabbed line
-</div>`;
-
-      expect(terminateHtmlFlowBlocks(input)).toBe(input);
-    });
-
-    it('does not insert after a tab-indented opening tag (a tab counts as 4 columns)', () => {
-      const input = `\t<div>
-text at column 0`;
-
-      expect(terminateHtmlFlowBlocks(input)).toBe(input);
-    });
-
-    it('does not modify non-HTML lines indented 4+ columns after an HTML tag', () => {
-      const input = `<div>
-      indented line
-      with some text after
-
-      should be left alone
-</div>
-      `;
 
       expect(terminateHtmlFlowBlocks(input)).toBe(input);
     });

--- a/__tests__/transformers/terminate-html-flow-blocks.test.ts
+++ b/__tests__/transformers/terminate-html-flow-blocks.test.ts
@@ -193,50 +193,6 @@ text at column 0`;
 text at column 0`);
     });
 
-    // The next three shapes reach 4+ columns; indented code is disabled, so the
-    // freed line parses as markdown rather than turning into a code block.
-    it('inserts blank line before a tab-indented (4-column) markdown line', () => {
-      const input = `<div>
-\tTabbed line
-</div>`;
-
-      const result = terminateHtmlFlowBlocks(input);
-      expect(result).toBe(`<div>
-
-\tTabbed line
-</div>`);
-    });
-
-    it('inserts blank line after a tab-indented lone opening tag followed by markdown', () => {
-      const input = `\t<div>
-text at column 0`;
-
-      const result = terminateHtmlFlowBlocks(input);
-      expect(result).toBe(`\t<div>
-
-text at column 0`);
-    });
-
-    it('inserts blank line after a lone opening tag when the next line is markdown at 4+ columns', () => {
-      const input = `<div>
-      indented line
-      with some text after
-
-      should be freed as markdown
-</div>
-      `;
-
-      const result = terminateHtmlFlowBlocks(input);
-      expect(result).toBe(`<div>
-
-      indented line
-      with some text after
-
-      should be freed as markdown
-</div>
-      `);
-    });
-
     it('inserts blank line when HTML line has text content between and after tags', () => {
       const input = `<div><p>Inner text</p></div>Outer text
 [block:callout]
@@ -290,6 +246,33 @@ Hello
 
     it('does not insert blank line after last line', () => {
       const input = '<div></div>';
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not insert blank line if next line starts with a tab', () => {
+      const input = `<div>
+\tTabbed line
+</div>`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not insert after a tab-indented opening tag (a tab counts as 4 columns)', () => {
+      const input = `\t<div>
+text at column 0`;
+
+      expect(terminateHtmlFlowBlocks(input)).toBe(input);
+    });
+
+    it('does not modify non-HTML lines indented 4+ columns after an HTML tag', () => {
+      const input = `<div>
+      indented line
+      with some text after
+
+      should be left alone
+</div>
+      `;
 
       expect(terminateHtmlFlowBlocks(input)).toBe(input);
     });

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -77,8 +77,10 @@ export const GENERIC_MDX_COMPONENT_EXCLUDED_TAGS = new Set<string>([
 ]);
 
 /**
- * Tags the micromark `mdxComponent` tokenizer must not claim, which
- * are inline components and those that have their own dedicated tokenizer
+ * Tags the micromark `mdxComponent` tokenizer must not claim: inline components,
+ * plus `Table` (whose rows `jsxTable` has to keep together). `HTMLBlock` is absent
+ * on purpose — claiming it yields the same `html` node, and the transforms skip it
+ * by name via {@link GENERIC_MDX_COMPONENT_EXCLUDED_TAGS}.
  */
 export const TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS = new Set<string>([
   'Table',

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -57,7 +57,7 @@ import variablesCodeResolver from '../processor/transform/mdxish/variables-code'
 import variablesTextTransformer from '../processor/transform/mdxish/variables-text';
 import tailwindTransformer from '../processor/transform/tailwind';
 
-import { MDXISH_CONTENT_FEATURES, mdxishExtensions } from './micromark/mdxish-extensions';
+import { FEATURES, mdxishExtensions } from './micromark/mdxish-extensions';
 import { loadComponents } from './utils/mdxish/mdxish-load-components';
 import { protectCodeBlocks, restoreCodeBlocks } from './utils/mdxish/protect-code-blocks';
 
@@ -142,10 +142,7 @@ export function mdxishAstProcessor(mdContent: string, opts: MdxishOpts = {}) {
     return acc;
   }, {});
 
-  // safeMode drops the expression-producing extensions (jsxComment,
-  // mdxExpressionLenient, mdxjsEsm); the builder owns that gate and the
-  // registration order, which is load-bearing for `<HTMLBlock>`.
-  const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(MDXISH_CONTENT_FEATURES, { safeMode });
+  const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(FEATURES.document, { safeMode });
 
   const processor = unified()
     .data('micromarkExtensions', micromarkExtensions)

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -1,13 +1,9 @@
 import type { CustomComponents, Variables } from '../types';
 import type { Root } from 'hast';
 import type { Root as MdastRoot } from 'mdast';
-import type { Extension } from 'micromark-util-types';
 import type { PluggableList } from 'unified';
 
-import { mdxExpressionFromMarkdown } from 'mdast-util-mdx-expression';
 import { mdxJsxToMarkdown } from 'mdast-util-mdx-jsx';
-import { mdxjsEsmFromMarkdown } from 'mdast-util-mdxjs-esm';
-import { mdxjsEsm } from 'micromark-extension-mdxjs-esm';
 import rehypeRaw from 'rehype-raw';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
@@ -60,24 +56,8 @@ import { terminateHtmlFlowBlocks } from '../processor/transform/mdxish/terminate
 import variablesCodeResolver from '../processor/transform/mdxish/variables-code';
 import variablesTextTransformer from '../processor/transform/mdxish/variables-text';
 import tailwindTransformer from '../processor/transform/tailwind';
-import { disableIndentedCode, jsxAcornParser } from '../processor/utils';
 
-import { emptyTaskListItemFromMarkdown } from './mdast-util/empty-task-list-item';
-import { gemojiFromMarkdown } from './mdast-util/gemoji';
-import { htmlBlockComponentFromMarkdown } from './mdast-util/html-block-component';
-import { jsxTableFromMarkdown } from './mdast-util/jsx-table';
-import { legacyVariableFromMarkdown } from './mdast-util/legacy-variable';
-import { magicBlockFromMarkdown } from './mdast-util/magic-block';
-import { mdxComponentFromMarkdown } from './mdast-util/mdx-component';
-import { gemoji } from './micromark/gemoji';
-import { htmlBlockComponent } from './micromark/html-block-component';
-import { jsxComment } from './micromark/jsx-comment';
-import { jsxTable } from './micromark/jsx-table';
-import { legacyVariable } from './micromark/legacy-variable';
-import { looseHtmlEntity, looseHtmlEntityFromMarkdown } from './micromark/loose-html-entities';
-import { magicBlock } from './micromark/magic-block';
-import { mdxComponent } from './micromark/mdx-component';
-import { mdxExpressionLenient } from './micromark/mdx-expression-lenient';
+import { MDXISH_CONTENT_FEATURES, mdxishExtensions } from './micromark/mdxish-extensions';
 import { loadComponents } from './utils/mdxish/mdxish-load-components';
 import { protectCodeBlocks, restoreCodeBlocks } from './utils/mdxish/protect-code-blocks';
 
@@ -162,53 +142,14 @@ export function mdxishAstProcessor(mdContent: string, opts: MdxishOpts = {}) {
     return acc;
   }, {});
 
-  // Parser extension for MDX expressions {}
-  const mdxExprTextOnly: Extension = mdxExpressionLenient();
-
-  const micromarkExts = [
-    disableIndentedCode,
-    jsxTable(),
-    magicBlock(),
-    mdxComponent(),
-    gemoji(),
-    legacyVariable(),
-    looseHtmlEntity(),
-    htmlBlockComponent(),
-  ];
-  const fromMarkdownExts = [
-    jsxTableFromMarkdown(),
-    magicBlockFromMarkdown(),
-    mdxComponentFromMarkdown(),
-    gemojiFromMarkdown(),
-    legacyVariableFromMarkdown(),
-    emptyTaskListItemFromMarkdown(),
-    looseHtmlEntityFromMarkdown(),
-    htmlBlockComponentFromMarkdown(),
-  ];
-
-  if (!safeMode) {
-    // Insert mdx expression (text-only, no flow) after gemoji at index 3
-    micromarkExts.splice(3, 0, mdxExprTextOnly);
-    fromMarkdownExts.splice(3, 0, mdxExpressionFromMarkdown());
-
-    // Tokenizer for MDX variable declarations
-    micromarkExts.push(mdxjsEsm({ acorn: jsxAcornParser, addResult: true }));
-    fromMarkdownExts.push(mdxjsEsmFromMarkdown());
-  }
-
-  if (!safeMode) {
-    // JSX comment tokenizer must come before magicBlock so it claims `{/* ... */}` first
-    micromarkExts.unshift(jsxComment());
-  }
-
-  // Claim `<HTMLBlock>` as one opaque token so broad tokenizers can't fragment its body
-  // We put this last as micromark tries the last-registered extension first, so push (not unshift) to win the `<` race.
-  // micromarkExts.push(htmlBlockComponent());
-  // fromMarkdownExts.push(htmlBlockComponentFromMarkdown());
+  // safeMode drops the expression-producing extensions (jsxComment,
+  // mdxExpressionLenient, mdxjsEsm); the builder owns that gate and the
+  // registration order, which is load-bearing for `<HTMLBlock>`.
+  const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(MDXISH_CONTENT_FEATURES, { safeMode });
 
   const processor = unified()
-    .data('micromarkExtensions', micromarkExts)
-    .data('fromMarkdownExtensions', fromMarkdownExts)
+    .data('micromarkExtensions', micromarkExtensions)
+    .data('fromMarkdownExtensions', fromMarkdownExtensions)
     .use(remarkParse)
     .use(remarkFrontmatter)
     .use(normalizeEmphasisAST)

--- a/lib/mdxishTags.ts
+++ b/lib/mdxishTags.ts
@@ -5,7 +5,7 @@ import { visit } from 'unist-util-visit';
 
 import mdxishMdxComponentBlocks from '../processor/transform/mdxish/components/mdx-blocks';
 import mdxishTables from '../processor/transform/mdxish/tables/mdxish-tables';
-import { isMDXElement } from '../processor/utils';
+import { disableIndentedCode, isMDXElement } from '../processor/utils';
 
 import { jsxTableFromMarkdown } from './mdast-util/jsx-table';
 import { magicBlockFromMarkdown } from './mdast-util/magic-block';
@@ -18,7 +18,7 @@ const tags = (doc: string) => {
   const set = new Set<string>();
 
   const processor = remark()
-    .data('micromarkExtensions', [jsxTable(), magicBlock(), mdxComponent()])
+    .data('micromarkExtensions', [disableIndentedCode, jsxTable(), magicBlock(), mdxComponent()])
     .data('fromMarkdownExtensions', [jsxTableFromMarkdown(), magicBlockFromMarkdown(), mdxComponentFromMarkdown()])
     .use(mdxishMdxComponentBlocks)
     .use(mdxishTables);

--- a/lib/mdxishTags.ts
+++ b/lib/mdxishTags.ts
@@ -5,21 +5,20 @@ import { visit } from 'unist-util-visit';
 
 import mdxishMdxComponentBlocks from '../processor/transform/mdxish/components/mdx-blocks';
 import mdxishTables from '../processor/transform/mdxish/tables/mdxish-tables';
-import { disableIndentedCode, isMDXElement } from '../processor/utils';
+import { isMDXElement } from '../processor/utils';
 
-import { jsxTableFromMarkdown } from './mdast-util/jsx-table';
-import { magicBlockFromMarkdown } from './mdast-util/magic-block';
-import { mdxComponentFromMarkdown } from './mdast-util/mdx-component';
-import { jsxTable } from './micromark/jsx-table';
-import { magicBlock } from './micromark/magic-block';
-import { mdxComponent } from './micromark/mdx-component';
+import { mdxishExtensions } from './micromark/mdxish-extensions';
+
+// Only the extensions that can carry a component name: this pipeline collects
+// tag names, so gemoji/variables/entities would be parsed for nothing.
+const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(['jsxTable', 'magicBlock', 'mdxComponent']);
 
 const tags = (doc: string) => {
   const set = new Set<string>();
 
   const processor = remark()
-    .data('micromarkExtensions', [disableIndentedCode, jsxTable(), magicBlock(), mdxComponent()])
-    .data('fromMarkdownExtensions', [jsxTableFromMarkdown(), magicBlockFromMarkdown(), mdxComponentFromMarkdown()])
+    .data('micromarkExtensions', micromarkExtensions)
+    .data('fromMarkdownExtensions', fromMarkdownExtensions)
     .use(mdxishMdxComponentBlocks)
     .use(mdxishTables);
   const tree = processor.parse(doc);

--- a/lib/mdxishTags.ts
+++ b/lib/mdxishTags.ts
@@ -7,11 +7,9 @@ import mdxishMdxComponentBlocks from '../processor/transform/mdxish/components/m
 import mdxishTables from '../processor/transform/mdxish/tables/mdxish-tables';
 import { isMDXElement } from '../processor/utils';
 
-import { mdxishExtensions } from './micromark/mdxish-extensions';
+import { FEATURES, mdxishExtensions } from './micromark/mdxish-extensions';
 
-// Only the extensions that can carry a component name: this pipeline collects
-// tag names, so gemoji/variables/entities would be parsed for nothing.
-const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(['jsxTable', 'magicBlock', 'mdxComponent']);
+const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(FEATURES.tags);
 
 const tags = (doc: string) => {
   const set = new Set<string>();

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -979,8 +979,10 @@ function createTokenize(mode: 'flow' | 'text') {
  * transformer. All other PascalCase is flow-only; ReadMe's custom components
  * are authored as block-level elements.
  *
- * Excludes tags handled by dedicated tokenizers: Table, HTMLBlock, Glossary,
- * Anchor.
+ * Excludes Table, Glossary and Anchor (`TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS`).
+ * `HTMLBlock` is deliberately *not* excluded — this claims it into the same
+ * opaque `html` node `htmlBlockComponent` would, and the transforms skip it by
+ * name via `GENERIC_MDX_COMPONENT_EXCLUDED_TAGS`.
  *
  * The resulting `html` mdast node is later restructured into an
  * `mdxJsxFlowElement` (block) or `mdxJsxTextElement` (inline) by the

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -5,12 +5,7 @@ import { markdownLineEnding, markdownSpace } from 'micromark-util-character';
 import { htmlBlockNames, htmlRawNames } from 'micromark-util-html-tag-name';
 import { codes, types } from 'micromark-util-symbol';
 
-import {
-  FOREIGN_CONTENT_TAGS,
-  HTML_TABLE_STRUCTURE_TAGS,
-  HTML_VOID_ELEMENTS,
-  NON_REPARSED_BODY_TAGS,
-} from '../../../utils/common-html-words';
+import { FOREIGN_CONTENT_TAGS, HTML_TABLE_STRUCTURE_TAGS, HTML_VOID_ELEMENTS } from '../../../utils/common-html-words';
 import { INLINE_COMPONENT_TAGS, TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
 
 import { markupOnlyContinuation, nonLazyContinuationStart } from './continuation-checks';
@@ -38,19 +33,13 @@ const plainBlockClaimTagNames = new Set(
 const foreignContentTags = new Set<string>(FOREIGN_CONTENT_TAGS);
 
 // Type-7 lowercase tags (a, span, button, and unknown names): CommonMark ends their
-// block at a blank line, fragmenting 4+ column children into indented code. Claimable
-// only in block-wrapper shape (see `blockWrapperOpenerRest`); lookalike openers
-// (`<https://…>`) never find a closer, so their claim retreats cleanly to CommonMark.
-// Voids never close and raw/foreign-content bodies have dedicated owners.
+// block at a blank line, fragmenting the wrapper so its children don't re-nest into
+// one element. Claimable only in block-wrapper shape (see `blockWrapperOpenerRest`);
+// lookalike openers (`<https://…>`) never find a closer, so their claim retreats
+// cleanly to CommonMark. Voids never close and raw/foreign-content bodies have
+// dedicated owners.
 const isBlockWrapperClaimTagName = (tag: string): boolean =>
   !htmlFlowTagNames.has(tag) && !HTML_VOID_ELEMENTS.has(tag) && !foreignContentTags.has(tag);
-
-// Both are 4 columns per CommonMark, but they mean different things: a tab advances
-// to the next multiple of TAB_STOP_WIDTH, and INDENTED_CODE_MIN_COLUMNS is the depth
-// at which a line would fragment into indented code. Named separately so the two
-// concepts don't read as one incidental literal.
-const TAB_STOP_WIDTH = 4;
-const INDENTED_CODE_MIN_COLUMNS = 4;
 
 function resolveToMdxComponent(events: Parameters<Resolver>[0]) {
   let index = events.length;
@@ -120,21 +109,6 @@ function createTokenize(mode: 'flow' | 'text') {
     let pendingBlankLine = false;
     // Type-7 tag claimed pending the block-wrapper (opener alone on its line) check.
     let pendingBlockWrapperClaim = false;
-    // True once a block-wrapper claim is confirmed; relaxes the top-of-body island gate
-    // below (type-7 fallback is the fragmentation bug, not intentional indented code).
-    let isBlockWrapperClaim = false;
-    // Leading indent columns of the current plain-claim line, reset per line; ≥4 is
-    // where CommonMark would fragment the island as indented code. Tabs advance to the
-    // next 4-column stop — the same rule `expandIndentToColumns`
-    // (processor/transform/mdxish/indentation.ts) applies, kept in sync by hand since
-    // this side works on a `Code` stream, not a string. NB: do NOT swap this for
-    // `self.now().column`; micromark bumps the point column by 1 per `horizontalTab`
-    // code (the trailing `virtualSpace` codes don't move it), so it measures a tab as
-    // 1 column, reviving the tab-under-measurement bug this math exists to avoid.
-    let plainClaimIndentColumns = 0;
-    // True once a non-blank line follows the opener: a deep island below it is nested
-    // (cosmetic indent), not top-of-body indented code.
-    let sawPlainBlockBodyContent = false;
 
     // Code span tracking
     let codeSpanOpenSize = 0;
@@ -507,7 +481,6 @@ function createTokenize(mode: 'flow' | 'text') {
       if (!markdownLineEnding(code)) return nok(code);
       pendingBlockWrapperClaim = false;
       isPlainBlockClaim = true;
-      isBlockWrapperClaim = true;
       return body(code);
     }
 
@@ -560,8 +533,6 @@ function createTokenize(mode: 'flow' | 'text') {
 
       if (code !== codes.space && code !== codes.horizontalTab) {
         openerLineHasContent = true;
-        // Continuation content marks a later deep island as nested, not indented code.
-        if (!onOpenerLine) sawPlainBlockBodyContent = true;
       }
 
       if (code === codes.backslash) {
@@ -931,10 +902,7 @@ function createTokenize(mode: 'flow' | 'text') {
         return inBodyBraceExpr(code);
       }
 
-      if (isPlainBlockClaim) {
-        plainClaimIndentColumns = 0;
-        return plainClaimLineStart(code);
-      }
+      if (isPlainBlockClaim) return plainClaimLineStart(code);
       return bodyLineStart(code);
     }
 
@@ -960,18 +928,12 @@ function createTokenize(mode: 'flow' | 'text') {
     }
 
     // Line-start gate for plain block claims. After a blank line the block may only
-    // continue on a tag line (`<…`); any markdown island (`**bold**`, `[block:…]`, a
-    // fence) refuses so CommonMark html-flow reparses it exactly as it does today.
+    // continue on a markup-only tag line (`<…`); anything else (prose, a fence, a
+    // magic block — at any indent, since indented code is disabled) refuses so
+    // CommonMark reparses it as markdown and rehype-raw re-nests it into the wrapper.
     function plainClaimLineStart(code: Code): State | undefined {
-      // Leading whitespace only → treat as a blank line, matching CommonMark. A tab
-      // advances to the next stop; its trailing `virtualSpace` fillers add nothing
-      // but must still be consumed or they'd read as line content below.
+      // Leading whitespace only → treat as a blank line, matching CommonMark.
       if (markdownSpace(code)) {
-        if (code === codes.horizontalTab) {
-          plainClaimIndentColumns += TAB_STOP_WIDTH - (plainClaimIndentColumns % TAB_STOP_WIDTH);
-        } else if (code === codes.space) {
-          plainClaimIndentColumns += 1;
-        }
         effects.consume(code);
         return plainClaimLineStart;
       }
@@ -981,20 +943,6 @@ function createTokenize(mode: 'flow' | 'text') {
         return bodyContinuationStart(code);
       }
       if (pendingBlankLine) {
-        // A 4+ col island nested under other tags is cosmetic nesting indent, not code:
-        // keep claiming so promotion dedents + re-parses it as markdown (RM-17560).
-        // Block-wrapper claims extend this to top-of-body islands — their CommonMark
-        // fallback is the fragmentation bug, not intentional indented code. Tags whose
-        // bodies stay raw are excluded: a claimed island there would leak as literal text.
-        if (
-          plainClaimIndentColumns >= INDENTED_CODE_MIN_COLUMNS &&
-          (sawPlainBlockBodyContent || isBlockWrapperClaim) &&
-          !NON_REPARSED_BODY_TAGS.has(tagName)
-        ) {
-          return plainClaimContinue(code);
-        }
-        // Otherwise only a markup-only tag line continues; markdown/prose falls back to
-        // CommonMark so it parses and rehype-raw re-nests it into the wrapper.
         if (code !== codes.lessThan) return nok(code);
         return effects.check(markupOnlyContinuation, plainClaimContinue, nok)(code);
       }

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -5,12 +5,7 @@ import { markdownLineEnding, markdownSpace } from 'micromark-util-character';
 import { htmlBlockNames, htmlRawNames } from 'micromark-util-html-tag-name';
 import { codes, types } from 'micromark-util-symbol';
 
-import {
-  FOREIGN_CONTENT_TAGS,
-  HTML_TABLE_STRUCTURE_TAGS,
-  HTML_VOID_ELEMENTS,
-  NON_REPARSED_BODY_TAGS,
-} from '../../../utils/common-html-words';
+import { FOREIGN_CONTENT_TAGS, HTML_TABLE_STRUCTURE_TAGS, HTML_VOID_ELEMENTS } from '../../../utils/common-html-words';
 import { INLINE_COMPONENT_TAGS, TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
 
 import { markupOnlyContinuation, nonLazyContinuationStart } from './continuation-checks';
@@ -37,20 +32,12 @@ const plainBlockClaimTagNames = new Set(
 
 const foreignContentTags = new Set<string>(FOREIGN_CONTENT_TAGS);
 
-// Type-7 lowercase tags (a, span, button, and unknown names): CommonMark ends their
-// block at a blank line, fragmenting 4+ column children into indented code. Claimable
-// only in block-wrapper shape (see `blockWrapperOpenerRest`); lookalike openers
-// (`<https://…>`) never find a closer, so their claim retreats cleanly to CommonMark.
-// Voids never close and raw/foreign-content bodies have dedicated owners.
+// Type-7 lowercase tags (a, span, button, unknown names): CommonMark ends their block
+// at a blank line, so the wrapper's children don't re-nest into one element. Only
+// claimable in block-wrapper shape (see `blockWrapperOpenerRest`), and never for voids
+// or raw/foreign-content bodies, which have dedicated owners.
 const isBlockWrapperClaimTagName = (tag: string): boolean =>
   !htmlFlowTagNames.has(tag) && !HTML_VOID_ELEMENTS.has(tag) && !foreignContentTags.has(tag);
-
-// Both are 4 columns per CommonMark, but they mean different things: a tab advances
-// to the next multiple of TAB_STOP_WIDTH, and INDENTED_CODE_MIN_COLUMNS is the depth
-// at which a line would fragment into indented code. Named separately so the two
-// concepts don't read as one incidental literal.
-const TAB_STOP_WIDTH = 4;
-const INDENTED_CODE_MIN_COLUMNS = 4;
 
 function resolveToMdxComponent(events: Parameters<Resolver>[0]) {
   let index = events.length;
@@ -120,21 +107,6 @@ function createTokenize(mode: 'flow' | 'text') {
     let pendingBlankLine = false;
     // Type-7 tag claimed pending the block-wrapper (opener alone on its line) check.
     let pendingBlockWrapperClaim = false;
-    // True once a block-wrapper claim is confirmed; relaxes the top-of-body island gate
-    // below (type-7 fallback is the fragmentation bug, not intentional indented code).
-    let isBlockWrapperClaim = false;
-    // Leading indent columns of the current plain-claim line, reset per line; ≥4 is
-    // where CommonMark would fragment the island as indented code. Tabs advance to the
-    // next 4-column stop — the same rule `expandIndentToColumns`
-    // (processor/transform/mdxish/indentation.ts) applies, kept in sync by hand since
-    // this side works on a `Code` stream, not a string. NB: do NOT swap this for
-    // `self.now().column`; micromark bumps the point column by 1 per `horizontalTab`
-    // code (the trailing `virtualSpace` codes don't move it), so it measures a tab as
-    // 1 column, reviving the tab-under-measurement bug this math exists to avoid.
-    let plainClaimIndentColumns = 0;
-    // True once a non-blank line follows the opener: a deep island below it is nested
-    // (cosmetic indent), not top-of-body indented code.
-    let sawPlainBlockBodyContent = false;
 
     // Code span tracking
     let codeSpanOpenSize = 0;
@@ -507,7 +479,6 @@ function createTokenize(mode: 'flow' | 'text') {
       if (!markdownLineEnding(code)) return nok(code);
       pendingBlockWrapperClaim = false;
       isPlainBlockClaim = true;
-      isBlockWrapperClaim = true;
       return body(code);
     }
 
@@ -560,8 +531,6 @@ function createTokenize(mode: 'flow' | 'text') {
 
       if (code !== codes.space && code !== codes.horizontalTab) {
         openerLineHasContent = true;
-        // Continuation content marks a later deep island as nested, not indented code.
-        if (!onOpenerLine) sawPlainBlockBodyContent = true;
       }
 
       if (code === codes.backslash) {
@@ -931,10 +900,7 @@ function createTokenize(mode: 'flow' | 'text') {
         return inBodyBraceExpr(code);
       }
 
-      if (isPlainBlockClaim) {
-        plainClaimIndentColumns = 0;
-        return plainClaimLineStart(code);
-      }
+      if (isPlainBlockClaim) return plainClaimLineStart(code);
       return bodyLineStart(code);
     }
 
@@ -960,18 +926,11 @@ function createTokenize(mode: 'flow' | 'text') {
     }
 
     // Line-start gate for plain block claims. After a blank line the block may only
-    // continue on a tag line (`<…`); any markdown island (`**bold**`, `[block:…]`, a
-    // fence) refuses so CommonMark html-flow reparses it exactly as it does today.
+    // continue on a markup-only tag line (`<…`); anything else refuses, so CommonMark
+    // reparses it as markdown and rehype-raw re-nests it into the wrapper.
     function plainClaimLineStart(code: Code): State | undefined {
-      // Leading whitespace only → treat as a blank line, matching CommonMark. A tab
-      // advances to the next stop; its trailing `virtualSpace` fillers add nothing
-      // but must still be consumed or they'd read as line content below.
+      // Leading whitespace only → treat as a blank line, matching CommonMark.
       if (markdownSpace(code)) {
-        if (code === codes.horizontalTab) {
-          plainClaimIndentColumns += TAB_STOP_WIDTH - (plainClaimIndentColumns % TAB_STOP_WIDTH);
-        } else if (code === codes.space) {
-          plainClaimIndentColumns += 1;
-        }
         effects.consume(code);
         return plainClaimLineStart;
       }
@@ -981,20 +940,6 @@ function createTokenize(mode: 'flow' | 'text') {
         return bodyContinuationStart(code);
       }
       if (pendingBlankLine) {
-        // A 4+ col island nested under other tags is cosmetic nesting indent, not code:
-        // keep claiming so promotion dedents + re-parses it as markdown (RM-17560).
-        // Block-wrapper claims extend this to top-of-body islands — their CommonMark
-        // fallback is the fragmentation bug, not intentional indented code. Tags whose
-        // bodies stay raw are excluded: a claimed island there would leak as literal text.
-        if (
-          plainClaimIndentColumns >= INDENTED_CODE_MIN_COLUMNS &&
-          (sawPlainBlockBodyContent || isBlockWrapperClaim) &&
-          !NON_REPARSED_BODY_TAGS.has(tagName)
-        ) {
-          return plainClaimContinue(code);
-        }
-        // Otherwise only a markup-only tag line continues; markdown/prose falls back to
-        // CommonMark so it parses and rehype-raw re-nests it into the wrapper.
         if (code !== codes.lessThan) return nok(code);
         return effects.check(markupOnlyContinuation, plainClaimContinue, nok)(code);
       }

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -5,7 +5,12 @@ import { markdownLineEnding, markdownSpace } from 'micromark-util-character';
 import { htmlBlockNames, htmlRawNames } from 'micromark-util-html-tag-name';
 import { codes, types } from 'micromark-util-symbol';
 
-import { FOREIGN_CONTENT_TAGS, HTML_TABLE_STRUCTURE_TAGS, HTML_VOID_ELEMENTS } from '../../../utils/common-html-words';
+import {
+  FOREIGN_CONTENT_TAGS,
+  HTML_TABLE_STRUCTURE_TAGS,
+  HTML_VOID_ELEMENTS,
+  NON_REPARSED_BODY_TAGS,
+} from '../../../utils/common-html-words';
 import { INLINE_COMPONENT_TAGS, TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
 
 import { markupOnlyContinuation, nonLazyContinuationStart } from './continuation-checks';
@@ -33,13 +38,19 @@ const plainBlockClaimTagNames = new Set(
 const foreignContentTags = new Set<string>(FOREIGN_CONTENT_TAGS);
 
 // Type-7 lowercase tags (a, span, button, and unknown names): CommonMark ends their
-// block at a blank line, fragmenting the wrapper so its children don't re-nest into
-// one element. Claimable only in block-wrapper shape (see `blockWrapperOpenerRest`);
-// lookalike openers (`<https://…>`) never find a closer, so their claim retreats
-// cleanly to CommonMark. Voids never close and raw/foreign-content bodies have
-// dedicated owners.
+// block at a blank line, fragmenting 4+ column children into indented code. Claimable
+// only in block-wrapper shape (see `blockWrapperOpenerRest`); lookalike openers
+// (`<https://…>`) never find a closer, so their claim retreats cleanly to CommonMark.
+// Voids never close and raw/foreign-content bodies have dedicated owners.
 const isBlockWrapperClaimTagName = (tag: string): boolean =>
   !htmlFlowTagNames.has(tag) && !HTML_VOID_ELEMENTS.has(tag) && !foreignContentTags.has(tag);
+
+// Both are 4 columns per CommonMark, but they mean different things: a tab advances
+// to the next multiple of TAB_STOP_WIDTH, and INDENTED_CODE_MIN_COLUMNS is the depth
+// at which a line would fragment into indented code. Named separately so the two
+// concepts don't read as one incidental literal.
+const TAB_STOP_WIDTH = 4;
+const INDENTED_CODE_MIN_COLUMNS = 4;
 
 function resolveToMdxComponent(events: Parameters<Resolver>[0]) {
   let index = events.length;
@@ -109,6 +120,21 @@ function createTokenize(mode: 'flow' | 'text') {
     let pendingBlankLine = false;
     // Type-7 tag claimed pending the block-wrapper (opener alone on its line) check.
     let pendingBlockWrapperClaim = false;
+    // True once a block-wrapper claim is confirmed; relaxes the top-of-body island gate
+    // below (type-7 fallback is the fragmentation bug, not intentional indented code).
+    let isBlockWrapperClaim = false;
+    // Leading indent columns of the current plain-claim line, reset per line; ≥4 is
+    // where CommonMark would fragment the island as indented code. Tabs advance to the
+    // next 4-column stop — the same rule `expandIndentToColumns`
+    // (processor/transform/mdxish/indentation.ts) applies, kept in sync by hand since
+    // this side works on a `Code` stream, not a string. NB: do NOT swap this for
+    // `self.now().column`; micromark bumps the point column by 1 per `horizontalTab`
+    // code (the trailing `virtualSpace` codes don't move it), so it measures a tab as
+    // 1 column, reviving the tab-under-measurement bug this math exists to avoid.
+    let plainClaimIndentColumns = 0;
+    // True once a non-blank line follows the opener: a deep island below it is nested
+    // (cosmetic indent), not top-of-body indented code.
+    let sawPlainBlockBodyContent = false;
 
     // Code span tracking
     let codeSpanOpenSize = 0;
@@ -481,6 +507,7 @@ function createTokenize(mode: 'flow' | 'text') {
       if (!markdownLineEnding(code)) return nok(code);
       pendingBlockWrapperClaim = false;
       isPlainBlockClaim = true;
+      isBlockWrapperClaim = true;
       return body(code);
     }
 
@@ -533,6 +560,8 @@ function createTokenize(mode: 'flow' | 'text') {
 
       if (code !== codes.space && code !== codes.horizontalTab) {
         openerLineHasContent = true;
+        // Continuation content marks a later deep island as nested, not indented code.
+        if (!onOpenerLine) sawPlainBlockBodyContent = true;
       }
 
       if (code === codes.backslash) {
@@ -902,7 +931,10 @@ function createTokenize(mode: 'flow' | 'text') {
         return inBodyBraceExpr(code);
       }
 
-      if (isPlainBlockClaim) return plainClaimLineStart(code);
+      if (isPlainBlockClaim) {
+        plainClaimIndentColumns = 0;
+        return plainClaimLineStart(code);
+      }
       return bodyLineStart(code);
     }
 
@@ -928,12 +960,18 @@ function createTokenize(mode: 'flow' | 'text') {
     }
 
     // Line-start gate for plain block claims. After a blank line the block may only
-    // continue on a markup-only tag line (`<…`); anything else (prose, a fence, a
-    // magic block — at any indent, since indented code is disabled) refuses so
-    // CommonMark reparses it as markdown and rehype-raw re-nests it into the wrapper.
+    // continue on a tag line (`<…`); any markdown island (`**bold**`, `[block:…]`, a
+    // fence) refuses so CommonMark html-flow reparses it exactly as it does today.
     function plainClaimLineStart(code: Code): State | undefined {
-      // Leading whitespace only → treat as a blank line, matching CommonMark.
+      // Leading whitespace only → treat as a blank line, matching CommonMark. A tab
+      // advances to the next stop; its trailing `virtualSpace` fillers add nothing
+      // but must still be consumed or they'd read as line content below.
       if (markdownSpace(code)) {
+        if (code === codes.horizontalTab) {
+          plainClaimIndentColumns += TAB_STOP_WIDTH - (plainClaimIndentColumns % TAB_STOP_WIDTH);
+        } else if (code === codes.space) {
+          plainClaimIndentColumns += 1;
+        }
         effects.consume(code);
         return plainClaimLineStart;
       }
@@ -943,6 +981,20 @@ function createTokenize(mode: 'flow' | 'text') {
         return bodyContinuationStart(code);
       }
       if (pendingBlankLine) {
+        // A 4+ col island nested under other tags is cosmetic nesting indent, not code:
+        // keep claiming so promotion dedents + re-parses it as markdown (RM-17560).
+        // Block-wrapper claims extend this to top-of-body islands — their CommonMark
+        // fallback is the fragmentation bug, not intentional indented code. Tags whose
+        // bodies stay raw are excluded: a claimed island there would leak as literal text.
+        if (
+          plainClaimIndentColumns >= INDENTED_CODE_MIN_COLUMNS &&
+          (sawPlainBlockBodyContent || isBlockWrapperClaim) &&
+          !NON_REPARSED_BODY_TAGS.has(tagName)
+        ) {
+          return plainClaimContinue(code);
+        }
+        // Otherwise only a markup-only tag line continues; markdown/prose falls back to
+        // CommonMark so it parses and rehype-raw re-nests it into the wrapper.
         if (code !== codes.lessThan) return nok(code);
         return effects.check(markupOnlyContinuation, plainClaimContinue, nok)(code);
       }

--- a/lib/micromark/mdxish-extensions.ts
+++ b/lib/micromark/mdxish-extensions.ts
@@ -26,8 +26,9 @@ import { mdxComponent } from './mdx-component';
 import { mdxExpressionLenient } from './mdx-expression-lenient';
 
 /**
- * Constructs disabled for every MDXish parser. `codeIndented` because 4+ column
- * indentation is formatting to an MDX author, never code — `mdx-md` drops it too.
+ * Constructs disabled for every MDXish parser. 
+ * -`codeIndented`: To avoing formatting 4+ column indentation as code (default commonmark behavior)
+ *                  and match MDX behavior.
  * Pass `extra` to disable more on top of the shared set, never in place of it.
  */
 export const disableConstructs = (extra: readonly string[] = []): Extension => ({
@@ -43,13 +44,13 @@ interface ExtensionPair {
 
 /**
  * Every MDXish extension, in canonical registration order — **lowest priority
- * first**, each syntax extension paired with its `fromMarkdown` counterpart.
+ * first** (`combineExtensions` prepends, so a later entry is tried first), each
+ * syntax extension paired with its `fromMarkdown` counterpart.
  *
- * `combineExtensions` prepends constructs and nothing sets `add: 'after'`, so a
- * *later* entry is tried *first*. Only `flow` + `<` is contended: keep
- * `htmlBlockComponent` after `mdxComponent`, or `mdxComponent` claims
- * `<HTMLBlock>` (it takes any PascalCase tag outside
- * `TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS`, which `HTMLBlock` is not in).
+ * Notes:
+ * - `<` is the only contended code, in both `flow` and `text`. Every contender
+ *   currently emits the same opaque `html` node, so this order is a latent
+ *   guarantee, not an active fix — it starts mattering if one emits a different token.
  */
 const REGISTRY = {
   jsxComment: { syntax: jsxComment, expression: true },
@@ -123,13 +124,11 @@ export const FEATURES = {
   /**
    * `lib/mdxishTags.ts` — collects component names, so nothing inline is needed.
    * Omits `htmlBlockComponent` deliberately since it's not a custom component,
-   * and not components can be nested inside it (it's just for raw HTML).
+   * and no components are meants to be nested inside it (it's just for raw HTML).
    */
   tags: BLOCK_CLAIMS.filter(feature => feature !== 'htmlBlockComponent'),
 
-  /**
-   * `tables/mdxish-tables.ts` — table cells.
-   */
+  /** `tables/mdxish-tables.ts` — table cells */
   tableCell: [...INLINE],
 
   /** `magic-blocks` — legacy content, no components */

--- a/lib/micromark/mdxish-extensions.ts
+++ b/lib/micromark/mdxish-extensions.ts
@@ -58,11 +58,10 @@ const REGISTRY = {
   // Two `{` tokenizers, never registered together: the document parser takes text
   // only, the component-body re-parser needs flow too for multi-line expressions.
   mdxExpressionLenient: { syntax: mdxExpressionLenient, fromMarkdown: mdxExpressionFromMarkdown, expression: true },
+  // `allowEmpty` is the package default; passed explicitly because `mdx-jsx`
+  // registers the same tokenizer with it off for attribute expressions.
   mdxExpression: {
-    syntax: () => {
-      const ext = mdxExpression({ allowEmpty: true });
-      return { flow: ext.flow, text: ext.text };
-    },
+    syntax: () => mdxExpression({ allowEmpty: true }),
     fromMarkdown: mdxExpressionFromMarkdown,
     expression: true,
   },
@@ -71,6 +70,7 @@ const REGISTRY = {
   legacyVariable: { syntax: legacyVariable, fromMarkdown: legacyVariableFromMarkdown },
   looseHtmlEntity: { syntax: looseHtmlEntity, fromMarkdown: looseHtmlEntityFromMarkdown },
   htmlBlockComponent: { syntax: htmlBlockComponent, fromMarkdown: htmlBlockComponentFromMarkdown },
+  // This is for in-document variable & function definitions
   mdxjsEsm: {
     syntax: () => mdxjsEsm({ acorn: jsxAcornParser, addResult: true }),
     fromMarkdown: mdxjsEsmFromMarkdown,
@@ -90,10 +90,10 @@ const BLOCK_CLAIMS: MdxishFeature[] = ['jsxTable', 'magicBlock', 'mdxComponent',
 const INLINE: MdxishFeature[] = ['gemoji', 'legacyVariable', 'looseHtmlEntity'];
 
 /**
- * `{}` and ESM syntax. A parser that re-parses a component body swaps
+ * `{}` and ESM (export) syntax. A parser that re-parses a component body swaps
  * `mdxExpressionLenient` for the flow-capable `mdxExpression`, so it composes
- * this group itself. What drops these in safeMode is the `expression` flag on
- * each registry entry, not this list — the two don't have to match.
+ * this group itself. The `expression` flag on each registry entry determines what
+ * drops these in safeMode
  */
 const EXPRESSIONS: MdxishFeature[] = ['jsxComment', 'mdxExpressionLenient', 'mdxjsEsm'];
 
@@ -103,10 +103,6 @@ const EXPRESSIONS: MdxishFeature[] = ['jsxComment', 'mdxExpressionLenient', 'mdx
  * The feature set of every MDXish sub-parser, kept together so adding a
  * tokenizer means deciding for each one rather than silently reaching none of
  * them. A site opting out of a group should say so here, in the open.
- *
- * `lib/stripComments.ts` is the one parser missing from this map: it needs
- * `mdxComponent` to outrank `htmlBlockComponent`, the reverse of the canonical
- * order, so it still builds its own list (CX-3708).
  */
 export const FEATURES = {
   /** `lib/mdxish.ts` — the document parser; the only site taking every group */
@@ -116,44 +112,39 @@ export const FEATURES = {
    * `components/utils.ts` — re-parses a component body, which should tokenize
    * like the document around it: when the two drifted a `<Table>` in a
    * `<Callout>` lost every row (CX-3705).
-   *
-   * @todo spelled out rather than composed because it is off both groups —
-   * missing `looseHtmlEntity`, so `&nbsp` renders literally here but as a space
-   * in prose, and missing `htmlBlockComponent`. Both are rendering changes;
-   * once made this collapses to `[...BLOCK_CLAIMS, ...INLINE, 'mdxExpression',
-   * 'emptyTaskListItem']`.
    */
   componentBody: [
-    'jsxTable',
-    'magicBlock',
-    'mdxComponent',
-    'gemoji',
-    'legacyVariable',
+    ...BLOCK_CLAIMS,
+    ...INLINE,
     'mdxExpression',
     'emptyTaskListItem',
   ],
 
   /**
    * `lib/mdxishTags.ts` — collects component names, so nothing inline is needed.
-   * Omits `htmlBlockComponent` deliberately: either way `<HTMLBlock>` is not
-   * reported as a custom component.
+   * Omits `htmlBlockComponent` deliberately since it's not a custom component,
+   * and not components can be nested inside it (it's just for raw HTML).
    */
-  tags: ['jsxTable', 'magicBlock', 'mdxComponent'],
+  tags: BLOCK_CLAIMS.filter(feature => feature !== 'htmlBlockComponent'),
 
   /**
-   * `tables/mdxish-tables.ts` — table cells. The block claims would recurse into
-   * the structure being parsed.
-   *
-   * @todo same `looseHtmlEntity` divergence as `componentBody`; once fixed this
-   * is just `[...INLINE]`.
+   * `tables/mdxish-tables.ts` — table cells.
    */
-  tableCell: ['gemoji', 'legacyVariable'],
+  tableCell: [...INLINE],
 
-  /** `magic-blocks` — callout/image bodies; legacy content, no components */
+  /** `magic-blocks` — legacy content, no components */
   magicBlockBody: [...INLINE, 'emptyTaskListItem'],
 
-  /** `magic-blocks` — api-header titles; also disables block constructs */
+  /** `magic-blocks` — api-header titles */
   apiHeaderTitle: [...INLINE],
+
+  /**
+   * `lib/stripComments.ts` — parses only to strip comments, then re-stringifies,
+   * so it needs the tokenizers that keep a construct in one piece across the
+   * round trip. 
+   * No inline syntax: nothing here rewrites prose, and magic blocks are already excluded.
+   */
+  stripComments: [...BLOCK_CLAIMS.filter(feature => feature !== 'magicBlock'), 'mdxExpression'],
 } satisfies Record<string, MdxishFeature[]>;
 
 /**

--- a/lib/micromark/mdxish-extensions.ts
+++ b/lib/micromark/mdxish-extensions.ts
@@ -3,6 +3,7 @@ import type { Extension } from 'micromark-util-types';
 
 import { mdxExpressionFromMarkdown } from 'mdast-util-mdx-expression';
 import { mdxjsEsmFromMarkdown } from 'mdast-util-mdxjs-esm';
+import { mdxExpression } from 'micromark-extension-mdx-expression';
 import { mdxjsEsm } from 'micromark-extension-mdxjs-esm';
 
 import { emptyTaskListItemFromMarkdown } from '../mdast-util/empty-task-list-item';
@@ -25,51 +26,46 @@ import { mdxComponent } from './mdx-component';
 import { mdxExpressionLenient } from './mdx-expression-lenient';
 
 /**
- * CommonMark constructs disabled for every MDXish parser.
- *
- * `codeIndented`: any line indented 4+ spaces is an indented code block per
- * CommonMark (https://spec.commonmark.org/0.28/#indented-code-blocks), which is
- * unexpected for users coming from MDX — `mdx-md` disables it for the same reason.
- *
- * Adding a construct here applies it to every sub-parser at once; before this
- * list existed each one had to be updated by hand and they drifted (CX-3708).
- */
-export const MDXISH_DISABLED_CONSTRUCTS: readonly string[] = ['codeIndented'];
-
-/**
- * Base construct config every MDXish parser registers. Pass `extra` to disable
- * further constructs on top of the shared set rather than replacing it.
+ * Constructs disabled for every MDXish parser. `codeIndented` because 4+ column
+ * indentation is formatting to an MDX author, never code — `mdx-md` drops it too.
+ * Pass `extra` to disable more on top of the shared set, never in place of it.
  */
 export const disableConstructs = (extra: readonly string[] = []): Extension => ({
-  disable: { null: [...MDXISH_DISABLED_CONSTRUCTS, ...extra] },
+  disable: { null: ['codeIndented', ...extra] },
 });
 
 interface ExtensionPair {
+  /** Produces expression syntax, so safeMode drops it. */
+  expression?: boolean;
   fromMarkdown?: () => FromMarkdownExtension;
   syntax?: () => Extension;
 }
 
 /**
- * Canonical registration order for MDXish content extensions, **lowest priority
- * first**, pairing each syntax extension with its `fromMarkdown` counterpart so
- * the two lists can't fall out of sync.
+ * Every MDXish extension, in canonical registration order — **lowest priority
+ * first**, each syntax extension paired with its `fromMarkdown` counterpart.
  *
- * `micromark-util-combine-extensions` prepends every extension's constructs and
- * nothing here sets `add: 'after'`, so a *later* entry is tried *first*. Only
- * `flow` + `<` is contended — `jsxTable`, `mdxComponent` and `htmlBlockComponent`
- * all claim it, and `htmlBlockComponent` must stay after `mdxComponent` or
- * `mdxComponent` wins `<HTMLBlock>` (it claims any PascalCase tag outside
+ * `combineExtensions` prepends constructs and nothing sets `add: 'after'`, so a
+ * *later* entry is tried *first*. Only `flow` + `<` is contended: keep
+ * `htmlBlockComponent` after `mdxComponent`, or `mdxComponent` claims
+ * `<HTMLBlock>` (it takes any PascalCase tag outside
  * `TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS`, which `HTMLBlock` is not in).
- * Every other extension owns its start code alone, so its position is inert.
- *
- * This order is the document parser's proven one — don't reorder without a
- * regression test for the tag above.
  */
 const REGISTRY = {
-  jsxComment: { syntax: jsxComment },
+  jsxComment: { syntax: jsxComment, expression: true },
   jsxTable: { syntax: jsxTable, fromMarkdown: jsxTableFromMarkdown },
   magicBlock: { syntax: magicBlock, fromMarkdown: magicBlockFromMarkdown },
-  mdxExpressionLenient: { syntax: mdxExpressionLenient, fromMarkdown: mdxExpressionFromMarkdown },
+  // Two `{` tokenizers, never registered together: the document parser takes text
+  // only, the component-body re-parser needs flow too for multi-line expressions.
+  mdxExpressionLenient: { syntax: mdxExpressionLenient, fromMarkdown: mdxExpressionFromMarkdown, expression: true },
+  mdxExpression: {
+    syntax: () => {
+      const ext = mdxExpression({ allowEmpty: true });
+      return { flow: ext.flow, text: ext.text };
+    },
+    fromMarkdown: mdxExpressionFromMarkdown,
+    expression: true,
+  },
   mdxComponent: { syntax: mdxComponent, fromMarkdown: mdxComponentFromMarkdown },
   gemoji: { syntax: gemoji, fromMarkdown: gemojiFromMarkdown },
   legacyVariable: { syntax: legacyVariable, fromMarkdown: legacyVariableFromMarkdown },
@@ -78,77 +74,108 @@ const REGISTRY = {
   mdxjsEsm: {
     syntax: () => mdxjsEsm({ acorn: jsxAcornParser, addResult: true }),
     fromMarkdown: mdxjsEsmFromMarkdown,
+    expression: true,
   },
   emptyTaskListItem: { fromMarkdown: emptyTaskListItemFromMarkdown },
 } satisfies Record<string, ExtensionPair>;
 
 export type MdxishFeature = keyof typeof REGISTRY;
 
-/** Insertion order of `REGISTRY` is the canonical priority order. */
-const FEATURE_ORDER = Object.keys(REGISTRY) as MdxishFeature[];
+// ======= TOKENIZER EXTENSION GROUP DEFINITIONS =======
+
+/** Tokenizers that claim a whole block so broader ones can't fragment it. */
+const BLOCK_CLAIMS: MdxishFeature[] = ['jsxTable', 'magicBlock', 'mdxComponent', 'htmlBlockComponent'];
+
+/** Inline syntax every parser that renders user prose needs. */
+const INLINE: MdxishFeature[] = ['gemoji', 'legacyVariable', 'looseHtmlEntity'];
 
 /**
- * Expression syntax is evaluated downstream, so safeMode drops every extension
- * that produces it. Centralised here so no call site can forget the gate.
+ * `{}` and ESM syntax. A parser that re-parses a component body swaps
+ * `mdxExpressionLenient` for the flow-capable `mdxExpression`, so it composes
+ * this group itself. What drops these in safeMode is the `expression` flag on
+ * each registry entry, not this list — the two don't have to match.
  */
-const SAFE_MODE_EXCLUDED: ReadonlySet<MdxishFeature> = new Set([
-  'jsxComment',
-  'mdxExpressionLenient',
-  'mdxjsEsm',
-]);
+const EXPRESSIONS: MdxishFeature[] = ['jsxComment', 'mdxExpressionLenient', 'mdxjsEsm'];
+
+// ======= TOKENIZER EXTENSION GROUP REGISTRY =======
 
 /**
- * The full MDXish content syntax set, shared by the parsers that render a
- * document: the top-level parser and the component-body re-parser. A component
- * body should tokenize exactly like the document it lives in — when the two
- * drifted, a `<Table>` nested in a `<Callout>` lost all of its rows (CX-3705).
+ * The feature set of every MDXish sub-parser, kept together so adding a
+ * tokenizer means deciding for each one rather than silently reaching none of
+ * them. A site opting out of a group should say so here, in the open.
+ *
+ * `lib/stripComments.ts` is the one parser missing from this map: it needs
+ * `mdxComponent` to outrank `htmlBlockComponent`, the reverse of the canonical
+ * order, so it still builds its own list (CX-3708).
  */
-export const MDXISH_CONTENT_FEATURES: readonly MdxishFeature[] = [
-  'jsxComment',
-  'jsxTable',
-  'magicBlock',
-  'mdxExpressionLenient',
-  'mdxComponent',
-  'gemoji',
-  'legacyVariable',
-  'looseHtmlEntity',
-  'htmlBlockComponent',
-  'mdxjsEsm',
-  'emptyTaskListItem',
-];
+export const FEATURES = {
+  /** `lib/mdxish.ts` — the document parser; the only site taking every group */
+  document: [...BLOCK_CLAIMS, ...INLINE, ...EXPRESSIONS, 'emptyTaskListItem'],
 
-interface MdxishExtensionOpts {
-  /** Constructs to disable on top of `MDXISH_DISABLED_CONSTRUCTS`. */
-  disable?: readonly string[];
-  /** Drops the expression-producing extensions. */
-  safeMode?: boolean;
-}
+  /**
+   * `components/utils.ts` — re-parses a component body, which should tokenize
+   * like the document around it: when the two drifted a `<Table>` in a
+   * `<Callout>` lost every row (CX-3705).
+   *
+   * @todo spelled out rather than composed because it is off both groups —
+   * missing `looseHtmlEntity`, so `&nbsp` renders literally here but as a space
+   * in prose, and missing `htmlBlockComponent`. Both are rendering changes;
+   * once made this collapses to `[...BLOCK_CLAIMS, ...INLINE, 'mdxExpression',
+   * 'emptyTaskListItem']`.
+   */
+  componentBody: [
+    'jsxTable',
+    'magicBlock',
+    'mdxComponent',
+    'gemoji',
+    'legacyVariable',
+    'mdxExpression',
+    'emptyTaskListItem',
+  ],
+
+  /**
+   * `lib/mdxishTags.ts` — collects component names, so nothing inline is needed.
+   * Omits `htmlBlockComponent` deliberately: either way `<HTMLBlock>` is not
+   * reported as a custom component.
+   */
+  tags: ['jsxTable', 'magicBlock', 'mdxComponent'],
+
+  /**
+   * `tables/mdxish-tables.ts` — table cells. The block claims would recurse into
+   * the structure being parsed.
+   *
+   * @todo same `looseHtmlEntity` divergence as `componentBody`; once fixed this
+   * is just `[...INLINE]`.
+   */
+  tableCell: ['gemoji', 'legacyVariable'],
+
+  /** `magic-blocks` — callout/image bodies; legacy content, no components */
+  magicBlockBody: [...INLINE, 'emptyTaskListItem'],
+
+  /** `magic-blocks` — api-header titles; also disables block constructs */
+  apiHeaderTitle: [...INLINE],
+} satisfies Record<string, MdxishFeature[]>;
 
 /**
- * Builds the micromark + `fromMarkdown` extension lists for an MDXish parser.
+ * Builds the extension lists for an MDXish parser. `features` is an unordered
+ * set — ordering is `REGISTRY`'s job, so a call site can't get it wrong — and
+ * the base construct config is always registered.
  *
- * `features` is treated as an unordered set: ordering is this module's job (see
- * `REGISTRY`), so a call site can't introduce an ordering bug by listing them
- * differently. The base construct config is always registered.
- *
- * Extensions outside the registry (`mdxjs()`, `gfmStrikethrough()`) stay at
- * their call site — spread them onto the returned lists. Position is only
- * load-bearing for `flow` + `<`, so appending is safe for everything else.
+ * Extensions outside the registry (`mdxjs()`, `gfmStrikethrough()`) stay at their
+ * call site; spread them onto the result, minding the `flow` + `<` order.
  */
 export function mdxishExtensions(
   features: readonly MdxishFeature[],
-  { disable = [], safeMode = false }: MdxishExtensionOpts = {},
+  { disable = [], safeMode = false }: { disable?: readonly string[]; safeMode?: boolean } = {},
 ): { fromMarkdownExtensions: FromMarkdownExtension[]; micromarkExtensions: Extension[] } {
-  const enabled = new Set(features);
-  const selected: ExtensionPair[] = FEATURE_ORDER.filter(
-    feature => enabled.has(feature) && !(safeMode && SAFE_MODE_EXCLUDED.has(feature)),
-  ).map(feature => REGISTRY[feature]);
+  const enabled: Set<string> = new Set(features);
+  const entries: [string, ExtensionPair][] = Object.entries(REGISTRY);
+  const selected = entries
+    .filter(([feature, pair]) => enabled.has(feature) && !(safeMode && pair.expression))
+    .map(([, pair]) => pair);
 
   return {
     fromMarkdownExtensions: selected.flatMap(({ fromMarkdown }) => (fromMarkdown ? [fromMarkdown()] : [])),
-    micromarkExtensions: [
-      disableConstructs(disable),
-      ...selected.flatMap(({ syntax }) => (syntax ? [syntax()] : [])),
-    ],
+    micromarkExtensions: [disableConstructs(disable), ...selected.flatMap(({ syntax }) => (syntax ? [syntax()] : []))],
   };
 }

--- a/lib/micromark/mdxish-extensions.ts
+++ b/lib/micromark/mdxish-extensions.ts
@@ -27,7 +27,7 @@ import { mdxExpressionLenient } from './mdx-expression-lenient';
 
 /**
  * Constructs disabled for every MDXish parser. 
- * -`codeIndented`: To avoing formatting 4+ column indentation as code (default commonmark behavior)
+ * -`codeIndented`: To avoid formatting 4+ column indentation as code (default commonmark behavior)
  *                  and match MDX behavior.
  * Pass `extra` to disable more on top of the shared set, never in place of it.
  */
@@ -124,7 +124,7 @@ export const FEATURES = {
   /**
    * `lib/mdxishTags.ts` — collects component names, so nothing inline is needed.
    * Omits `htmlBlockComponent` deliberately since it's not a custom component,
-   * and no components are meants to be nested inside it (it's just for raw HTML).
+   * and no components are meant to be nested inside it (it's just for raw HTML).
    */
   tags: BLOCK_CLAIMS.filter(feature => feature !== 'htmlBlockComponent'),
 

--- a/lib/micromark/mdxish-extensions.ts
+++ b/lib/micromark/mdxish-extensions.ts
@@ -1,0 +1,154 @@
+import type { Extension as FromMarkdownExtension } from 'mdast-util-from-markdown';
+import type { Extension } from 'micromark-util-types';
+
+import { mdxExpressionFromMarkdown } from 'mdast-util-mdx-expression';
+import { mdxjsEsmFromMarkdown } from 'mdast-util-mdxjs-esm';
+import { mdxjsEsm } from 'micromark-extension-mdxjs-esm';
+
+import { emptyTaskListItemFromMarkdown } from '../mdast-util/empty-task-list-item';
+import { gemojiFromMarkdown } from '../mdast-util/gemoji';
+import { htmlBlockComponentFromMarkdown } from '../mdast-util/html-block-component';
+import { jsxTableFromMarkdown } from '../mdast-util/jsx-table';
+import { legacyVariableFromMarkdown } from '../mdast-util/legacy-variable';
+import { magicBlockFromMarkdown } from '../mdast-util/magic-block';
+import { mdxComponentFromMarkdown } from '../mdast-util/mdx-component';
+import { jsxAcornParser } from '../utils/jsx-acorn-parser';
+
+import { gemoji } from './gemoji';
+import { htmlBlockComponent } from './html-block-component';
+import { jsxComment } from './jsx-comment';
+import { jsxTable } from './jsx-table';
+import { legacyVariable } from './legacy-variable';
+import { looseHtmlEntity, looseHtmlEntityFromMarkdown } from './loose-html-entities';
+import { magicBlock } from './magic-block';
+import { mdxComponent } from './mdx-component';
+import { mdxExpressionLenient } from './mdx-expression-lenient';
+
+/**
+ * CommonMark constructs disabled for every MDXish parser.
+ *
+ * `codeIndented`: any line indented 4+ spaces is an indented code block per
+ * CommonMark (https://spec.commonmark.org/0.28/#indented-code-blocks), which is
+ * unexpected for users coming from MDX — `mdx-md` disables it for the same reason.
+ *
+ * Adding a construct here applies it to every sub-parser at once; before this
+ * list existed each one had to be updated by hand and they drifted (CX-3708).
+ */
+export const MDXISH_DISABLED_CONSTRUCTS: readonly string[] = ['codeIndented'];
+
+/**
+ * Base construct config every MDXish parser registers. Pass `extra` to disable
+ * further constructs on top of the shared set rather than replacing it.
+ */
+export const disableConstructs = (extra: readonly string[] = []): Extension => ({
+  disable: { null: [...MDXISH_DISABLED_CONSTRUCTS, ...extra] },
+});
+
+interface ExtensionPair {
+  fromMarkdown?: () => FromMarkdownExtension;
+  syntax?: () => Extension;
+}
+
+/**
+ * Canonical registration order for MDXish content extensions, **lowest priority
+ * first**, pairing each syntax extension with its `fromMarkdown` counterpart so
+ * the two lists can't fall out of sync.
+ *
+ * `micromark-util-combine-extensions` prepends every extension's constructs and
+ * nothing here sets `add: 'after'`, so a *later* entry is tried *first*. Only
+ * `flow` + `<` is contended — `jsxTable`, `mdxComponent` and `htmlBlockComponent`
+ * all claim it, and `htmlBlockComponent` must stay after `mdxComponent` or
+ * `mdxComponent` wins `<HTMLBlock>` (it claims any PascalCase tag outside
+ * `TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS`, which `HTMLBlock` is not in).
+ * Every other extension owns its start code alone, so its position is inert.
+ *
+ * This order is the document parser's proven one — don't reorder without a
+ * regression test for the tag above.
+ */
+const REGISTRY = {
+  jsxComment: { syntax: jsxComment },
+  jsxTable: { syntax: jsxTable, fromMarkdown: jsxTableFromMarkdown },
+  magicBlock: { syntax: magicBlock, fromMarkdown: magicBlockFromMarkdown },
+  mdxExpressionLenient: { syntax: mdxExpressionLenient, fromMarkdown: mdxExpressionFromMarkdown },
+  mdxComponent: { syntax: mdxComponent, fromMarkdown: mdxComponentFromMarkdown },
+  gemoji: { syntax: gemoji, fromMarkdown: gemojiFromMarkdown },
+  legacyVariable: { syntax: legacyVariable, fromMarkdown: legacyVariableFromMarkdown },
+  looseHtmlEntity: { syntax: looseHtmlEntity, fromMarkdown: looseHtmlEntityFromMarkdown },
+  htmlBlockComponent: { syntax: htmlBlockComponent, fromMarkdown: htmlBlockComponentFromMarkdown },
+  mdxjsEsm: {
+    syntax: () => mdxjsEsm({ acorn: jsxAcornParser, addResult: true }),
+    fromMarkdown: mdxjsEsmFromMarkdown,
+  },
+  emptyTaskListItem: { fromMarkdown: emptyTaskListItemFromMarkdown },
+} satisfies Record<string, ExtensionPair>;
+
+export type MdxishFeature = keyof typeof REGISTRY;
+
+/** Insertion order of `REGISTRY` is the canonical priority order. */
+const FEATURE_ORDER = Object.keys(REGISTRY) as MdxishFeature[];
+
+/**
+ * Expression syntax is evaluated downstream, so safeMode drops every extension
+ * that produces it. Centralised here so no call site can forget the gate.
+ */
+const SAFE_MODE_EXCLUDED: ReadonlySet<MdxishFeature> = new Set([
+  'jsxComment',
+  'mdxExpressionLenient',
+  'mdxjsEsm',
+]);
+
+/**
+ * The full MDXish content syntax set, shared by the parsers that render a
+ * document: the top-level parser and the component-body re-parser. A component
+ * body should tokenize exactly like the document it lives in — when the two
+ * drifted, a `<Table>` nested in a `<Callout>` lost all of its rows (CX-3705).
+ */
+export const MDXISH_CONTENT_FEATURES: readonly MdxishFeature[] = [
+  'jsxComment',
+  'jsxTable',
+  'magicBlock',
+  'mdxExpressionLenient',
+  'mdxComponent',
+  'gemoji',
+  'legacyVariable',
+  'looseHtmlEntity',
+  'htmlBlockComponent',
+  'mdxjsEsm',
+  'emptyTaskListItem',
+];
+
+interface MdxishExtensionOpts {
+  /** Constructs to disable on top of `MDXISH_DISABLED_CONSTRUCTS`. */
+  disable?: readonly string[];
+  /** Drops the expression-producing extensions. */
+  safeMode?: boolean;
+}
+
+/**
+ * Builds the micromark + `fromMarkdown` extension lists for an MDXish parser.
+ *
+ * `features` is treated as an unordered set: ordering is this module's job (see
+ * `REGISTRY`), so a call site can't introduce an ordering bug by listing them
+ * differently. The base construct config is always registered.
+ *
+ * Extensions outside the registry (`mdxjs()`, `gfmStrikethrough()`) stay at
+ * their call site — spread them onto the returned lists. Position is only
+ * load-bearing for `flow` + `<`, so appending is safe for everything else.
+ */
+export function mdxishExtensions(
+  features: readonly MdxishFeature[],
+  { disable = [], safeMode = false }: MdxishExtensionOpts = {},
+): { fromMarkdownExtensions: FromMarkdownExtension[]; micromarkExtensions: Extension[] } {
+  const enabled = new Set(features);
+  const selected: ExtensionPair[] = FEATURE_ORDER.filter(
+    feature => enabled.has(feature) && !(safeMode && SAFE_MODE_EXCLUDED.has(feature)),
+  ).map(feature => REGISTRY[feature]);
+
+  return {
+    fromMarkdownExtensions: selected.flatMap(({ fromMarkdown }) => (fromMarkdown ? [fromMarkdown()] : [])),
+    micromarkExtensions: [
+      disableConstructs(disable),
+      ...selected.flatMap(({ syntax }) => (syntax ? [syntax()] : [])),
+    ],
+  };
+}

--- a/lib/stripComments.ts
+++ b/lib/stripComments.ts
@@ -9,7 +9,6 @@ import { unified } from 'unified';
 
 import normalizeEmphasisAST from '../processor/transform/mdxish/normalize-malformed-md-syntax';
 import { stripCommentsTransformer } from '../processor/transform/stripComments';
-import { disableIndentedCode } from '../processor/utils';
 
 import { htmlBlockComponentFromMarkdown } from './mdast-util/html-block-component';
 import { jsxTableFromMarkdown } from './mdast-util/jsx-table';
@@ -17,6 +16,7 @@ import { mdxComponentFromMarkdown } from './mdast-util/mdx-component';
 import { htmlBlockComponent } from './micromark/html-block-component';
 import { jsxTable } from './micromark/jsx-table';
 import { mdxComponent } from './micromark/mdx-component';
+import { disableConstructs } from './micromark/mdxish-extensions';
 import { extractMagicBlocks, restoreMagicBlocks } from './utils/extractMagicBlocks';
 
 interface Opts {
@@ -39,7 +39,16 @@ async function stripComments(doc: string, { mdx, mdxish }: Opts = {}): Promise<s
   // 4. we need mdxComponent to parse custom components as one node, and prevent the tag from getting escaped
   if (mdxish) {
     processor
-      .data('micromarkExtensions', [disableIndentedCode, htmlBlockComponent(), jsxTable(), mdxComponent(), mdxExpression({ allowEmpty: true })])
+      // NOTE: `mdxComponent` is registered last, so it — not `htmlBlockComponent` —
+      // wins the `<` race and claims `<HTMLBlock>` here, the opposite of the
+      // document parser. Converging the two is tracked as part of CX-3708.
+      .data('micromarkExtensions', [
+        disableConstructs(),
+        htmlBlockComponent(),
+        jsxTable(),
+        mdxComponent(),
+        mdxExpression({ allowEmpty: true }),
+      ])
       .data('fromMarkdownExtensions', [
         htmlBlockComponentFromMarkdown(),
         jsxTableFromMarkdown(),

--- a/lib/stripComments.ts
+++ b/lib/stripComments.ts
@@ -9,6 +9,7 @@ import { unified } from 'unified';
 
 import normalizeEmphasisAST from '../processor/transform/mdxish/normalize-malformed-md-syntax';
 import { stripCommentsTransformer } from '../processor/transform/stripComments';
+import { disableIndentedCode } from '../processor/utils';
 
 import { htmlBlockComponentFromMarkdown } from './mdast-util/html-block-component';
 import { jsxTableFromMarkdown } from './mdast-util/jsx-table';
@@ -38,7 +39,7 @@ async function stripComments(doc: string, { mdx, mdxish }: Opts = {}): Promise<s
   // 4. we need mdxComponent to parse custom components as one node, and prevent the tag from getting escaped
   if (mdxish) {
     processor
-      .data('micromarkExtensions', [htmlBlockComponent(), jsxTable(), mdxComponent(), mdxExpression({ allowEmpty: true })])
+      .data('micromarkExtensions', [disableIndentedCode, htmlBlockComponent(), jsxTable(), mdxComponent(), mdxExpression({ allowEmpty: true })])
       .data('fromMarkdownExtensions', [
         htmlBlockComponentFromMarkdown(),
         jsxTableFromMarkdown(),

--- a/lib/stripComments.ts
+++ b/lib/stripComments.ts
@@ -1,6 +1,5 @@
 import { VARIABLE_REGEXP } from '@readme/variable';
-import { mdxExpressionFromMarkdown, mdxExpressionToMarkdown } from 'mdast-util-mdx-expression';
-import { mdxExpression } from 'micromark-extension-mdx-expression';
+import { mdxExpressionToMarkdown } from 'mdast-util-mdx-expression';
 import remarkGfm from 'remark-gfm';
 import remarkMdx from 'remark-mdx';
 import remarkParse from 'remark-parse';
@@ -10,13 +9,7 @@ import { unified } from 'unified';
 import normalizeEmphasisAST from '../processor/transform/mdxish/normalize-malformed-md-syntax';
 import { stripCommentsTransformer } from '../processor/transform/stripComments';
 
-import { htmlBlockComponentFromMarkdown } from './mdast-util/html-block-component';
-import { jsxTableFromMarkdown } from './mdast-util/jsx-table';
-import { mdxComponentFromMarkdown } from './mdast-util/mdx-component';
-import { htmlBlockComponent } from './micromark/html-block-component';
-import { jsxTable } from './micromark/jsx-table';
-import { mdxComponent } from './micromark/mdx-component';
-import { disableConstructs } from './micromark/mdxish-extensions';
+import { FEATURES, mdxishExtensions } from './micromark/mdxish-extensions';
 import { extractMagicBlocks, restoreMagicBlocks } from './utils/extractMagicBlocks';
 
 interface Opts {
@@ -32,26 +25,17 @@ async function stripComments(doc: string, { mdx, mdxish }: Opts = {}): Promise<s
 
   const processor = unified();
 
-  // we still require these extensions because:
-  // 1. we can rely on remarkMdx to parse MDXish
-  // 2. we need to parse JSX comments into mdxTextExpression nodes so that the transformers can pick them up
-  // 3. we need to claim <HTMLBlock> before htmlFlow intercepts its inner HTML tags
-  // 4. we need mdxComponent to parse custom components as one node, and prevent the tag from getting escaped
+  // We can't lean on remarkMdx for MDXish, so these tokenizers keep each
+  // construct in one node across the parse/stringify round trip: JSX comments
+  // become mdxTextExpression nodes the transformer can find, `<HTMLBlock>` is
+  // claimed before htmlFlow intercepts its inner tags, and a custom component
+  // stays whole instead of having its tag escaped.
   if (mdxish) {
+    const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(FEATURES.stripComments);
+
     processor
-      .data('micromarkExtensions', [
-        disableConstructs(),
-        htmlBlockComponent(),
-        jsxTable(),
-        mdxComponent(),
-        mdxExpression({ allowEmpty: true }),
-      ])
-      .data('fromMarkdownExtensions', [
-        htmlBlockComponentFromMarkdown(),
-        jsxTableFromMarkdown(),
-        mdxComponentFromMarkdown(),
-        mdxExpressionFromMarkdown(),
-      ])
+      .data('micromarkExtensions', micromarkExtensions)
+      .data('fromMarkdownExtensions', fromMarkdownExtensions)
       .data('toMarkdownExtensions', [mdxExpressionToMarkdown()]);
   }
 

--- a/lib/stripComments.ts
+++ b/lib/stripComments.ts
@@ -39,9 +39,6 @@ async function stripComments(doc: string, { mdx, mdxish }: Opts = {}): Promise<s
   // 4. we need mdxComponent to parse custom components as one node, and prevent the tag from getting escaped
   if (mdxish) {
     processor
-      // NOTE: `mdxComponent` is registered last, so it — not `htmlBlockComponent` —
-      // wins the `<` race and claims `<HTMLBlock>` here, the opposite of the
-      // document parser. Converging the two is tracked as part of CX-3708.
       .data('micromarkExtensions', [
         disableConstructs(),
         htmlBlockComponent(),

--- a/lib/utils/jsx-acorn-parser.ts
+++ b/lib/utils/jsx-acorn-parser.ts
@@ -1,0 +1,12 @@
+import { Parser } from 'acorn';
+import acornJsx from 'acorn-jsx';
+
+/**
+ * Single instance of acorn parser extended with `acorn-jsx`
+ * to parse expressions containing JSX.
+ *
+ * Lives in its own dependency-free module because the micromark extension
+ * registry needs it during module initialisation, and `processor/utils` sits in
+ * an import cycle with the parsers that consume the registry.
+ */
+export const jsxAcornParser = Parser.extend(acornJsx());

--- a/processor/transform/mdxish/collapse-foreign-content-blank-lines.ts
+++ b/processor/transform/mdxish/collapse-foreign-content-blank-lines.ts
@@ -68,7 +68,8 @@ function findForeignContentSpans(text: string): [number, number][] {
 /**
  * Drop blank lines inside `<svg>`/`<math>` islands: their whitespace is
  * insignificant XML, but a blank line ends the CommonMark HTML block and spills the
- * children out as a code block (#1545). Collapsing keeps the island one block.
+ * children out of the island, where parse5 drops the orphaned foreign tags (#1545).
+ * Collapsing keeps the island one block.
  */
 export function collapseForeignContentBlankLines(content: string): string {
   // Fast path: nothing to do when the doc has no foreign-content island.

--- a/processor/transform/mdxish/collapse-foreign-content-blank-lines.ts
+++ b/processor/transform/mdxish/collapse-foreign-content-blank-lines.ts
@@ -68,8 +68,7 @@ function findForeignContentSpans(text: string): [number, number][] {
 /**
  * Drop blank lines inside `<svg>`/`<math>` islands: their whitespace is
  * insignificant XML, but a blank line ends the CommonMark HTML block and spills the
- * children out of the island, where parse5 drops the orphaned foreign tags (#1545).
- * Collapsing keeps the island one block.
+ * children out as a code block (#1545). Collapsing keeps the island one block.
  */
 export function collapseForeignContentBlankLines(content: string): string {
   // Fast path: nothing to do when the doc has no foreign-content island.

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -34,15 +34,15 @@ const hasNestedGenericComponentTag = (content: string): boolean =>
   [...content.matchAll(NESTED_COMPONENT_TAG_RE)].some(match => !GENERIC_MDX_COMPONENT_EXCLUDED_TAGS.has(match[1]));
 
 /**
- * Strip the shared leading indentation from a component body so readability indentation
- * isn't parsed as indented code (4+ columns), e.g. `  <p>` / `   text` -> `<p>` / ` text`.
- * Relative indentation is kept, so content genuinely 4+ columns deeper stays code. We
- * only strip when a line actually reaches 4 columns; otherwise the body is left as-is so
- * its leading whitespace survives as text nodes (mixed component + HTML content needs it).
+ * Strip the shared leading indentation from a component body so it parses as it would at
+ * column 0, e.g. `  <p>` / `   text` -> `<p>` / ` text`. Columns still shape parsing
+ * (list/blockquote continuation, table rows, the mdxComponent claim gates), and relative
+ * indentation is kept so genuinely deeper content still nests. We only strip when a line
+ * reaches 4 columns; otherwise leading whitespace survives as text nodes, which mixed
+ * component + HTML content needs.
  *
- * Indentation is measured in CommonMark columns (tab = up to 4), matching how the parser
- * decides indented code. A char count (tab = 1) under-measures tab-indented bodies, so
- * they slip past the 4-column gate and their nested content fragments into code blocks.
+ * Indentation is measured in CommonMark columns (tab = up to 4), matching micromark: a
+ * char count (tab = 1) under-measures tab-indented bodies so they slip the gate (#1556).
  */
 function safeDeindent(text: string): string {
   const lines = text.split('\n');

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -34,17 +34,15 @@ const hasNestedGenericComponentTag = (content: string): boolean =>
   [...content.matchAll(NESTED_COMPONENT_TAG_RE)].some(match => !GENERIC_MDX_COMPONENT_EXCLUDED_TAGS.has(match[1]));
 
 /**
- * Strip the shared leading indentation from a component body so it parses as it would
- * at column 0, e.g. `  <p>` / `   text` -> `<p>` / ` text`. Indented code is disabled,
- * but columns still shape parsing — list/blockquote continuation, table rows, and the
- * mdxComponent claim gates all measure the line prefix — and relative indentation is
- * kept so genuinely deeper content still nests. We only strip when a line actually
- * reaches 4 columns; otherwise the body is left as-is so its leading whitespace
- * survives as text nodes (mixed component + HTML content needs it).
+ * Strip the shared leading indentation from a component body so readability indentation
+ * isn't parsed as indented code (4+ columns), e.g. `  <p>` / `   text` -> `<p>` / ` text`.
+ * Relative indentation is kept, so content genuinely 4+ columns deeper stays code. We
+ * only strip when a line actually reaches 4 columns; otherwise the body is left as-is so
+ * its leading whitespace survives as text nodes (mixed component + HTML content needs it).
  *
- * Indentation is measured in CommonMark columns (tab = up to 4), matching micromark.
- * A char count (tab = 1) under-measures tab-indented bodies, so they slip past the
- * 4-column gate and their nested content mis-parses (#1556).
+ * Indentation is measured in CommonMark columns (tab = up to 4), matching how the parser
+ * decides indented code. A char count (tab = 1) under-measures tab-indented bodies, so
+ * they slip past the 4-column gate and their nested content fragments into code blocks.
  */
 function safeDeindent(text: string): string {
   const lines = text.split('\n');

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -34,15 +34,17 @@ const hasNestedGenericComponentTag = (content: string): boolean =>
   [...content.matchAll(NESTED_COMPONENT_TAG_RE)].some(match => !GENERIC_MDX_COMPONENT_EXCLUDED_TAGS.has(match[1]));
 
 /**
- * Strip the shared leading indentation from a component body so readability indentation
- * isn't parsed as indented code (4+ columns), e.g. `  <p>` / `   text` -> `<p>` / ` text`.
- * Relative indentation is kept, so content genuinely 4+ columns deeper stays code. We
- * only strip when a line actually reaches 4 columns; otherwise the body is left as-is so
- * its leading whitespace survives as text nodes (mixed component + HTML content needs it).
+ * Strip the shared leading indentation from a component body so it parses as it would
+ * at column 0, e.g. `  <p>` / `   text` -> `<p>` / ` text`. Indented code is disabled,
+ * but columns still shape parsing — list/blockquote continuation, table rows, and the
+ * mdxComponent claim gates all measure the line prefix — and relative indentation is
+ * kept so genuinely deeper content still nests. We only strip when a line actually
+ * reaches 4 columns; otherwise the body is left as-is so its leading whitespace
+ * survives as text nodes (mixed component + HTML content needs it).
  *
- * Indentation is measured in CommonMark columns (tab = up to 4), matching how the parser
- * decides indented code. A char count (tab = 1) under-measures tab-indented bodies, so
- * they slip past the 4-column gate and their nested content fragments into code blocks.
+ * Indentation is measured in CommonMark columns (tab = up to 4), matching micromark.
+ * A char count (tab = 1) under-measures tab-indented bodies, so they slip past the
+ * 4-column gate and their nested content mis-parses (#1556).
  */
 function safeDeindent(text: string): string {
   const lines = text.split('\n');

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -1,26 +1,13 @@
 import type { Html, Node, PhrasingContent } from 'mdast';
 import type { MdxJsxAttribute, MdxJsxExpressionAttribute, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 
-import { mdxExpressionFromMarkdown } from 'mdast-util-mdx-expression';
-import { mdxExpression } from 'micromark-extension-mdx-expression';
 import { htmlRawNames } from 'micromark-util-html-tag-name';
 import remarkGfm from 'remark-gfm';
 import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 
 import { NodeTypes } from '../../../../enums';
-import { emptyTaskListItemFromMarkdown } from '../../../../lib/mdast-util/empty-task-list-item';
-import { gemojiFromMarkdown } from '../../../../lib/mdast-util/gemoji';
-import { jsxTableFromMarkdown } from '../../../../lib/mdast-util/jsx-table';
-import { legacyVariableFromMarkdown } from '../../../../lib/mdast-util/legacy-variable';
-import { magicBlockFromMarkdown } from '../../../../lib/mdast-util/magic-block';
-import { mdxComponentFromMarkdown } from '../../../../lib/mdast-util/mdx-component';
-import { gemoji } from '../../../../lib/micromark/gemoji';
-import { jsxTable } from '../../../../lib/micromark/jsx-table';
-import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
-import { magicBlock } from '../../../../lib/micromark/magic-block';
-import { mdxComponent } from '../../../../lib/micromark/mdx-component';
-import { disableConstructs } from '../../../../lib/micromark/mdxish-extensions';
+import { FEATURES, mdxishExtensions } from '../../../../lib/micromark/mdxish-extensions';
 import { NON_REPARSED_BODY_TAGS } from '../../../../utils/common-html-words';
 import { walkTags } from '../tables/tag-walker';
 import { tableTags } from '../tables/utils';
@@ -28,31 +15,11 @@ import { tableTags } from '../tables/utils';
 export type MdxAttributes = (MdxJsxAttribute | MdxJsxExpressionAttribute)[];
 
 const buildInlineMdProcessor = (safeMode: boolean) => {
-  // `jsxTable` must be present so a `<Table>`/`<table>` nested in a component
-  // body (e.g. a `<Callout>`) is captured as one html node. Without it, blank
-  // lines between rows let CommonMark HTML block type 6 fragment the table and
-  // its rows spill out as text / indented code blocks (CX-3705).
-  const micromarkExts = [disableConstructs(), jsxTable(), mdxComponent(), gemoji(), legacyVariable(), magicBlock()];
-  const fromMarkdownExts = [
-    jsxTableFromMarkdown(),
-    mdxComponentFromMarkdown(),
-    gemojiFromMarkdown(),
-    legacyVariableFromMarkdown(),
-    emptyTaskListItemFromMarkdown(),
-    magicBlockFromMarkdown(),
-  ];
-
-  // Since evaluating expressions can be dangerous, do so only when safeMode is off
-  if (!safeMode) {
-    const mdxExprExt = mdxExpression({ allowEmpty: true });
-    // We include both flow and text extensions to support both single-line and multi-line expressions
-    micromarkExts.push({ flow: mdxExprExt.flow, text: mdxExprExt.text });
-    fromMarkdownExts.push(mdxExpressionFromMarkdown());
-  }
+  const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(FEATURES.componentBody, { safeMode });
 
   return unified()
-    .data('micromarkExtensions', micromarkExts)
-    .data('fromMarkdownExtensions', fromMarkdownExts)
+    .data('micromarkExtensions', micromarkExtensions)
+    .data('fromMarkdownExtensions', fromMarkdownExtensions)
     .use(remarkParse)
     .use(remarkGfm);
 };

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -20,8 +20,8 @@ import { jsxTable } from '../../../../lib/micromark/jsx-table';
 import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
 import { magicBlock } from '../../../../lib/micromark/magic-block';
 import { mdxComponent } from '../../../../lib/micromark/mdx-component';
+import { disableConstructs } from '../../../../lib/micromark/mdxish-extensions';
 import { NON_REPARSED_BODY_TAGS } from '../../../../utils/common-html-words';
-import { disableIndentedCode } from '../../../utils';
 import { walkTags } from '../tables/tag-walker';
 import { tableTags } from '../tables/utils';
 
@@ -32,7 +32,7 @@ const buildInlineMdProcessor = (safeMode: boolean) => {
   // body (e.g. a `<Callout>`) is captured as one html node. Without it, blank
   // lines between rows let CommonMark HTML block type 6 fragment the table and
   // its rows spill out as text / indented code blocks (CX-3705).
-  const micromarkExts = [disableIndentedCode, jsxTable(), mdxComponent(), gemoji(), legacyVariable(), magicBlock()];
+  const micromarkExts = [disableConstructs(), jsxTable(), mdxComponent(), gemoji(), legacyVariable(), magicBlock()];
   const fromMarkdownExts = [
     jsxTableFromMarkdown(),
     mdxComponentFromMarkdown(),

--- a/processor/transform/mdxish/indentation.ts
+++ b/processor/transform/mdxish/indentation.ts
@@ -2,11 +2,11 @@
  * CommonMark indentation helpers, shared by the mdxish preprocessors so tab- and
  * space-indented content is measured (and sliced) on one scale.
  *
- * CommonMark measures indentation in *columns*, and a tab is a 4-column tab stop —
- * not a fixed 4 characters. Counting characters (tab = 1) under-measures tab-indented
- * lines, so column-anchored decisions (body dedenting, HTML-flow termination) would
- * drift from how micromark reads the same lines. Keeping one implementation here
- * stops the callers from drifting on what a column means.
+ * CommonMark's indented-code threshold is 4 *columns*, and a tab is a 4-column tab
+ * stop — not a fixed 4 characters. Counting characters (tab = 1) under-measures
+ * tab-indented lines, letting them slip past the 4-column gate so their content
+ * fragments into code blocks. Keeping one implementation here stops the two callers
+ * from drifting on what "4 columns" means.
  */
 
 /** The run of leading spaces/tabs on a line. */

--- a/processor/transform/mdxish/indentation.ts
+++ b/processor/transform/mdxish/indentation.ts
@@ -2,11 +2,10 @@
  * CommonMark indentation helpers, shared by the mdxish preprocessors so tab- and
  * space-indented content is measured (and sliced) on one scale.
  *
- * CommonMark's indented-code threshold is 4 *columns*, and a tab is a 4-column tab
- * stop — not a fixed 4 characters. Counting characters (tab = 1) under-measures
- * tab-indented lines, letting them slip past the 4-column gate so their content
- * fragments into code blocks. Keeping one implementation here stops the two callers
- * from drifting on what "4 columns" means.
+ * CommonMark measures indentation in *columns*, and a tab is a 4-column tab stop — not a
+ * fixed 4 characters. Counting characters (tab = 1) under-measures tab-indented lines, so
+ * column-anchored decisions (body dedenting, HTML-flow termination) would drift from how
+ * micromark reads the same lines.
  */
 
 /** The run of leading spaces/tabs on a line. */

--- a/processor/transform/mdxish/indentation.ts
+++ b/processor/transform/mdxish/indentation.ts
@@ -2,11 +2,11 @@
  * CommonMark indentation helpers, shared by the mdxish preprocessors so tab- and
  * space-indented content is measured (and sliced) on one scale.
  *
- * CommonMark's indented-code threshold is 4 *columns*, and a tab is a 4-column tab
- * stop — not a fixed 4 characters. Counting characters (tab = 1) under-measures
- * tab-indented lines, letting them slip past the 4-column gate so their content
- * fragments into code blocks. Keeping one implementation here stops the two callers
- * from drifting on what "4 columns" means.
+ * CommonMark measures indentation in *columns*, and a tab is a 4-column tab stop —
+ * not a fixed 4 characters. Counting characters (tab = 1) under-measures tab-indented
+ * lines, so column-anchored decisions (body dedenting, HTML-flow termination) would
+ * drift from how micromark reads the same lines. Keeping one implementation here
+ * stops the callers from drifting on what a column means.
  */
 
 /** The run of leading spaces/tabs on a line. */

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -37,15 +37,10 @@ import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 import { visitParents } from 'unist-util-visit-parents';
 
-import { emptyTaskListItemFromMarkdown } from '../../../../lib/mdast-util/empty-task-list-item';
-import { gemojiFromMarkdown } from '../../../../lib/mdast-util/gemoji';
-import { legacyVariableFromMarkdown } from '../../../../lib/mdast-util/legacy-variable';
-import { gemoji } from '../../../../lib/micromark/gemoji';
-import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
-import { looseHtmlEntity, looseHtmlEntityFromMarkdown } from '../../../../lib/micromark/loose-html-entities';
+import { mdxishExtensions } from '../../../../lib/micromark/mdxish-extensions';
 import { STANDARD_HTML_TAGS } from '../../../../utils/common-html-words';
 import hardBreaks from '../../../plugin/hard-breaks';
-import { disableIndentedCode, toAttributes } from '../../../utils';
+import { toAttributes } from '../../../utils';
 import normalizeEmphasisAST from '../normalize-malformed-md-syntax';
 
 import {
@@ -117,10 +112,14 @@ const preprocessBody = (text: string): string => {
   return ensureLeadingBreaks(text);
 };
 
+// A magic block body is legacy content: it carries the inline syntax but never
+// the component/table tokenizers, which the surrounding document parser owns.
+const bodyExtensions = mdxishExtensions(['gemoji', 'legacyVariable', 'looseHtmlEntity', 'emptyTaskListItem']);
+
 /** Markdown parser */
 const contentParser = unified()
-  .data('micromarkExtensions', [disableIndentedCode, gemoji(), legacyVariable(), looseHtmlEntity()])
-  .data('fromMarkdownExtensions', [gemojiFromMarkdown(), legacyVariableFromMarkdown(), emptyTaskListItemFromMarkdown(), looseHtmlEntityFromMarkdown()])
+  .data('micromarkExtensions', bodyExtensions.micromarkExtensions)
+  .data('fromMarkdownExtensions', bodyExtensions.fromMarkdownExtensions)
   .use(remarkParse)
   .use(hardBreaks)
   .use(remarkGfm)
@@ -134,8 +133,8 @@ const contentParser = unified()
  * such as `<ul><li>https://a</li>\n</ul>` due to subtokenizing recursion for URLs
  */
 const markdownToHtml = unified()
-  .data('micromarkExtensions', [disableIndentedCode, gfmStrikethrough(), gemoji(), legacyVariable(), looseHtmlEntity()])
-  .data('fromMarkdownExtensions', [gfmStrikethroughFromMarkdown(), gemojiFromMarkdown(), legacyVariableFromMarkdown(), emptyTaskListItemFromMarkdown(), looseHtmlEntityFromMarkdown()])
+  .data('micromarkExtensions', [...bodyExtensions.micromarkExtensions, gfmStrikethrough()])
+  .data('fromMarkdownExtensions', [...bodyExtensions.fromMarkdownExtensions, gfmStrikethroughFromMarkdown()])
   .use(remarkParse)
   .use(normalizeEmphasisAST)
   .use(remarkRehype)
@@ -301,25 +300,16 @@ const parseBlock = (text: string): MdastNode[] => {
 
 /**
  * Minimal parser for api-header titles.
- * Disables markdown constructs that are not parsed in legacy (headings, lists)
+ * Disables markdown constructs that are not parsed in legacy (headings, lists),
+ * on top of the base set rather than in place of it.
  */
+const titleExtensions = mdxishExtensions(['gemoji', 'legacyVariable', 'looseHtmlEntity'], {
+  disable: ['blockQuote', 'headingAtx', 'list', 'thematicBreak'],
+});
+
 const apiHeaderTitleParser = unified()
-  .data('micromarkExtensions', [
-    gemoji(),
-    legacyVariable(),
-    looseHtmlEntity(),
-    {
-      disable: {
-        null: [
-          'blockQuote',
-          'headingAtx',
-          'list',
-          'thematicBreak',
-        ],
-      },
-    },
-  ])
-  .data('fromMarkdownExtensions', [gemojiFromMarkdown(), legacyVariableFromMarkdown(), looseHtmlEntityFromMarkdown()])
+  .data('micromarkExtensions', titleExtensions.micromarkExtensions)
+  .data('fromMarkdownExtensions', titleExtensions.fromMarkdownExtensions)
   .use(remarkParse)
   .use(remarkGfm);
 

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -250,9 +250,9 @@ const separateBlockTagFromContent = (match: string, tag: string, inlineChar?: st
   return `</${tag}>${breaks}\n\n${inlineChar || nextLineChar}`;
 };
 
-/** Escape a leading `-`/`*`/`+` (allowing indentation, followed by space/EOL) so cells don't become bullet lists. */
+/** Escape leading `-`/`*`/`+` (followed by space/EOL) so cells don't become bullet lists. */
 const escapeLeadingListMarkers = (text: string): string =>
-  text.replace(/^([ \t]*)([-*+])(?=[ \t]|$)/gm, '$1\\$2');
+  text.replace(/^([-*+])(?=[ \t]|$)/gm, '\\$1');
 
 /**
  * CommonMark doesn't process markdown inside HTML blocks -
@@ -264,11 +264,13 @@ const parseTableCell = (text: string): MdastNode[] => {
 
   // Convert \n (and surrounding whitespace) to <br> inside HTML blocks so
   // CommonMark doesn't split them on blank lines.
+  // Then strip leading whitespace to prevent indented code blocks.
   const escaped = processBackslashEscapes(text);
   const normalized = escaped
     .replace(HTML_ELEMENT_BLOCK_RE, match => match.replace(NEWLINE_WITH_WHITESPACE_RE, '<br>'))
     .replace(CLOSE_BLOCK_TAG_BOUNDARY_RE, separateBlockTagFromContent);
-  const processed = escapeLeadingListMarkers(normalized);
+  const trimmedLines = normalized.split('\n').map(line => line.trimStart());
+  const processed = escapeLeadingListMarkers(trimmedLines.join('\n'));
   const tree = contentParser.runSync(contentParser.parse(processed)) as MdastRoot;
 
   // Process markdown inside HTML blocks that have non-tag inner text (e.g. `<div>**x**`

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -248,9 +248,9 @@ const separateBlockTagFromContent = (match: string, tag: string, inlineChar?: st
   return `</${tag}>${breaks}\n\n${inlineChar || nextLineChar}`;
 };
 
-/** Escape leading `-`/`*`/`+` (followed by space/EOL) so cells don't become bullet lists. */
+/** Escape a leading (possibly indented) `-`/`*`/`+` so cells don't become bullet lists. */
 const escapeLeadingListMarkers = (text: string): string =>
-  text.replace(/^([-*+])(?=[ \t]|$)/gm, '\\$1');
+  text.replace(/^([ \t]*)([-*+])(?=[ \t]|$)/gm, '$1\\$2');
 
 /**
  * CommonMark doesn't process markdown inside HTML blocks -
@@ -262,13 +262,11 @@ const parseTableCell = (text: string): MdastNode[] => {
 
   // Convert \n (and surrounding whitespace) to <br> inside HTML blocks so
   // CommonMark doesn't split them on blank lines.
-  // Then strip leading whitespace to prevent indented code blocks.
   const escaped = processBackslashEscapes(text);
   const normalized = escaped
     .replace(HTML_ELEMENT_BLOCK_RE, match => match.replace(NEWLINE_WITH_WHITESPACE_RE, '<br>'))
     .replace(CLOSE_BLOCK_TAG_BOUNDARY_RE, separateBlockTagFromContent);
-  const trimmedLines = normalized.split('\n').map(line => line.trimStart());
-  const processed = escapeLeadingListMarkers(trimmedLines.join('\n'));
+  const processed = escapeLeadingListMarkers(normalized);
   const tree = contentParser.runSync(contentParser.parse(processed)) as MdastRoot;
 
   // Process markdown inside HTML blocks that have non-tag inner text (e.g. `<div>**x**`

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -37,7 +37,7 @@ import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 import { visitParents } from 'unist-util-visit-parents';
 
-import { mdxishExtensions } from '../../../../lib/micromark/mdxish-extensions';
+import { FEATURES, mdxishExtensions } from '../../../../lib/micromark/mdxish-extensions';
 import { STANDARD_HTML_TAGS } from '../../../../utils/common-html-words';
 import hardBreaks from '../../../plugin/hard-breaks';
 import { toAttributes } from '../../../utils';
@@ -112,9 +112,7 @@ const preprocessBody = (text: string): string => {
   return ensureLeadingBreaks(text);
 };
 
-// A magic block body is legacy content: it carries the inline syntax but never
-// the component/table tokenizers, which the surrounding document parser owns.
-const bodyExtensions = mdxishExtensions(['gemoji', 'legacyVariable', 'looseHtmlEntity', 'emptyTaskListItem']);
+const bodyExtensions = mdxishExtensions(FEATURES.magicBlockBody);
 
 /** Markdown parser */
 const contentParser = unified()
@@ -305,7 +303,7 @@ const parseBlock = (text: string): MdastNode[] => {
  * Disables markdown constructs that are not parsed in legacy (headings, lists),
  * on top of the base set rather than in place of it.
  */
-const titleExtensions = mdxishExtensions(['gemoji', 'legacyVariable', 'looseHtmlEntity'], {
+const titleExtensions = mdxishExtensions(FEATURES.apiHeaderTitle, {
   disable: ['blockQuote', 'headingAtx', 'list', 'thematicBreak'],
 });
 

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -45,7 +45,7 @@ import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
 import { looseHtmlEntity, looseHtmlEntityFromMarkdown } from '../../../../lib/micromark/loose-html-entities';
 import { STANDARD_HTML_TAGS } from '../../../../utils/common-html-words';
 import hardBreaks from '../../../plugin/hard-breaks';
-import { toAttributes } from '../../../utils';
+import { disableIndentedCode, toAttributes } from '../../../utils';
 import normalizeEmphasisAST from '../normalize-malformed-md-syntax';
 
 import {
@@ -119,7 +119,7 @@ const preprocessBody = (text: string): string => {
 
 /** Markdown parser */
 const contentParser = unified()
-  .data('micromarkExtensions', [gemoji(), legacyVariable(), looseHtmlEntity()])
+  .data('micromarkExtensions', [disableIndentedCode, gemoji(), legacyVariable(), looseHtmlEntity()])
   .data('fromMarkdownExtensions', [gemojiFromMarkdown(), legacyVariableFromMarkdown(), emptyTaskListItemFromMarkdown(), looseHtmlEntityFromMarkdown()])
   .use(remarkParse)
   .use(hardBreaks)
@@ -134,7 +134,7 @@ const contentParser = unified()
  * such as `<ul><li>https://a</li>\n</ul>` due to subtokenizing recursion for URLs
  */
 const markdownToHtml = unified()
-  .data('micromarkExtensions', [gfmStrikethrough(), gemoji(), legacyVariable(), looseHtmlEntity()])
+  .data('micromarkExtensions', [disableIndentedCode, gfmStrikethrough(), gemoji(), legacyVariable(), looseHtmlEntity()])
   .data('fromMarkdownExtensions', [gfmStrikethroughFromMarkdown(), gemojiFromMarkdown(), legacyVariableFromMarkdown(), emptyTaskListItemFromMarkdown(), looseHtmlEntityFromMarkdown()])
   .use(remarkParse)
   .use(normalizeEmphasisAST)
@@ -251,9 +251,9 @@ const separateBlockTagFromContent = (match: string, tag: string, inlineChar?: st
   return `</${tag}>${breaks}\n\n${inlineChar || nextLineChar}`;
 };
 
-/** Escape leading `-`/`*`/`+` (followed by space/EOL) so cells don't become bullet lists. */
+/** Escape a leading `-`/`*`/`+` (allowing indentation, followed by space/EOL) so cells don't become bullet lists. */
 const escapeLeadingListMarkers = (text: string): string =>
-  text.replace(/^([-*+])(?=[ \t]|$)/gm, '\\$1');
+  text.replace(/^([ \t]*)([-*+])(?=[ \t]|$)/gm, '$1\\$2');
 
 /**
  * CommonMark doesn't process markdown inside HTML blocks -
@@ -265,13 +265,11 @@ const parseTableCell = (text: string): MdastNode[] => {
 
   // Convert \n (and surrounding whitespace) to <br> inside HTML blocks so
   // CommonMark doesn't split them on blank lines.
-  // Then strip leading whitespace to prevent indented code blocks.
   const escaped = processBackslashEscapes(text);
   const normalized = escaped
     .replace(HTML_ELEMENT_BLOCK_RE, match => match.replace(NEWLINE_WITH_WHITESPACE_RE, '<br>'))
     .replace(CLOSE_BLOCK_TAG_BOUNDARY_RE, separateBlockTagFromContent);
-  const trimmedLines = normalized.split('\n').map(line => line.trimStart());
-  const processed = escapeLeadingListMarkers(trimmedLines.join('\n'));
+  const processed = escapeLeadingListMarkers(normalized);
   const tree = contentParser.runSync(contentParser.parse(processed)) as MdastRoot;
 
   // Process markdown inside HTML blocks that have non-tag inner text (e.g. `<div>**x**`

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -11,11 +11,8 @@ import { unified } from 'unified';
 import { EXIT, visit } from 'unist-util-visit';
 
 import { NodeTypes } from '../../../../enums';
-import { gemojiFromMarkdown } from '../../../../lib/mdast-util/gemoji';
-import { legacyVariableFromMarkdown } from '../../../../lib/mdast-util/legacy-variable';
-import { gemoji } from '../../../../lib/micromark/gemoji';
-import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
-import { disableIndentedCode, getAttrs, isMDXElement } from '../../../utils';
+import { mdxishExtensions } from '../../../../lib/micromark/mdxish-extensions';
+import { getAttrs, isMDXElement } from '../../../utils';
 import calloutTransformer from '../../callouts';
 import codeTabsTransformer from '../../code-tabs';
 import { extractText } from '../../extract-text';
@@ -45,23 +42,26 @@ const tableTypes = {
 // `mdxjs` + `mdxFromMarkdown` is what `remarkMdx` registers internally; we
 // register them manually so we control ordering against our other tokenizers.
 // The fallback omits these so blank-line-separated markdown inside cells still
-// parses when mdxjs throws on malformed JSX. `mdxjs` already disables indented
-// code (via `mdx-md`), so the fallback registers `disableIndentedCode` to match.
+// parses when mdxjs throws on malformed JSX. Both paths end up with indented
+// code disabled — the base config on the fallback, `mdx-md` on the primary.
 //
 // mdx parsing is used because it heavily simplifies the parsing of the table structure;
 // it can identify the rows and cells. The heavy lifting is done by it
-const buildTableNodeProcessor = (withMdx: boolean) =>
-  unified()
-    .data('micromarkExtensions', [...(withMdx ? [mdxjs()] : [disableIndentedCode]), gemoji(), legacyVariable()])
-    .data('fromMarkdownExtensions', [
-      ...(withMdx ? [mdxFromMarkdown()] : []),
-      gemojiFromMarkdown(),
-      legacyVariableFromMarkdown(),
-    ])
+const buildTableNodeProcessor = (withMdx: boolean) => {
+  // A cell only needs the inline tokenizers; the component/table ones would
+  // recurse into the structure we're in the middle of parsing.
+  const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(['gemoji', 'legacyVariable']);
+
+  // `mdxjs` goes first (= lowest priority): its `mdxJsx` also claims `text` + `<`,
+  // and `legacyVariable` has to keep winning that race so `<<var>>` still parses.
+  return unified()
+    .data('micromarkExtensions', [...(withMdx ? [mdxjs()] : []), ...micromarkExtensions])
+    .data('fromMarkdownExtensions', [...(withMdx ? [mdxFromMarkdown()] : []), ...fromMarkdownExtensions])
     .use(remarkParse)
     .use(normalizeEmphasisAST)
     .use([[calloutTransformer, { isMdxish: true }], codeTabsTransformer])
     .use(remarkGfm);
+};
 
 const tableNodeProcessor = buildTableNodeProcessor(true);
 const fallbackTableNodeProcessor = buildTableNodeProcessor(false);

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -11,7 +11,7 @@ import { unified } from 'unified';
 import { EXIT, visit } from 'unist-util-visit';
 
 import { NodeTypes } from '../../../../enums';
-import { mdxishExtensions } from '../../../../lib/micromark/mdxish-extensions';
+import { FEATURES, mdxishExtensions } from '../../../../lib/micromark/mdxish-extensions';
 import { getAttrs, isMDXElement } from '../../../utils';
 import calloutTransformer from '../../callouts';
 import codeTabsTransformer from '../../code-tabs';
@@ -48,9 +48,7 @@ const tableTypes = {
 // mdx parsing is used because it heavily simplifies the parsing of the table structure;
 // it can identify the rows and cells. The heavy lifting is done by it
 const buildTableNodeProcessor = (withMdx: boolean) => {
-  // A cell only needs the inline tokenizers; the component/table ones would
-  // recurse into the structure we're in the middle of parsing.
-  const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(['gemoji', 'legacyVariable']);
+  const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(FEATURES.tableCell);
 
   // `mdxjs` goes first (= lowest priority): its `mdxJsx` also claims `text` + `<`,
   // and `legacyVariable` has to keep winning that race so `<<var>>` still parses.

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -15,7 +15,7 @@ import { gemojiFromMarkdown } from '../../../../lib/mdast-util/gemoji';
 import { legacyVariableFromMarkdown } from '../../../../lib/mdast-util/legacy-variable';
 import { gemoji } from '../../../../lib/micromark/gemoji';
 import { legacyVariable } from '../../../../lib/micromark/legacy-variable';
-import { getAttrs, isMDXElement } from '../../../utils';
+import { disableIndentedCode, getAttrs, isMDXElement } from '../../../utils';
 import calloutTransformer from '../../callouts';
 import codeTabsTransformer from '../../code-tabs';
 import { extractText } from '../../extract-text';
@@ -45,13 +45,14 @@ const tableTypes = {
 // `mdxjs` + `mdxFromMarkdown` is what `remarkMdx` registers internally; we
 // register them manually so we control ordering against our other tokenizers.
 // The fallback omits these so blank-line-separated markdown inside cells still
-// parses when mdxjs throws on malformed JSX.
+// parses when mdxjs throws on malformed JSX. `mdxjs` already disables indented
+// code (via `mdx-md`), so the fallback registers `disableIndentedCode` to match.
 //
 // mdx parsing is used because it heavily simplifies the parsing of the table structure;
 // it can identify the rows and cells. The heavy lifting is done by it
 const buildTableNodeProcessor = (withMdx: boolean) =>
   unified()
-    .data('micromarkExtensions', [...(withMdx ? [mdxjs()] : []), gemoji(), legacyVariable()])
+    .data('micromarkExtensions', [...(withMdx ? [mdxjs()] : [disableIndentedCode]), gemoji(), legacyVariable()])
     .data('fromMarkdownExtensions', [
       ...(withMdx ? [mdxFromMarkdown()] : []),
       gemojiFromMarkdown(),

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -57,10 +57,6 @@ function shouldTerminateBetween(
 
   const currentIndent = indentWidth(line);
   const nextIndent = indentWidth(next);
-  // 4+ columns is CommonMark indented-code territory: an inserted blank line
-  // would turn the next line into a code block instead of freeing it (#1344).
-  if (currentIndent > 3 || nextIndent > 3) return false;
-
   const currentTrimmed = line.trim();
   const nextTrimmed = next.trim();
   if (!isLineHtml(currentTrimmed) || isLineHtml(nextTrimmed) || lineLeavesRawOpen) {
@@ -72,9 +68,10 @@ function shouldTerminateBetween(
   // termination for the whole rest of the document.
   if (currentIndent === 0 && nextIndent === 0) return true;
 
-  // Indented shapes (either line at 1–3 columns) are stricter: only a lone opening
-  // tag followed by markdown. A next line opening a tag or expression must stay
-  // glued for the mdxComponent tokenizer; raw-content payloads stay byte-exact.
+  // Indented shapes (either line indented — any depth, since indented code is
+  // disabled) are stricter: only a lone opening tag followed by markdown. A next
+  // line opening a tag or expression must stay glued for the mdxComponent
+  // tokenizer; raw-content payloads stay byte-exact.
   return (
     !insideRawContent &&
     SINGLE_OPENING_TAG_REGEX.test(currentTrimmed) &&

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -57,10 +57,6 @@ function shouldTerminateBetween(
 
   const currentIndent = indentWidth(line);
   const nextIndent = indentWidth(next);
-  // 4+ columns is CommonMark indented-code territory: an inserted blank line
-  // would turn the next line into a code block instead of freeing it (#1344).
-  if (currentIndent > 3 || nextIndent > 3) return false;
-
   const currentTrimmed = line.trim();
   const nextTrimmed = next.trim();
   if (!isLineHtml(currentTrimmed) || isLineHtml(nextTrimmed) || lineLeavesRawOpen) {
@@ -72,9 +68,9 @@ function shouldTerminateBetween(
   // termination for the whole rest of the document.
   if (currentIndent === 0 && nextIndent === 0) return true;
 
-  // Indented shapes (either line at 1–3 columns) are stricter: only a lone opening
-  // tag followed by markdown. A next line opening a tag or expression must stay
-  // glued for the mdxComponent tokenizer; raw-content payloads stay byte-exact.
+  // Indented shapes (either line, any depth) are stricter: only a lone opening tag
+  // followed by markdown. A next line opening a tag or expression must stay glued for
+  // the mdxComponent tokenizer; raw-content payloads stay byte-exact.
   return (
     !insideRawContent &&
     SINGLE_OPENING_TAG_REGEX.test(currentTrimmed) &&

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -57,6 +57,10 @@ function shouldTerminateBetween(
 
   const currentIndent = indentWidth(line);
   const nextIndent = indentWidth(next);
+  // 4+ columns is CommonMark indented-code territory: an inserted blank line
+  // would turn the next line into a code block instead of freeing it (#1344).
+  if (currentIndent > 3 || nextIndent > 3) return false;
+
   const currentTrimmed = line.trim();
   const nextTrimmed = next.trim();
   if (!isLineHtml(currentTrimmed) || isLineHtml(nextTrimmed) || lineLeavesRawOpen) {
@@ -68,10 +72,9 @@ function shouldTerminateBetween(
   // termination for the whole rest of the document.
   if (currentIndent === 0 && nextIndent === 0) return true;
 
-  // Indented shapes (either line indented — any depth, since indented code is
-  // disabled) are stricter: only a lone opening tag followed by markdown. A next
-  // line opening a tag or expression must stay glued for the mdxComponent
-  // tokenizer; raw-content payloads stay byte-exact.
+  // Indented shapes (either line at 1–3 columns) are stricter: only a lone opening
+  // tag followed by markdown. A next line opening a tag or expression must stay
+  // glued for the mdxComponent tokenizer; raw-content payloads stay byte-exact.
   return (
     !insideRawContent &&
     SINGLE_OPENING_TAG_REGEX.test(currentTrimmed) &&

--- a/processor/utils.ts
+++ b/processor/utils.ts
@@ -7,29 +7,15 @@ import type {
   MdxJsxAttributeValueExpression,
   MdxJsxAttributeValueExpressionData,
 } from 'mdast-util-mdx-jsx';
-import type { Extension } from 'micromark-util-types';
 import type { Point } from 'unist';
 
-import { Parser } from 'acorn';
-import acornJsx from 'acorn-jsx';
 import { decodeHTMLStrict } from 'entities';
 import { CONTINUE, EXIT, visit } from 'unist-util-visit';
 
 import mdast from '../lib/mdast';
+import { jsxAcornParser } from '../lib/utils/jsx-acorn-parser';
 
-/**
- * Single instance of acorn parser extended with `acorn-jsx`
- * to parse expressions containing JSX.
- */
-export const jsxAcornParser = Parser.extend(acornJsx());
-
-/**
- * Disables CommonMark's indented-code-block construct (4+ spaces)
- * The micromark tokenizers use follow the CommonMark specification: https://spec.commonmark.org/0.28/#indented-code-blocks
- * So any lines indented 4+ spaces are considered as a code block,
- * which is unexpected from users that used MDX before.
- */
-export const disableIndentedCode = { disable: { null: ['codeIndented'] } } satisfies Extension;
+export { jsxAcornParser };
 
 /**
  * Evaluate a JavaScript expression source and return its value.


### PR DESCRIPTION
| 🎫 Resolve CX-3708 |
| :-----------------: |

## 🎯 What does this PR do?

Follow-up to #1566 & implementing CX-3708. MDXish registered its micromark extensions as hand-maintained parallel arrays in every sub-parser. They drifted — that drift caused [CX-3705](https://linear.app/readme-io/issue/CX-3705), and it's why #1566 couldn't disable indented code everywhere in one pass.

- Adds `lib/micromark/mdxish-extensions.ts`: one ordered registry pairing each syntax extension with its `fromMarkdown` counterpart, composable groups (`BLOCK_CLAIMS` / `INLINE` / `EXPRESSIONS`), and a `FEATURES` map holding **every** sub-parser's set in one place. Call sites pass an unordered set — the builder owns ordering and the `safeMode` gate.
- The base construct config (`codeIndented`) is now applied by construction, so the parsers #1566 missed all get it: magic-block bodies, api-header titles, table cells, `stripComments`, `mdxishTags`, component bodies. Adding the next base construct is a one-line change instead of seven.
- Fixes drift the grouping surfaced: component bodies and table cells were missing `looseHtmlEntity`, so `&nbsp` rendered literally in those but as a space in prose.
- Guard tests fail if a new sub-parser skips the map or the shared base config.

⚠️ Ordering is load-bearing: micromark evaluates these arrays **right-to-left**, and `htmlBlockComponent` must outrank `mdxComponent` or `<HTMLBlock>` is claimed as a generic component (it isn't in `TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS`). The registry order is the document parser's proven one; I verified each migrated parser against its pre-refactor build.

Trimming the now-dead indent mitigations (4-col island bypass, stale comments) is split into a separate PR.

## 🧪 QA tips

- [ ] Indented content in `[block:callout]`/`[block:image]` bodies, table cells and component bodies renders as prose, not `<pre>`; fenced code/CodeTabs still work.
- [ ] `<HTMLBlock>`, `<Table>` inside a `<Callout>`, magic blocks, `<<vars>>` and `{expressions}` all still parse. `&nbsp` (no semicolon) now renders as a space in cells/component bodies.

## 📸 Screenshot or Loom

- No UI change; covered by unit tests + fixture snapshots.
