### PR TITLE
fix(mdxish): render raw tables preceded by text

### DIFF
--- a/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
@@ -1,4 +1,5 @@
 import { toHtml } from 'hast-util-to-html';
+import { removePosition } from 'unist-util-remove-position';
 
 import { mdxish } from '../../../lib';
 import { collectNodes, findAllElementsByTagName, findElementByTagName, parseMdxish } from '../../helpers';
@@ -132,13 +133,31 @@ describe('markdown inside single-line plain HTML tags', () => {
     });
 
     it('reassembles a raw table preceded by text on the same line (CX-3645)', () => {
-      const ast = mdxish(
-        'Bad request <table><thead><tr><th>Error Code</th><th>Description</th></tr></thead><tbody><tr><td>amount_mismatch</td><td>Mismatch</td></tr></tbody></table>',
-        { safeMode: true },
-      );
+      const source = 'Bad request <table><tr><td>Error</td></tr></table>';
+      const mdast = parseMdxish(source, { safeMode: true });
+      removePosition(mdast, { force: true });
 
-      expect(toHtml(ast)).toBe(
-        '<p>Bad request </p><table><thead><tr><th>Error Code</th><th>Description</th></tr></thead><tbody><tr><td>amount_mismatch</td><td>Mismatch</td></tr></tbody></table><p></p>',
+      expect(mdast).toStrictEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              { type: 'text', value: 'Bad request ' },
+              { type: 'html', value: '<table>' },
+              { type: 'html', value: '<tr>' },
+              { type: 'html', value: '<td>' },
+              { type: 'text', value: 'Error' },
+              { type: 'html', value: '</td>' },
+              { type: 'html', value: '</tr>' },
+              { type: 'html', value: '</table>' },
+            ],
+          },
+        ],
+      });
+
+      expect(toHtml(mdxish(source, { safeMode: true }))).toBe(
+        '<p>Bad request </p><table><tbody><tr><td>Error</td></tr></tbody></table><p></p>',
       );
     });
 

--- a/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-single-line-html.test.ts
@@ -131,6 +131,17 @@ describe('markdown inside single-line plain HTML tags', () => {
       });
     });
 
+    it('reassembles a raw table preceded by text on the same line (CX-3645)', () => {
+      const ast = mdxish(
+        'Bad request <table><thead><tr><th>Error Code</th><th>Description</th></tr></thead><tbody><tr><td>amount_mismatch</td><td>Mismatch</td></tr></tbody></table>',
+        { safeMode: true },
+      );
+
+      expect(toHtml(ast)).toBe(
+        '<p>Bad request </p><table><thead><tr><th>Error Code</th><th>Description</th></tr></thead><tbody><tr><td>amount_mismatch</td><td>Mismatch</td></tr></tbody></table><p></p>',
+      );
+    });
+
     it('does not promote a wrapper holding a nested table', () => {
       const ast = mdxish('<div><table><tr><td>**x**</td></tr></table></div>');
 

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -403,11 +403,9 @@ const mdxishTables = (): Transform => tree => {
     if (typeof index !== 'number' || !parent || !('children' in parent)) return;
     if (!node.value.startsWith('<Table') && !node.value.startsWith('<table')) return;
 
-    // A table preceded by text on the same line is tokenized as separate raw
-    // HTML fragments inside a paragraph (`<table>`, `<thead>`, ...). Leave the
-    // opening fragment untouched so rehype-raw can reassemble the full table.
-    // Complete inline table nodes still take the normal table-transform path.
-    if (parent.type === 'paragraph' && !/<\/table\s*>/i.test(node.value)) return;
+    // Inline tables are tokenized as separate raw HTML fragments inside a
+    // paragraph. Leave them untouched so rehype-raw can reassemble the table.
+    if (parent.type === 'paragraph') return;
 
     // Because the processor uses remarkMdx, it is stricter in what it accepts
     // and only accepts valid MDX syntax in the table node. To get around that,

--- a/processor/transform/mdxish/tables/mdxish-tables.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables.ts
@@ -403,6 +403,12 @@ const mdxishTables = (): Transform => tree => {
     if (typeof index !== 'number' || !parent || !('children' in parent)) return;
     if (!node.value.startsWith('<Table') && !node.value.startsWith('<table')) return;
 
+    // A table preceded by text on the same line is tokenized as separate raw
+    // HTML fragments inside a paragraph (`<table>`, `<thead>`, ...). Leave the
+    // opening fragment untouched so rehype-raw can reassemble the full table.
+    // Complete inline table nodes still take the normal table-transform path.
+    if (parent.type === 'paragraph' && !/<\/table\s*>/i.test(node.value)) return;
+
     // Because the processor uses remarkMdx, it is stricter in what it accepts
     // and only accepts valid MDX syntax in the table node. To get around that,
     // fall back to the cumulative repairs when the first parse fails.


### PR DESCRIPTION
| 🎫 Resolve CX-3645 |
| :---------------: |

## 🎯 What does this PR do?

- Keeps raw HTML tables intact when they are preceded by text on the same line.
- Leaves fragmented inline table HTML for `rehype-raw` to reconstruct instead of converting the opening tag into an empty table.

## 🧪 QA tips

- [x] Added safe-mode regression coverage for `Bad request <table>...</table>`.
- [x] Existing standalone, nested, and malformed table coverage remains green.

## 📸 Screenshot or Loom

### Before

<img width="446" height="652" alt="image" src="https://github.com/user-attachments/assets/5383416e-67fa-44d6-bf8b-99d9cfdef2f7" />


### After

<img width="447" height="792" alt="image" src="https://github.com/user-attachments/assets/5cbe3b6d-ba97-446a-9090-a34ff066b89a" />

