### PR TITLE
chore(mdxish): delete indented-code workarounds

### DIFF
--- a/.claude/context/MDXish/Processor Overview.md
+++ b/.claude/context/MDXish/Processor Overview.md
@@ -18,7 +18,7 @@ It applies seven transforms in sequence (the function carries a matching docstri
    Fixes malformed GFM table separator rows — e.g. misplaced alignment colons like `|: ---` → `| :---`. Without this, remarkGfm would fail to recognize the table.
 1. **`collapseForeignContentBlankLines()`**
 
-   Collapses blank lines inside `<svg>`/`<math>` islands. A blank line inside foreign content would otherwise fragment it — the children spill out as an indented code block once a wrapper re-parses its deindented body (#1545).
+   Collapses blank lines inside `<svg>`/`<math>` islands. A blank line inside foreign content would otherwise fragment it — the children spill out of the island, where parse5 drops the orphaned foreign tags (#1545).
 1. **`terminateHtmlFlowBlocks()`**
 
    Inserts blank lines after standalone HTML elements (like `<div>...</div>`) when the next line is regular markdown. CommonMark's HTML flow rules only terminate on blank lines, so without this, the parser would swallow subsequent markdown content into the HTML block token.
@@ -251,6 +251,8 @@ A tokenizer registers itself under one or more **constructs**, keyed by the char
 - **text** — inline constructs that appear inside a paragraph or other text.
 
 A construct may set `concrete: true` to keep container markers (`>` for blockquotes, `-`/`*` for list items) from interrupting it mid-body. Registration **order matters**: micromark tries the last-registered extension first, so the pipeline splices or prepends constructs to win the race for a shared trigger character — e.g. `jsxComment` is prepended so it claims `{/* … */}` before other `{`-openers, and the MDX expression extension is registered *text-only* (`mdxExpressionLenient()`, no flow construct) so a line-leading `{` can't hijack a block that owns it.
+
+The pipeline also **disables** one core CommonMark construct: `disableIndentedCode` (@processor/utils.ts) turns off indented code blocks, matching MDX (`micromark-extension-mdx-md`). Content indented 4+ columns parses as ordinary markdown/HTML at any depth, and code requires an explicit fence (CX-3739). Both the main parser and the component-body re-parser (`getInlineMdProcessor`) register it.
 
 ### Example: magic blocks
 

--- a/__tests__/lib/mdxish/magic-blocks.test.ts
+++ b/__tests__/lib/mdxish/magic-blocks.test.ts
@@ -505,6 +505,20 @@ ${JSON.stringify(
         expect(html).toContain('<em>foo</em>');
       });
 
+      it('renders a 4-space-indented cell line as prose, not a code block (CX-3739)', () => {
+        const html = getCellHtml('Detail.\n\n    const value = 1;');
+        expect(html).not.toContain('<pre>');
+        expect(html).not.toContain('<code>');
+        expect(html).toContain('const value = 1;');
+      });
+
+      it('does not render an indented leading dash as a bullet list in a cell', () => {
+        const html = getCellHtml('Intro\n\n    - foo');
+        expect(html).not.toContain('<ul>');
+        expect(html).not.toContain('<li>');
+        expect(html).toContain('- foo');
+      });
+
       it('renders block-level HTML as list when it appears inline after text (e.g. "Note: <ul><li>...</li></ul>")', () => {
         const input =
           'Note the following: <ul><li>A **Live** status means the domain is externally accessible (HTTP request passes)</li><li>A **Not Live** status means the domain is not exposed and cannot be reached from the internet (HTTP request fails)</li></ul>';

--- a/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
+++ b/__tests__/lib/mdxish/markdown-inside-indented-html.test.ts
@@ -5,7 +5,7 @@ import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
 
 // Markdown inside plain lowercase HTML must parse even when indented for
 // readability — at top level and nested inside custom components (whose bodies are
-// re-parsed). Guards HTML-flow swallowing and 4+-column indented-code fallout.
+// re-parsed). Guards HTML-flow swallowing and deep-indent fragmentation fallout.
 describe('markdown inside indented plain HTML blocks', () => {
   it('parses indented markdown in a <div> nested inside <Columns>/<Column>', () => {
     const md = `<Columns layout="auto">
@@ -86,6 +86,21 @@ describe('markdown inside indented plain HTML blocks', () => {
     expect(findElementByTagName(ast, 'pre')).toBeNull();
     expect(findElementByTagName(ast, 'h2')).not.toBeNull();
     expect(findElementByTagName(ast, 'a')).toMatchObject({ properties: { href: 'https://example.com' } });
+  });
+
+  it('parses markdown directly after a deeply indented (4+ col) opening tag', () => {
+    const md = `<div>
+    <section>
+    ## Deep heading
+    </section>
+</div>`;
+
+    const ast = mdxish(md);
+
+    expect(findElementByTagName(ast, 'pre')).toBeNull();
+    expect(findElementByTagName(ast, 'h2')).toMatchObject({
+      children: [{ type: 'text', value: 'Deep heading' }],
+    });
   });
 
   it('keeps deeply indented (4+ columns) HTML lines inside a wrapper as HTML (#1344)', () => {

--- a/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
+++ b/__tests__/lib/mdxish/plain-html-block-blank-lines.test.ts
@@ -194,9 +194,9 @@ const x = 1;
     expect(html).toContain('<strong>super nested ul</strong>');
   });
 
-  it('claims a nested wrapper so a 4+ column markdown island parses, not fragments (RM-17560)', () => {
-    // 6-col nesting indent would let CommonMark swallow the island as indented code;
-    // being nested (prior body content), the block is claimed and its body re-parsed.
+  it('parses a 4+ column markdown island inside a nested wrapper, not fragments (RM-17560)', () => {
+    // The island falls back to CommonMark at the blank line and parses as markdown
+    // (indented code is disabled); rehype-raw re-nests it into the wrapper fragments.
     const md = `<ol>
   <li>
     <details>
@@ -221,7 +221,7 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('&#x3C;/details>');
   });
 
-  it('claims a 4+ col island in a single 4-space-indented wrapper, no nesting (RM-17560)', () => {
+  it('parses a 4+ col island in a single 4-space-indented wrapper, no nesting (RM-17560)', () => {
     const md = `<div class="card">
     <p>Install the CLI:</p>
 
@@ -239,7 +239,7 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('```');
   });
 
-  it('claims a 4+ col island under 2-space-nested layout tags (RM-17560)', () => {
+  it('parses a 4+ col island under 2-space-nested layout tags (RM-17560)', () => {
     const md = `<section>
   <article>
     <p>Release notes</p>
@@ -263,7 +263,7 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('###');
   });
 
-  it('claims a 4+ col prose + fence island in a <details> without a list wrapper (RM-17560)', () => {
+  it('parses a 4+ col prose + fence island in a <details> without a list wrapper (RM-17560)', () => {
     const md = `<details>
     <summary>How do I authenticate?</summary>
 
@@ -300,10 +300,10 @@ const x = 1;
     expect(toHtml(ast)).not.toContain('```');
   });
 
-  it('keeps the CommonMark fallback for a deep island inside <figure> (non-promotable)', () => {
-    // Note: In this example the indented content would still be parsed as code
-    // Since this looks like an edge case, we'll leave it as is first since it
-    // requires a bigger refactor.
+  it('parses a deep island inside <figure> via the CommonMark fallback', () => {
+    // Figure bodies aren't re-parsed by promotion, but the island still renders:
+    // it falls back at the blank line and parses as markdown (indented code is
+    // disabled), landing between the figure's raw fragments.
     const md = `<figure>
   <figcaption>cap</figcaption>
 
@@ -321,6 +321,11 @@ const x = 1;
     expect(findElementByTagName(figure!, 'figcaption')).toMatchObject({
       children: [{ type: 'text', value: 'cap' }],
     });
+    expect(findElementByTagName(ast, 'h3')).toMatchObject({
+      children: [{ type: 'text', value: 'Heading' }],
+    });
+    expect(toHtml(ast)).toContain('const x = 1;');
+    expect(toHtml(ast)).not.toContain('```');
   });
 
   it('allows blank lines inside a brace expression body (e.g. a .map() callback)', () => {

--- a/__tests__/lib/mdxish/type-7-html-block-blank-lines.test.ts
+++ b/__tests__/lib/mdxish/type-7-html-block-blank-lines.test.ts
@@ -7,8 +7,9 @@ import { mdxish, compile, run } from '../../../lib';
 import { findAllElementsByTagName, findElementByTagName, roundTripMdxish } from '../../helpers';
 
 // Type-7 tags (a, span, button, …) end their HTML block at a blank line, fragmenting
-// 4+ column children into indented code. The mdxComponent tokenizer claims them like
-// type-6 plain blocks, but only when the opener sits alone on its line.
+// the wrapper so its children don't re-nest into one element. The mdxComponent
+// tokenizer claims them like type-6 plain blocks, but only when the opener sits
+// alone on its line.
 describe('block-wrapper claims for type-7 wrapper tags', () => {
   const wrapperTags = [
     'a',
@@ -113,7 +114,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       });
     });
 
-    it('claims a tab-indented island sitting directly after the opener blank line', () => {
+    it('renders a tab-indented island sitting directly after the opener blank line', () => {
       const md = '<button class="tabbed">\n\n\t<h3>Tab-indented heading</h3>\n\t<p>Indented with a real tab.</p>\n</button>';
 
       const ast = mdxish(md);
@@ -128,7 +129,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       });
     });
 
-    it('claims a top-of-body prose island at 4+ columns instead of fragmenting it', () => {
+    it('renders a top-of-body prose island at 4+ columns instead of fragmenting it', () => {
       const md = `<span class="badge">
 
     some indented text
@@ -140,7 +141,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       expect(toHtml(findElementByTagName(ast, 'span')!)).toContain('some indented text');
     });
 
-    it('claims a top-of-body island in an unknown lowercase tag', () => {
+    it('renders a top-of-body island in an unknown lowercase tag', () => {
       const md = `<placeholder>
 
     some indented text
@@ -152,7 +153,7 @@ describe('block-wrapper claims for type-7 wrapper tags', () => {
       expect(toHtml(findElementByTagName(ast, 'placeholder')!)).toContain('some indented text');
     });
 
-    it('claims a top-of-body titled fence island so it parses as a code sample (RM-17560 shape)', () => {
+    it('parses a top-of-body titled fence island as a code sample (RM-17560 shape)', () => {
       const md = `<a href="sample" class="content-card">
 
       \`\`\`json 0100 Request

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -375,8 +375,12 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
 `;
 
 exports[`Render engine regressions tests > indented-markdown-islands-in-html (mdxish) 1`] = `
-"<ol><li><details>
-  <summary>Authorization request</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="1-authorization-request"></div><div class="heading-text">1. Authorization request</div><a aria-label="Skip link to 1. Authorization request" class="heading-anchor-icon fa fa-regular fa-anchor" href="#1-authorization-request"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">0100 Request</button><button type="button" value="json">0100 Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+"<ol>
+  <li>
+    <details>
+      <summary>Authorization request</summary>
+<h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="1-authorization-request"></div><div class="heading-text">1. Authorization request</div><a aria-label="Skip link to 1. Authorization request" class="heading-anchor-icon fa fa-regular fa-anchor" href="#1-authorization-request"></a></h3>
+<div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">0100 Request</button><button type="button" value="json">0100 Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;MESSAGE_TYPE&quot;: {
         &quot;Message_Type&quot;: &quot;0100&quot;,
         &quot;Message_Desc&quot;: &quot;Authorisation Request&quot;
@@ -387,8 +391,14 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
     }
 }</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;Message_Type&quot;: &quot;0110&quot;,
-}</code></pre></div></div></details></li><li><details>
-  <summary>ATM withdrawal and reversal</summary><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="2-atm-withdrawal-and-reversal"></div><div class="heading-text">2. ATM withdrawal and reversal</div><a aria-label="Skip link to 2. ATM withdrawal and reversal" class="heading-anchor-icon fa fa-regular fa-anchor" href="#2-atm-withdrawal-and-reversal"></a></h3><div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">Request</button><button type="button" value="json">Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
+}</code></pre></div></div>
+    </details>
+  </li>
+  <li>
+    <details>
+      <summary>ATM withdrawal and reversal</summary>
+<h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="2-atm-withdrawal-and-reversal"></div><div class="heading-text">2. ATM withdrawal and reversal</div><a aria-label="Skip link to 2. ATM withdrawal and reversal" class="heading-anchor-icon fa fa-regular fa-anchor" href="#2-atm-withdrawal-and-reversal"></a></h3>
+<div class="CodeTabs CodeTabs_initial theme-undefined"><div class="CodeTabs-toolbar"><button type="button" value="json">Request</button><button type="button" value="json">Response</button></div><div class="CodeTabs-inner"><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;MESSAGE_TYPE&quot;: {
         &quot;Message_Type&quot;: &quot;0400&quot;,
         &quot;Message_Desc&quot;: &quot;Reversal Request&quot;
@@ -404,7 +414,10 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
 }</code></pre><pre><code class="rdmd-code lang-json theme-undefined" data-lang="json">{
     &quot;DE11&quot;: &quot;000071&quot;,
     &quot;DE2&quot;: &quot;818654321&quot;,
-}</code></pre></div></div></details></li></ol>
+}</code></pre></div></div>
+    </details>
+  </li>
+</ol>
 <div class="content-card-container">
   
   <a class="content-card" href="invoices" target="" title="">

--- a/__tests__/regression/fixtures/indented-markdown-islands-in-html/README.md
+++ b/__tests__/regression/fixtures/indented-markdown-islands-in-html/README.md
@@ -2,10 +2,13 @@
 
 Markdown islands (headings, fenced code) sitting 4+ columns deep inside nested
 plain HTML block tags, separated from the tags by blank lines. The trigger is
-structural, not tag-specific: any CommonMark type-6 wrapper chain whose nesting
-indent reaches 4 columns puts the island past the indented-code threshold, so
-everything after the blank line — fence markers, headings, prose — collapsed
-into one literal `<pre>` code block, with closing tags leaking into it.
+structural, not tag-specific: any CommonMark type-6 wrapper chain ends at the
+blank line, so everything after it — fence markers, headings, prose — used to
+collapse into one literal `<pre>` code block (indented code is disabled now,
+see `indented-content-is-not-code`), with closing tags leaking into it. Today
+the islands parse as markdown; this fixture locks in that they render fully
+(headings, CodeTabs) with the wrapper's raw fragments in balanced order, so
+the browser DOM re-nests them.
 
 This body is a stripped-down version of the RM-17560 customer doc:
 `<ol>/<li>/<details>/<summary>` at 6-column depth with titled `json` fences.
@@ -27,10 +30,16 @@ sits alone on its line (see `isBlockWrapperClaimTagName` in `syntax.ts`).
 
 ## What flips this fixture
 
-Changes to the `mdxComponent` tokenizer's plain-block-claim continuation
-(`plainClaimLineStart` / the 4-column island rule in
-`lib/micromark/mdx-component/syntax.ts`), the block-wrapper claim for
-non-type-6 wrapper tags (`isBlockWrapperClaimTagName` /
-`blockWrapperOpenerRest` in the same file), the bottom-up promotion recursion
-in `processor/transform/mdxish/components/mdx-blocks.ts` (`parseMdChildren` /
+Re-enabling the `codeIndented` construct (`disableIndentedCode` in
+`processor/utils.ts`), changes to the `mdxComponent` tokenizer's
+plain-block-claim continuation (`plainClaimLineStart`) or the block-wrapper
+claim for non-type-6 wrapper tags (`isBlockWrapperClaimTagName` /
+`blockWrapperOpenerRest`) in `lib/micromark/mdx-component/syntax.ts`, the
+bottom-up promotion recursion in
+`processor/transform/mdxish/components/mdx-blocks.ts` (`parseMdChildren` /
 `promoteComponentBlocks`), or `safeDeindent`'s shared-indent stripping.
+
+The snapshot shape changed when the post-blank 4-column island bypass was
+removed from `plainClaimLineStart`: islands now fall back to CommonMark and
+render between the wrapper's raw fragments instead of being re-nested in the
+HAST. The two shapes were verified DOM-equivalent through parse5.

--- a/__tests__/transformers/terminate-html-flow-blocks.test.ts
+++ b/__tests__/transformers/terminate-html-flow-blocks.test.ts
@@ -193,6 +193,50 @@ text at column 0`;
 text at column 0`);
     });
 
+    // The next three shapes reach 4+ columns; indented code is disabled, so the
+    // freed line parses as markdown rather than turning into a code block.
+    it('inserts blank line before a tab-indented (4-column) markdown line', () => {
+      const input = `<div>
+\tTabbed line
+</div>`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+\tTabbed line
+</div>`);
+    });
+
+    it('inserts blank line after a tab-indented lone opening tag followed by markdown', () => {
+      const input = `\t<div>
+text at column 0`;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`\t<div>
+
+text at column 0`);
+    });
+
+    it('inserts blank line after a lone opening tag when the next line is markdown at 4+ columns', () => {
+      const input = `<div>
+      indented line
+      with some text after
+
+      should be freed as markdown
+</div>
+      `;
+
+      const result = terminateHtmlFlowBlocks(input);
+      expect(result).toBe(`<div>
+
+      indented line
+      with some text after
+
+      should be freed as markdown
+</div>
+      `);
+    });
+
     it('inserts blank line when HTML line has text content between and after tags', () => {
       const input = `<div><p>Inner text</p></div>Outer text
 [block:callout]
@@ -246,33 +290,6 @@ Hello
 
     it('does not insert blank line after last line', () => {
       const input = '<div></div>';
-
-      expect(terminateHtmlFlowBlocks(input)).toBe(input);
-    });
-
-    it('does not insert blank line if next line starts with a tab', () => {
-      const input = `<div>
-\tTabbed line
-</div>`;
-
-      expect(terminateHtmlFlowBlocks(input)).toBe(input);
-    });
-
-    it('does not insert after a tab-indented opening tag (a tab counts as 4 columns)', () => {
-      const input = `\t<div>
-text at column 0`;
-
-      expect(terminateHtmlFlowBlocks(input)).toBe(input);
-    });
-
-    it('does not modify non-HTML lines indented 4+ columns after an HTML tag', () => {
-      const input = `<div>
-      indented line
-      with some text after
-
-      should be left alone
-</div>
-      `;
 
       expect(terminateHtmlFlowBlocks(input)).toBe(input);
     });

--- a/lib/micromark/mdx-component/syntax.ts
+++ b/lib/micromark/mdx-component/syntax.ts
@@ -5,12 +5,7 @@ import { markdownLineEnding, markdownSpace } from 'micromark-util-character';
 import { htmlBlockNames, htmlRawNames } from 'micromark-util-html-tag-name';
 import { codes, types } from 'micromark-util-symbol';
 
-import {
-  FOREIGN_CONTENT_TAGS,
-  HTML_TABLE_STRUCTURE_TAGS,
-  HTML_VOID_ELEMENTS,
-  NON_REPARSED_BODY_TAGS,
-} from '../../../utils/common-html-words';
+import { FOREIGN_CONTENT_TAGS, HTML_TABLE_STRUCTURE_TAGS, HTML_VOID_ELEMENTS } from '../../../utils/common-html-words';
 import { INLINE_COMPONENT_TAGS, TOKENIZER_MDX_COMPONENT_EXCLUDED_TAGS } from '../../constants';
 
 import { markupOnlyContinuation, nonLazyContinuationStart } from './continuation-checks';
@@ -37,20 +32,12 @@ const plainBlockClaimTagNames = new Set(
 
 const foreignContentTags = new Set<string>(FOREIGN_CONTENT_TAGS);
 
-// Type-7 lowercase tags (a, span, button, and unknown names): CommonMark ends their
-// block at a blank line, fragmenting 4+ column children into indented code. Claimable
-// only in block-wrapper shape (see `blockWrapperOpenerRest`); lookalike openers
-// (`<https://…>`) never find a closer, so their claim retreats cleanly to CommonMark.
-// Voids never close and raw/foreign-content bodies have dedicated owners.
+// Type-7 lowercase tags (a, span, button, unknown names): CommonMark ends their block
+// at a blank line, so the wrapper's children don't re-nest into one element. Only
+// claimable in block-wrapper shape (see `blockWrapperOpenerRest`), and never for voids
+// or raw/foreign-content bodies, which have dedicated owners.
 const isBlockWrapperClaimTagName = (tag: string): boolean =>
   !htmlFlowTagNames.has(tag) && !HTML_VOID_ELEMENTS.has(tag) && !foreignContentTags.has(tag);
-
-// Both are 4 columns per CommonMark, but they mean different things: a tab advances
-// to the next multiple of TAB_STOP_WIDTH, and INDENTED_CODE_MIN_COLUMNS is the depth
-// at which a line would fragment into indented code. Named separately so the two
-// concepts don't read as one incidental literal.
-const TAB_STOP_WIDTH = 4;
-const INDENTED_CODE_MIN_COLUMNS = 4;
 
 function resolveToMdxComponent(events: Parameters<Resolver>[0]) {
   let index = events.length;
@@ -120,21 +107,6 @@ function createTokenize(mode: 'flow' | 'text') {
     let pendingBlankLine = false;
     // Type-7 tag claimed pending the block-wrapper (opener alone on its line) check.
     let pendingBlockWrapperClaim = false;
-    // True once a block-wrapper claim is confirmed; relaxes the top-of-body island gate
-    // below (type-7 fallback is the fragmentation bug, not intentional indented code).
-    let isBlockWrapperClaim = false;
-    // Leading indent columns of the current plain-claim line, reset per line; ≥4 is
-    // where CommonMark would fragment the island as indented code. Tabs advance to the
-    // next 4-column stop — the same rule `expandIndentToColumns`
-    // (processor/transform/mdxish/indentation.ts) applies, kept in sync by hand since
-    // this side works on a `Code` stream, not a string. NB: do NOT swap this for
-    // `self.now().column`; micromark bumps the point column by 1 per `horizontalTab`
-    // code (the trailing `virtualSpace` codes don't move it), so it measures a tab as
-    // 1 column, reviving the tab-under-measurement bug this math exists to avoid.
-    let plainClaimIndentColumns = 0;
-    // True once a non-blank line follows the opener: a deep island below it is nested
-    // (cosmetic indent), not top-of-body indented code.
-    let sawPlainBlockBodyContent = false;
 
     // Code span tracking
     let codeSpanOpenSize = 0;
@@ -507,7 +479,6 @@ function createTokenize(mode: 'flow' | 'text') {
       if (!markdownLineEnding(code)) return nok(code);
       pendingBlockWrapperClaim = false;
       isPlainBlockClaim = true;
-      isBlockWrapperClaim = true;
       return body(code);
     }
 
@@ -560,8 +531,6 @@ function createTokenize(mode: 'flow' | 'text') {
 
       if (code !== codes.space && code !== codes.horizontalTab) {
         openerLineHasContent = true;
-        // Continuation content marks a later deep island as nested, not indented code.
-        if (!onOpenerLine) sawPlainBlockBodyContent = true;
       }
 
       if (code === codes.backslash) {
@@ -931,10 +900,7 @@ function createTokenize(mode: 'flow' | 'text') {
         return inBodyBraceExpr(code);
       }
 
-      if (isPlainBlockClaim) {
-        plainClaimIndentColumns = 0;
-        return plainClaimLineStart(code);
-      }
+      if (isPlainBlockClaim) return plainClaimLineStart(code);
       return bodyLineStart(code);
     }
 
@@ -960,18 +926,11 @@ function createTokenize(mode: 'flow' | 'text') {
     }
 
     // Line-start gate for plain block claims. After a blank line the block may only
-    // continue on a tag line (`<…`); any markdown island (`**bold**`, `[block:…]`, a
-    // fence) refuses so CommonMark html-flow reparses it exactly as it does today.
+    // continue on a markup-only tag line (`<…`); anything else refuses, so CommonMark
+    // reparses it as markdown and rehype-raw re-nests it into the wrapper.
     function plainClaimLineStart(code: Code): State | undefined {
-      // Leading whitespace only → treat as a blank line, matching CommonMark. A tab
-      // advances to the next stop; its trailing `virtualSpace` fillers add nothing
-      // but must still be consumed or they'd read as line content below.
+      // Leading whitespace only → treat as a blank line, matching CommonMark.
       if (markdownSpace(code)) {
-        if (code === codes.horizontalTab) {
-          plainClaimIndentColumns += TAB_STOP_WIDTH - (plainClaimIndentColumns % TAB_STOP_WIDTH);
-        } else if (code === codes.space) {
-          plainClaimIndentColumns += 1;
-        }
         effects.consume(code);
         return plainClaimLineStart;
       }
@@ -981,20 +940,6 @@ function createTokenize(mode: 'flow' | 'text') {
         return bodyContinuationStart(code);
       }
       if (pendingBlankLine) {
-        // A 4+ col island nested under other tags is cosmetic nesting indent, not code:
-        // keep claiming so promotion dedents + re-parses it as markdown (RM-17560).
-        // Block-wrapper claims extend this to top-of-body islands — their CommonMark
-        // fallback is the fragmentation bug, not intentional indented code. Tags whose
-        // bodies stay raw are excluded: a claimed island there would leak as literal text.
-        if (
-          plainClaimIndentColumns >= INDENTED_CODE_MIN_COLUMNS &&
-          (sawPlainBlockBodyContent || isBlockWrapperClaim) &&
-          !NON_REPARSED_BODY_TAGS.has(tagName)
-        ) {
-          return plainClaimContinue(code);
-        }
-        // Otherwise only a markup-only tag line continues; markdown/prose falls back to
-        // CommonMark so it parses and rehype-raw re-nests it into the wrapper.
         if (code !== codes.lessThan) return nok(code);
         return effects.check(markupOnlyContinuation, plainClaimContinue, nok)(code);
       }

--- a/processor/transform/mdxish/collapse-foreign-content-blank-lines.ts
+++ b/processor/transform/mdxish/collapse-foreign-content-blank-lines.ts
@@ -68,7 +68,8 @@ function findForeignContentSpans(text: string): [number, number][] {
 /**
  * Drop blank lines inside `<svg>`/`<math>` islands: their whitespace is
  * insignificant XML, but a blank line ends the CommonMark HTML block and spills the
- * children out as a code block (#1545). Collapsing keeps the island one block.
+ * children out of the island, where parse5 drops the orphaned foreign tags (#1545).
+ * Collapsing keeps the island one block.
  */
 export function collapseForeignContentBlankLines(content: string): string {
   // Fast path: nothing to do when the doc has no foreign-content island.

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -34,15 +34,15 @@ const hasNestedGenericComponentTag = (content: string): boolean =>
   [...content.matchAll(NESTED_COMPONENT_TAG_RE)].some(match => !GENERIC_MDX_COMPONENT_EXCLUDED_TAGS.has(match[1]));
 
 /**
- * Strip the shared leading indentation from a component body so readability indentation
- * isn't parsed as indented code (4+ columns), e.g. `  <p>` / `   text` -> `<p>` / ` text`.
- * Relative indentation is kept, so content genuinely 4+ columns deeper stays code. We
- * only strip when a line actually reaches 4 columns; otherwise the body is left as-is so
- * its leading whitespace survives as text nodes (mixed component + HTML content needs it).
+ * Strip the shared leading indentation from a component body so it parses as it would at
+ * column 0, e.g. `  <p>` / `   text` -> `<p>` / ` text`. Columns still shape parsing
+ * (list/blockquote continuation, table rows, the mdxComponent claim gates), and relative
+ * indentation is kept so genuinely deeper content still nests. We only strip when a line
+ * reaches 4 columns; otherwise leading whitespace survives as text nodes, which mixed
+ * component + HTML content needs.
  *
- * Indentation is measured in CommonMark columns (tab = up to 4), matching how the parser
- * decides indented code. A char count (tab = 1) under-measures tab-indented bodies, so
- * they slip past the 4-column gate and their nested content fragments into code blocks.
+ * Indentation is measured in CommonMark columns (tab = up to 4), matching micromark: a
+ * char count (tab = 1) under-measures tab-indented bodies so they slip the gate (#1556).
  */
 function safeDeindent(text: string): string {
   const lines = text.split('\n');

--- a/processor/transform/mdxish/indentation.ts
+++ b/processor/transform/mdxish/indentation.ts
@@ -2,11 +2,10 @@
  * CommonMark indentation helpers, shared by the mdxish preprocessors so tab- and
  * space-indented content is measured (and sliced) on one scale.
  *
- * CommonMark's indented-code threshold is 4 *columns*, and a tab is a 4-column tab
- * stop — not a fixed 4 characters. Counting characters (tab = 1) under-measures
- * tab-indented lines, letting them slip past the 4-column gate so their content
- * fragments into code blocks. Keeping one implementation here stops the two callers
- * from drifting on what "4 columns" means.
+ * CommonMark measures indentation in *columns*, and a tab is a 4-column tab stop — not a
+ * fixed 4 characters. Counting characters (tab = 1) under-measures tab-indented lines, so
+ * column-anchored decisions (body dedenting, HTML-flow termination) would drift from how
+ * micromark reads the same lines.
  */
 
 /** The run of leading spaces/tabs on a line. */

--- a/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
+++ b/processor/transform/mdxish/magic-blocks/magic-block-transformer.ts
@@ -250,9 +250,9 @@ const separateBlockTagFromContent = (match: string, tag: string, inlineChar?: st
   return `</${tag}>${breaks}\n\n${inlineChar || nextLineChar}`;
 };
 
-/** Escape leading `-`/`*`/`+` (followed by space/EOL) so cells don't become bullet lists. */
+/** Escape a leading (possibly indented) `-`/`*`/`+` so cells don't become bullet lists. */
 const escapeLeadingListMarkers = (text: string): string =>
-  text.replace(/^([-*+])(?=[ \t]|$)/gm, '\\$1');
+  text.replace(/^([ \t]*)([-*+])(?=[ \t]|$)/gm, '$1\\$2');
 
 /**
  * CommonMark doesn't process markdown inside HTML blocks -
@@ -264,13 +264,11 @@ const parseTableCell = (text: string): MdastNode[] => {
 
   // Convert \n (and surrounding whitespace) to <br> inside HTML blocks so
   // CommonMark doesn't split them on blank lines.
-  // Then strip leading whitespace to prevent indented code blocks.
   const escaped = processBackslashEscapes(text);
   const normalized = escaped
     .replace(HTML_ELEMENT_BLOCK_RE, match => match.replace(NEWLINE_WITH_WHITESPACE_RE, '<br>'))
     .replace(CLOSE_BLOCK_TAG_BOUNDARY_RE, separateBlockTagFromContent);
-  const trimmedLines = normalized.split('\n').map(line => line.trimStart());
-  const processed = escapeLeadingListMarkers(trimmedLines.join('\n'));
+  const processed = escapeLeadingListMarkers(normalized);
   const tree = contentParser.runSync(contentParser.parse(processed)) as MdastRoot;
 
   // Process markdown inside HTML blocks that have non-tag inner text (e.g. `<div>**x**`

--- a/processor/transform/mdxish/terminate-html-flow-blocks.ts
+++ b/processor/transform/mdxish/terminate-html-flow-blocks.ts
@@ -57,10 +57,6 @@ function shouldTerminateBetween(
 
   const currentIndent = indentWidth(line);
   const nextIndent = indentWidth(next);
-  // 4+ columns is CommonMark indented-code territory: an inserted blank line
-  // would turn the next line into a code block instead of freeing it (#1344).
-  if (currentIndent > 3 || nextIndent > 3) return false;
-
   const currentTrimmed = line.trim();
   const nextTrimmed = next.trim();
   if (!isLineHtml(currentTrimmed) || isLineHtml(nextTrimmed) || lineLeavesRawOpen) {
@@ -72,9 +68,9 @@ function shouldTerminateBetween(
   // termination for the whole rest of the document.
   if (currentIndent === 0 && nextIndent === 0) return true;
 
-  // Indented shapes (either line at 1–3 columns) are stricter: only a lone opening
-  // tag followed by markdown. A next line opening a tag or expression must stay
-  // glued for the mdxComponent tokenizer; raw-content payloads stay byte-exact.
+  // Indented shapes (either line, any depth) are stricter: only a lone opening tag
+  // followed by markdown. A next line opening a tag or expression must stay glued for
+  // the mdxComponent tokenizer; raw-content payloads stay byte-exact.
   return (
     !insideRawContent &&
     SINGLE_OPENING_TAG_REGEX.test(currentTrimmed) &&


### PR DESCRIPTION
| 🎫 Resolve CX-3739 |
| :-----------------: |

## 🎯 What does this PR do?

Stacked on #156. Now that indented code is disabled, this deletes the workarounds that only existed to dodge indented-code fallback:

- **`mdx-component` tokenizer** — drops the 4-column island bypass in `plainClaimLineStart` (its column tracking, `sawPlainBlockBodyContent`/`isBlockWrapperClaim` state, and tab-stop constants). After a blank line, only a markup-only tag line continues a plain claim, at any indent.
- **`terminateHtmlFlowBlocks`** — drops the `indent > 3` early return, so indented HTML/markdown pairs terminate at any depth.
- **`parseTableCell`** — drops the per-line `trimStart()`; `escapeLeadingListMarkers` now allows leading indentation instead.
- Refreshes the now-stale "becomes indented code" comments and trims them down.

## 🧪 QA tips

- [ ] Indented markdown islands inside HTML wrappers still re-nest correctly (see the `indented-markdown-islands-in-html` fixture).
- [ ] Indented `<div>` + markdown pairs still get their terminating blank line; `<pre>`/`<table>` payloads stay byte-exact.
- [ ] Indented `-`/`*` list markers in magic-block table cells stay literal.

## 📸 Screenshot or Loom

- No UI change; covered by unit tests + fixture snapshots.
