### PR TITLE
fix(mdxish): stamp re-parsed component bodies with their source 

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -93,6 +93,29 @@ export const parseMdxish = (doc: string, opts: MdxishOpts = {}): MdastRoot =>
   parseMdxishWithSource(doc, opts).tree;
 
 /**
+ * Parses markdown and returns a `sliceOf` that resolves each node's coordinate space the
+ * way a consumer must: a node's offsets index into the nearest `data.reparseSource` on
+ * itself or an ancestor, falling back to the post-preprocess document source.
+ */
+export const parseMdxishWithResolvedSources = (doc: string, opts: MdxishOpts = {}) => {
+  const { source, tree } = parseMdxishWithSource(doc, opts);
+  const sourceByNode = new Map<Node, string>();
+
+  const resolve = (node: Node, inherited: string) => {
+    const resolved = node.data?.reparseSource ?? inherited;
+    sourceByNode.set(node, resolved);
+    if ('children' in node) (node.children as Node[]).forEach(child => resolve(child, resolved));
+  };
+  resolve(tree, source);
+
+  return {
+    tree,
+    sliceOf: (node: Node): string | undefined =>
+      sourceByNode.get(node)?.slice(node.position?.start.offset, node.position?.end.offset),
+  };
+};
+
+/**
  * Round-trips markdown: parse → MDAST → serialize back to markdown.
  */
 export const roundTripMdxish = (doc: string, opts: MdxishOpts = {}): string =>

--- a/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
+++ b/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
@@ -1,8 +1,10 @@
-import type { Node, Parent, Root, Strong, Table } from 'mdast';
+import type { Parent, Root, Table } from 'mdast';
 import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 
+import { visit } from 'unist-util-visit';
+
 import { mdxishAstProcessor, mdxishMdastToMd } from '../../../lib/mdxish';
-import { roundTripMdxish } from '../../helpers';
+import { parseMdxishWithResolvedSources, roundTripMdxish } from '../../helpers';
 
 describe('mdxishAstProcessor', () => {
   describe('deferred processing (handled by mdxish rendering pipeline)', () => {
@@ -98,21 +100,28 @@ describe('mdxishAstProcessor', () => {
     });
   });
 
-  describe('re-parsed component body positions', () => {
-    const parseMdast = (md: string): Root => {
-      const { processor, parserReadyContent } = mdxishAstProcessor(md, { newEditorTypes: true });
-      return processor.runSync(processor.parse(parserReadyContent)) as Root;
-    };
-
+  // CX-3772: WYSIWYG mangled tab-block content because nodes re-parsed from a component
+  // body carry offsets into that body, not the document. Each re-parsed subtree root is
+  // stamped with `data.reparseSource`; descendants resolve via their nearest stamped
+  // ancestor. These tests assert through that resolution, exactly as a consumer must.
+  describe('re-parsed component body positions (CX-3772)', () => {
+    // `Variable` declares no `type`, so it survives the discriminant check and the cast
+    // is what actually reaches `name`.
     const findJsxChild = (parent: Parent, name: string): MdxJsxFlowElement =>
       parent.children.find(
-        (child): child is MdxJsxFlowElement => child.type === 'mdxJsxFlowElement' && (child as MdxJsxFlowElement).name === name,
+        (child): child is MdxJsxFlowElement =>
+          child.type === 'mdxJsxFlowElement' && (child as MdxJsxFlowElement).name === name,
       )!;
 
-    const sliceReparseSource = (node: Node): string | undefined =>
-      node.data?.reparseSource?.slice(node.position?.start.offset, node.position?.end.offset);
+    const stampedNodeTypes = (tree: Root): string[] => {
+      const stamped: string[] = [];
+      visit(tree, node => {
+        if (node.data?.reparseSource) stamped.push(node.type);
+      });
+      return stamped;
+    };
 
-    it('stamps nodes inside a component body with the source their positions refer to', () => {
+    it('resolves every node in a nested component body to its own source', () => {
       const md = [
         '<Tabs>',
         '  <Tab title="Accounts">',
@@ -122,42 +131,52 @@ describe('mdxishAstProcessor', () => {
         '  </Tab>',
         '</Tabs>',
       ].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
-      // Top-level node positions still refer to the document, so it carries no stamp.
-      const tabs = findJsxChild(mdast, 'Tabs');
+      // Top-level positions still index into the document, so `Tabs` carries no stamp.
+      const tabs = findJsxChild(tree, 'Tabs');
       expect(tabs.data?.reparseSource).toBeUndefined();
+      expect(sliceOf(tabs)).toBe(md);
 
       const tab = findJsxChild(tabs, 'Tab');
-      expect(sliceReparseSource(tab)).toBe(
+      expect(sliceOf(tab)).toBe(
         ['<Tab title="Accounts">', '  ### Common Account Fields', '', '  <ExampleComponent />', '</Tab>'].join('\n'),
       );
 
-      const nested = findJsxChild(tab, 'ExampleComponent');
-      expect(sliceReparseSource(nested)).toBe('  <ExampleComponent />');
+      const heading = tab.children.find(child => child.type === 'heading')!;
+      expect(sliceOf(heading)).toBe('### Common Account Fields');
+      expect(sliceOf(findJsxChild(tab, 'ExampleComponent'))).toBe('  <ExampleComponent />');
     });
 
-    it('stamps expression nodes inside a component body', () => {
+    it('stamps only subtree roots, never their descendants', () => {
+      const md = ['<Wrapper>', '  Some **bold** text', '</Wrapper>'].join('\n');
+      const { tree } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
+
+      // The body's sole root is the paragraph; `strong`/`text` inherit from it.
+      expect(stampedNodeTypes(tree)).toStrictEqual(['paragraph']);
+    });
+
+    it('resolves expression nodes inside a component body', () => {
       const md = ['<Wrapper>', '  {1 + 1}', '</Wrapper>'].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
-      const expression = findJsxChild(mdast, 'Wrapper').children.find(child => child.type === 'mdxFlowExpression')!;
-      expect(sliceReparseSource(expression)).toBe('{1 + 1}');
+      const expression = findJsxChild(tree, 'Wrapper').children.find(child => child.type === 'mdxFlowExpression')!;
+      expect(sliceOf(expression)).toBe('{1 + 1}');
     });
 
-    it('stamps siblings spliced after a self-closing component with their own source', () => {
+    it('resolves siblings spliced after a self-closing component against their own source', () => {
       const md = ['<Wrapper>', '  <ExampleComponent />', '  Some *sibling* text', '</Wrapper>'].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
-      const wrapper = findJsxChild(mdast, 'Wrapper');
+      const wrapper = findJsxChild(tree, 'Wrapper');
       const paragraph = wrapper.children.find(child => child.type === 'paragraph')!;
-      expect(sliceReparseSource(paragraph)).toBe('Some *sibling* text');
+      expect(sliceOf(paragraph)).toBe('Some *sibling* text');
 
-      const emphasis = paragraph.children.find(child => child.type === 'emphasis')!;
-      expect(sliceReparseSource(emphasis)).toBe('*sibling*');
+      const emphasis = (paragraph as Parent).children.find(child => child.type === 'emphasis')!;
+      expect(sliceOf(emphasis)).toBe('*sibling*');
     });
 
-    it('stamps deeply indented bodies with the dedented source', () => {
+    it('resolves deeply indented bodies against the dedented source', () => {
       const md = [
         '<Tabs>',
         '    <Tab title="One">',
@@ -167,14 +186,13 @@ describe('mdxishAstProcessor', () => {
         '    </Tab>',
         '</Tabs>',
       ].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
-      const tab = findJsxChild(findJsxChild(mdast, 'Tabs'), 'Tab');
-      const nested = findJsxChild(tab, 'ExampleComponent');
-      expect(sliceReparseSource(nested)).toBe('<ExampleComponent />');
+      const tab = findJsxChild(findJsxChild(tree, 'Tabs'), 'Tab');
+      expect(sliceOf(findJsxChild(tab, 'ExampleComponent'))).toBe('<ExampleComponent />');
     });
 
-    it('stamps ReadMe components nested inside other components at every depth', () => {
+    it('resolves ReadMe components nested inside other components at every depth', () => {
       const md = [
         '<Tabs>',
         '  <Tab title="One">',
@@ -186,11 +204,11 @@ describe('mdxishAstProcessor', () => {
         '  </Tab>',
         '</Tabs>',
       ].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
-      const tab = findJsxChild(findJsxChild(mdast, 'Tabs'), 'Tab');
+      const tab = findJsxChild(findJsxChild(tree, 'Tabs'), 'Tab');
       const cards = findJsxChild(tab, 'Cards');
-      expect(sliceReparseSource(cards)).toBe(
+      expect(sliceOf(cards)).toBe(
         [
           '<Cards columns={2}>',
           '  <Card title="First" icon="fa-rocket">',
@@ -201,53 +219,56 @@ describe('mdxishAstProcessor', () => {
       );
 
       const card = findJsxChild(cards, 'Card');
-      expect(sliceReparseSource(card)).toBe(
+      expect(sliceOf(card)).toBe(
         ['<Card title="First" icon="fa-rocket">', '  Card **body** text', '</Card>'].join('\n'),
       );
 
       const paragraph = card.children.find(child => child.type === 'paragraph')!;
-      expect(sliceReparseSource(paragraph)).toBe('Card **body** text');
+      expect(sliceOf(paragraph)).toBe('Card **body** text');
+
+      // Descendants of a stamped root inherit it rather than carrying their own copy.
+      const strong = (paragraph as Parent).children.find(child => child.type === 'strong')!;
+      expect(strong.data?.reparseSource).toBeUndefined();
+      expect(sliceOf(strong)).toBe('**body**');
     });
 
-    it('stamps a multi-line HTML sequence and the markdown between its tags', () => {
+    it('resolves a multi-line HTML sequence and the markdown between its tags', () => {
       const md = ['<Wrapper>', '  <div>', '    A **bold** move', '  </div>', '</Wrapper>'].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
       // A multi-line lowercase tag stays a pair of html nodes with markdown between;
-      // all three share the body's re-parsed source (blank line added by the body re-parse).
-      const wrapper = findJsxChild(mdast, 'Wrapper');
-      const bodySource = '<div>\n\n  A **bold** move\n</div>';
+      // all three are body roots (the body re-parse adds the blank line after `<div>`).
+      const wrapper = findJsxChild(tree, 'Wrapper');
       const openingTag = wrapper.children.find(child => child.type === 'html')!;
-      expect(openingTag.data?.reparseSource).toBe(bodySource);
+      expect(openingTag.data?.reparseSource).toBe('<div>\n\n  A **bold** move\n</div>');
+      expect(sliceOf(openingTag)).toBe('<div>');
 
       const paragraph = wrapper.children.find(child => child.type === 'paragraph')!;
-      expect(sliceReparseSource(paragraph)).toBe('A **bold** move');
-
-      const strong = paragraph.children.find(child => child.type === 'strong')!;
-      expect(sliceReparseSource(strong)).toBe('**bold**');
+      expect(sliceOf(paragraph)).toBe('A **bold** move');
+      expect(sliceOf((paragraph as Parent).children.find(child => child.type === 'strong')!)).toBe('**bold**');
     });
 
-    it('stamps children of a single-line lowercase HTML tag promoted for markdown parsing', () => {
+    it('resolves children of a single-line lowercase HTML tag promoted for markdown parsing', () => {
       const md = ['<Wrapper>', '  <div>A **bold** move</div>', '</Wrapper>'].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
-      const div = findJsxChild(findJsxChild(mdast, 'Wrapper'), 'div');
-      expect(sliceReparseSource(div)).toBe('<div>A **bold** move</div>');
+      const div = findJsxChild(findJsxChild(tree, 'Wrapper'), 'div');
+      expect(sliceOf(div)).toBe('<div>A **bold** move</div>');
 
-      // Lowercase promotion unwraps the sole paragraph, so phrasing sits directly on the div.
-      const strong = (div.children as Node[]).find((child): child is Strong => child.type === 'strong')!;
-      expect(sliceReparseSource(strong)).toBe('**bold**');
+      // A lowercase tag unwraps its sole paragraph, so phrasing sits directly under `div`.
+      const strong = (div as Parent).children.find(child => child.type === 'strong')!;
+      expect(sliceOf(strong)).toBe('**bold**');
     });
 
-    it('stamps lowercase HTML promoted through an MDX expression attribute', () => {
+    it('resolves lowercase HTML promoted through an MDX expression attribute', () => {
       const md = ['<Wrapper>', '  <button style={{ color: "red" }}>Click me</button>', '</Wrapper>'].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
-      const button = findJsxChild(findJsxChild(mdast, 'Wrapper'), 'button');
-      expect(sliceReparseSource(button)).toBe('<button style={{ color: "red" }}>Click me</button>');
+      const button = findJsxChild(findJsxChild(tree, 'Wrapper'), 'button');
+      expect(sliceOf(button)).toBe('<button style={{ color: "red" }}>Click me</button>');
     });
 
-    it('stamps a component nested inside a list item of a component body', () => {
+    it('resolves a component nested inside a list item of a component body', () => {
       const md = [
         '<Tabs>',
         '    <Tab title="One">',
@@ -256,16 +277,15 @@ describe('mdxishAstProcessor', () => {
         '    </Tab>',
         '</Tabs>',
       ].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
-      const tab = findJsxChild(findJsxChild(mdast, 'Tabs'), 'Tab');
+      const tab = findJsxChild(findJsxChild(tree, 'Tabs'), 'Tab');
       const list = tab.children.find(child => child.type === 'list')!;
-      const secondItem = list.children[1];
-      const nested = findJsxChild(secondItem, 'ExampleComponent');
-      expect(sliceReparseSource(nested)).toBe('<ExampleComponent />');
+      const nested = findJsxChild((list as Parent).children[1] as Parent, 'ExampleComponent');
+      expect(sliceOf(nested)).toBe('<ExampleComponent />');
     });
 
-    it('stamps sibling components separated by extra blank lines with the same body source', () => {
+    it('resolves sibling components separated by extra blank lines against the same body source', () => {
       const md = [
         '<Wrapper>',
         '',
@@ -278,15 +298,28 @@ describe('mdxishAstProcessor', () => {
         '',
         '</Wrapper>',
       ].join('\n');
-      const mdast = parseMdast(md);
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
-      const wrapper = findJsxChild(mdast, 'Wrapper');
+      const wrapper = findJsxChild(tree, 'Wrapper');
       const first = findJsxChild(wrapper, 'First');
       const second = findJsxChild(wrapper, 'Second');
 
       expect(first.data?.reparseSource).toBe(second.data?.reparseSource);
-      expect(sliceReparseSource(first)).toBe('<First />');
-      expect(sliceReparseSource(second)).toBe(['<Second>', '  content', '</Second>'].join('\n'));
+      expect(sliceOf(first)).toBe('<First />');
+      expect(sliceOf(second)).toBe(['<Second>', '  content', '</Second>'].join('\n'));
+    });
+
+    // The inline path re-parses bodies too, so it must stamp its roots for the same reason.
+    it('resolves the re-parsed body of an inline component', () => {
+      const md = 'Lead in <span style={{ color: "red" }}>an **emphatic** label</span> and out.';
+      const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
+
+      const paragraph = tree.children[0] as Parent;
+      const span = paragraph.children.find(child => child.type === 'mdxJsxTextElement')!;
+      expect(sliceOf(span)).toBe('<span style={{ color: "red" }}>an **emphatic** label</span>');
+
+      const strong = (span as Parent).children.find(child => child.type === 'strong')!;
+      expect(sliceOf(strong)).toBe('**emphatic**');
     });
   });
 

--- a/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
+++ b/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
@@ -1,4 +1,5 @@
-import type { Root, Table } from 'mdast';
+import type { Node, Parent, Root, Strong, Table } from 'mdast';
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 
 import { mdxishAstProcessor, mdxishMdastToMd } from '../../../lib/mdxish';
 import { roundTripMdxish } from '../../helpers';
@@ -94,6 +95,198 @@ describe('mdxishAstProcessor', () => {
           { type: 'paragraph' },
         ],
       });
+    });
+  });
+
+  describe('re-parsed component body positions', () => {
+    const parseMdast = (md: string): Root => {
+      const { processor, parserReadyContent } = mdxishAstProcessor(md, { newEditorTypes: true });
+      return processor.runSync(processor.parse(parserReadyContent)) as Root;
+    };
+
+    const findJsxChild = (parent: Parent, name: string): MdxJsxFlowElement =>
+      parent.children.find(
+        (child): child is MdxJsxFlowElement => child.type === 'mdxJsxFlowElement' && (child as MdxJsxFlowElement).name === name,
+      )!;
+
+    const sliceReparseSource = (node: Node): string | undefined =>
+      node.data?.reparseSource?.slice(node.position?.start.offset, node.position?.end.offset);
+
+    it('stamps nodes inside a component body with the source their positions refer to', () => {
+      const md = [
+        '<Tabs>',
+        '  <Tab title="Accounts">',
+        '    ### Common Account Fields',
+        '',
+        '    <ExampleComponent />',
+        '  </Tab>',
+        '</Tabs>',
+      ].join('\n');
+      const mdast = parseMdast(md);
+
+      // Top-level node positions still refer to the document, so it carries no stamp.
+      const tabs = findJsxChild(mdast, 'Tabs');
+      expect(tabs.data?.reparseSource).toBeUndefined();
+
+      const tab = findJsxChild(tabs, 'Tab');
+      expect(sliceReparseSource(tab)).toBe(
+        ['<Tab title="Accounts">', '  ### Common Account Fields', '', '  <ExampleComponent />', '</Tab>'].join('\n'),
+      );
+
+      const nested = findJsxChild(tab, 'ExampleComponent');
+      expect(sliceReparseSource(nested)).toBe('  <ExampleComponent />');
+    });
+
+    it('stamps expression nodes inside a component body', () => {
+      const md = ['<Wrapper>', '  {1 + 1}', '</Wrapper>'].join('\n');
+      const mdast = parseMdast(md);
+
+      const expression = findJsxChild(mdast, 'Wrapper').children.find(child => child.type === 'mdxFlowExpression')!;
+      expect(sliceReparseSource(expression)).toBe('{1 + 1}');
+    });
+
+    it('stamps siblings spliced after a self-closing component with their own source', () => {
+      const md = ['<Wrapper>', '  <ExampleComponent />', '  Some *sibling* text', '</Wrapper>'].join('\n');
+      const mdast = parseMdast(md);
+
+      const wrapper = findJsxChild(mdast, 'Wrapper');
+      const paragraph = wrapper.children.find(child => child.type === 'paragraph')!;
+      expect(sliceReparseSource(paragraph)).toBe('Some *sibling* text');
+
+      const emphasis = paragraph.children.find(child => child.type === 'emphasis')!;
+      expect(sliceReparseSource(emphasis)).toBe('*sibling*');
+    });
+
+    it('stamps deeply indented bodies with the dedented source', () => {
+      const md = [
+        '<Tabs>',
+        '    <Tab title="One">',
+        '',
+        '        <ExampleComponent />',
+        '',
+        '    </Tab>',
+        '</Tabs>',
+      ].join('\n');
+      const mdast = parseMdast(md);
+
+      const tab = findJsxChild(findJsxChild(mdast, 'Tabs'), 'Tab');
+      const nested = findJsxChild(tab, 'ExampleComponent');
+      expect(sliceReparseSource(nested)).toBe('<ExampleComponent />');
+    });
+
+    it('stamps ReadMe components nested inside other components at every depth', () => {
+      const md = [
+        '<Tabs>',
+        '  <Tab title="One">',
+        '    <Cards columns={2}>',
+        '      <Card title="First" icon="fa-rocket">',
+        '        Card **body** text',
+        '      </Card>',
+        '    </Cards>',
+        '  </Tab>',
+        '</Tabs>',
+      ].join('\n');
+      const mdast = parseMdast(md);
+
+      const tab = findJsxChild(findJsxChild(mdast, 'Tabs'), 'Tab');
+      const cards = findJsxChild(tab, 'Cards');
+      expect(sliceReparseSource(cards)).toBe(
+        [
+          '<Cards columns={2}>',
+          '  <Card title="First" icon="fa-rocket">',
+          '    Card **body** text',
+          '  </Card>',
+          '</Cards>',
+        ].join('\n'),
+      );
+
+      const card = findJsxChild(cards, 'Card');
+      expect(sliceReparseSource(card)).toBe(
+        ['<Card title="First" icon="fa-rocket">', '  Card **body** text', '</Card>'].join('\n'),
+      );
+
+      const paragraph = card.children.find(child => child.type === 'paragraph')!;
+      expect(sliceReparseSource(paragraph)).toBe('Card **body** text');
+    });
+
+    it('stamps a multi-line HTML sequence and the markdown between its tags', () => {
+      const md = ['<Wrapper>', '  <div>', '    A **bold** move', '  </div>', '</Wrapper>'].join('\n');
+      const mdast = parseMdast(md);
+
+      // A multi-line lowercase tag stays a pair of html nodes with markdown between;
+      // all three share the body's re-parsed source (blank line added by the body re-parse).
+      const wrapper = findJsxChild(mdast, 'Wrapper');
+      const bodySource = '<div>\n\n  A **bold** move\n</div>';
+      const openingTag = wrapper.children.find(child => child.type === 'html')!;
+      expect(openingTag.data?.reparseSource).toBe(bodySource);
+
+      const paragraph = wrapper.children.find(child => child.type === 'paragraph')!;
+      expect(sliceReparseSource(paragraph)).toBe('A **bold** move');
+
+      const strong = paragraph.children.find(child => child.type === 'strong')!;
+      expect(sliceReparseSource(strong)).toBe('**bold**');
+    });
+
+    it('stamps children of a single-line lowercase HTML tag promoted for markdown parsing', () => {
+      const md = ['<Wrapper>', '  <div>A **bold** move</div>', '</Wrapper>'].join('\n');
+      const mdast = parseMdast(md);
+
+      const div = findJsxChild(findJsxChild(mdast, 'Wrapper'), 'div');
+      expect(sliceReparseSource(div)).toBe('<div>A **bold** move</div>');
+
+      // Lowercase promotion unwraps the sole paragraph, so phrasing sits directly on the div.
+      const strong = (div.children as Node[]).find((child): child is Strong => child.type === 'strong')!;
+      expect(sliceReparseSource(strong)).toBe('**bold**');
+    });
+
+    it('stamps lowercase HTML promoted through an MDX expression attribute', () => {
+      const md = ['<Wrapper>', '  <button style={{ color: "red" }}>Click me</button>', '</Wrapper>'].join('\n');
+      const mdast = parseMdast(md);
+
+      const button = findJsxChild(findJsxChild(mdast, 'Wrapper'), 'button');
+      expect(sliceReparseSource(button)).toBe('<button style={{ color: "red" }}>Click me</button>');
+    });
+
+    it('stamps a component nested inside a list item of a component body', () => {
+      const md = [
+        '<Tabs>',
+        '    <Tab title="One">',
+        '        - item one',
+        '        - <ExampleComponent />',
+        '    </Tab>',
+        '</Tabs>',
+      ].join('\n');
+      const mdast = parseMdast(md);
+
+      const tab = findJsxChild(findJsxChild(mdast, 'Tabs'), 'Tab');
+      const list = tab.children.find(child => child.type === 'list')!;
+      const secondItem = list.children[1];
+      const nested = findJsxChild(secondItem, 'ExampleComponent');
+      expect(sliceReparseSource(nested)).toBe('<ExampleComponent />');
+    });
+
+    it('stamps sibling components separated by extra blank lines with the same body source', () => {
+      const md = [
+        '<Wrapper>',
+        '',
+        '  <First />',
+        '',
+        '',
+        '  <Second>',
+        '    content',
+        '  </Second>',
+        '',
+        '</Wrapper>',
+      ].join('\n');
+      const mdast = parseMdast(md);
+
+      const wrapper = findJsxChild(mdast, 'Wrapper');
+      const first = findJsxChild(wrapper, 'First');
+      const second = findJsxChild(wrapper, 'Second');
+
+      expect(first.data?.reparseSource).toBe(second.data?.reparseSource);
+      expect(sliceReparseSource(first)).toBe('<First />');
+      expect(sliceReparseSource(second)).toBe(['<Second>', '  content', '</Second>'].join('\n'));
     });
   });
 
@@ -350,10 +543,13 @@ Content here
 
       const second = mdxishAstProcessor(out, { newEditorTypes: true });
       const tree2 = second.processor.runSync(second.processor.parse(second.parserReadyContent)) as Root;
-      const callout = tree2.children[0] as { children: { type: string }[]; data?: { hProperties?: { empty?: boolean } } };
+      const callout = tree2.children[0] as {
+        children: { type: string }[];
+        data?: { hProperties?: { empty?: boolean } };
+      };
 
       expect(callout.data?.hProperties?.empty).toBe(true);
-      const firstChildText = ((callout.children[0] as { children?: { value?: string }[] }).children?.[0]?.value) ?? '';
+      const firstChildText = (callout.children[0] as { children?: { value?: string }[] }).children?.[0]?.value ?? '';
       expect(firstChildText).toBe('');
       expect(callout.children[1]).toMatchObject({
         type: 'paragraph',

--- a/processor/transform/mdxish/components/inline-html.ts
+++ b/processor/transform/mdxish/components/inline-html.ts
@@ -6,7 +6,13 @@ import { visit } from 'unist-util-visit';
 import { INLINE_COMPONENT_TAGS } from '../../../../lib/constants';
 import { type ParseAttributesOptions, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
 
-import { getInlineMdProcessor, hasExpressionAttr, isPascalCase, toMdxJsxTextElement } from './utils';
+import {
+  getInlineMdProcessor,
+  hasExpressionAttr,
+  isPascalCase,
+  stampReparseSource,
+  toMdxJsxTextElement,
+} from './utils';
 
 /**
  * Parse the body of an inline component as phrasing content. Remark always
@@ -21,7 +27,10 @@ const parsePhrasingChildren = (value: string, safeMode: boolean): PhrasingConten
   const trimmed = value.trim();
   if (!trimmed) return [];
   const [first] = getInlineMdProcessor({ safeMode }).parse(trimmed).children;
-  return first?.type === 'paragraph' ? (first as Paragraph).children : [];
+  if (first?.type !== 'paragraph') return [];
+  // These children root a new coordinate space: their offsets index into `trimmed`.
+  stampReparseSource((first as Paragraph).children, trimmed);
+  return (first as Paragraph).children;
 };
 
 /**

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -21,6 +21,16 @@ import {
 
 export { parseAttributes, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
 
+declare module 'mdast' {
+  interface Data {
+    /**
+     * The string this node's positions refer to. Set on subtrees produced by
+     * re-parsing a component body, whose offsets don't map to the document source.
+     */
+    reparseSource?: string;
+  }
+}
+
 // Matches a JSX attribute expression (e.g. `key={i}`) anywhere in a string. */
 const NESTED_ATTR_EXPRESSION_RE = /[\w-]+\s*=\s*\{/;
 
@@ -65,17 +75,35 @@ function safeDeindent(text: string): string {
     .join('\n');
 }
 
+// Structural view of any mdast node; some custom node types declare inline `data`
+// shapes that don't extend mdast's `Data`, so the visit() union rejects the stamp.
+interface StampableNode {
+  children?: StampableNode[];
+  data?: { hName?: unknown; hProperties?: unknown; reparseSource?: string };
+  type: string;
+}
+
+// Re-parsed subtrees carry positions relative to the re-parsed string, not the document.
+// Stamp that string so position-based consumers (e.g. the editor) slice the right source.
+// Nodes stamped by a deeper re-parse keep their own (deeper) string.
+const stampReparseSource = (node: StampableNode, reparseSource: string) => {
+  if (!node.data?.reparseSource) node.data = { ...node.data, reparseSource };
+  node.children?.forEach(child => stampReparseSource(child, reparseSource));
+};
+
 /**
  * Parse component-body markdown into mdast children. Dedenting shifts columns and
  * stales the top-level `terminateHtmlFlowBlocks` decisions, so that one preprocessor
  * re-runs here; other column-anchored fixups (compact headings, tables) do not.
  */
 const parseMdChildren = (value: string, safeMode: boolean): RootContent[] => {
-  const parsed = getInlineMdProcessor({ safeMode }).parse(terminateHtmlFlowBlocks(safeDeindent(value).trim()));
+  const reparseSource = terminateHtmlFlowBlocks(safeDeindent(value).trim());
+  const parsed = getInlineMdProcessor({ safeMode }).parse(reparseSource);
   // Promote nested wrappers bottom-up so an outer wrapper sees markdown buried in a
   // child claimed whole (e.g. `<li>` in `<ol>`) before its containsMarkdownConstruct check (RM-17560).
   // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutually recursive; hoisted decl, safe at runtime
   promoteComponentBlocks(parsed as Parent, safeMode, null);
+  stampReparseSource(parsed, reparseSource);
   return parsed.children || [];
 };
 
@@ -102,7 +130,11 @@ interface ComponentNodeOptions {
 
 // Ends the position at `consumedLength` so the component doesn't claim trailing
 // content the tokenizer swallowed into the same html node.
-const positionEndingAtConsumed = (nodePosition: Node['position'], value: string, consumedLength: number): Node['position'] => {
+const positionEndingAtConsumed = (
+  nodePosition: Node['position'],
+  value: string,
+  consumedLength: number,
+): Node['position'] => {
   if (!nodePosition?.start) return nodePosition;
   return { start: nodePosition.start, end: pointAfter(nodePosition.start, value.slice(0, consumedLength)) };
 };
@@ -122,7 +154,13 @@ const positionEndingAtClosingTagInSource = (
   return { start: nodePosition.start, end: pointAfter(nodePosition.start, consumed) };
 };
 
-const createComponentNode = ({ tag, attributes, children, startPosition, endPosition }: ComponentNodeOptions): MdxJsxFlowElement => ({
+const createComponentNode = ({
+  tag,
+  attributes,
+  children,
+  startPosition,
+  endPosition,
+}: ComponentNodeOptions): MdxJsxFlowElement => ({
   type: 'mdxJsxFlowElement',
   name: tag,
   attributes,
@@ -133,7 +171,15 @@ const createComponentNode = ({ tag, attributes, children, startPosition, endPosi
   },
 });
 
-const substituteNodeWithMdxNode = (parent: Parent, index: number, mdxNode: MdxJsxFlowElement) => {
+// The promoted node inherits the html node's position, so it must also inherit the
+// stamp saying which re-parsed string that position refers to (`reparseSource`).
+const substituteNodeWithMdxNode = (
+  parent: Parent,
+  index: number,
+  mdxNode: MdxJsxFlowElement,
+  reparseSource?: string,
+) => {
+  if (reparseSource) mdxNode.data = { ...mdxNode.data, reparseSource };
   (parent.children as Node[]).splice(index, 1, mdxNode);
 };
 
@@ -243,7 +289,7 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
         // End at the self-closing tag, not at any trailing content.
         endPosition: positionEndingAtConsumed(node.position, value, leadingWhitespace + openingTagEnd),
       });
-      substituteNodeWithMdxNode(parent, index, componentNode);
+      substituteNodeWithMdxNode(parent, index, componentNode, node.data?.reparseSource);
 
       const remainingContent = contentAfterTag.trim();
       if (remainingContent) {
@@ -297,7 +343,7 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
         startPosition: node.position,
         endPosition,
       });
-      substituteNodeWithMdxNode(parent, index, componentNode);
+      substituteNodeWithMdxNode(parent, index, componentNode, node.data?.reparseSource);
 
       // The unwrap reparented the children out of their paragraph, so re-walk them
       // since the children HTML may contain promotable syntax (e.g. `{…}`-attr tags)
@@ -329,9 +375,11 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
   return tree;
 }
 
-const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> = (opts = {}) => (tree, file) => {
-  const source: string | null = file?.value ? String(file.value) : null;
-  return promoteComponentBlocks(tree, !!opts.safeMode, source);
-};
+const mdxishMdxComponentBlocks: Plugin<[{ safeMode?: boolean }?], Parent> =
+  (opts = {}) =>
+  (tree, file) => {
+    const source: string | null = file?.value ? String(file.value) : null;
+    return promoteComponentBlocks(tree, !!opts.safeMode, source);
+  };
 
 export default mdxishMdxComponentBlocks;

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -17,19 +17,10 @@ import {
   isMarkdownPromotableHtmlTag,
   isPascalCase,
   NESTED_TABLE_RE,
+  stampReparseSource,
 } from './utils';
 
 export { parseAttributes, parseTag } from '../../../../lib/utils/mdxish/mdxish-component-tag-parser';
-
-declare module 'mdast' {
-  interface Data {
-    /**
-     * The string this node's positions refer to. Set on subtrees produced by
-     * re-parsing a component body, whose offsets don't map to the document source.
-     */
-    reparseSource?: string;
-  }
-}
 
 // Matches a JSX attribute expression (e.g. `key={i}`) anywhere in a string. */
 const NESTED_ATTR_EXPRESSION_RE = /[\w-]+\s*=\s*\{/;
@@ -75,22 +66,6 @@ function safeDeindent(text: string): string {
     .join('\n');
 }
 
-// Structural view of any mdast node; some custom node types declare inline `data`
-// shapes that don't extend mdast's `Data`, so the visit() union rejects the stamp.
-interface StampableNode {
-  children?: StampableNode[];
-  data?: { hName?: unknown; hProperties?: unknown; reparseSource?: string };
-  type: string;
-}
-
-// Re-parsed subtrees carry positions relative to the re-parsed string, not the document.
-// Stamp that string so position-based consumers (e.g. the editor) slice the right source.
-// Nodes stamped by a deeper re-parse keep their own (deeper) string.
-const stampReparseSource = (node: StampableNode, reparseSource: string) => {
-  if (!node.data?.reparseSource) node.data = { ...node.data, reparseSource };
-  node.children?.forEach(child => stampReparseSource(child, reparseSource));
-};
-
 /**
  * Parse component-body markdown into mdast children. Dedenting shifts columns and
  * stales the top-level `terminateHtmlFlowBlocks` decisions, so that one preprocessor
@@ -103,8 +78,10 @@ const parseMdChildren = (value: string, safeMode: boolean): RootContent[] => {
   // child claimed whole (e.g. `<li>` in `<ol>`) before its containsMarkdownConstruct check (RM-17560).
   // eslint-disable-next-line @typescript-eslint/no-use-before-define -- mutually recursive; hoisted decl, safe at runtime
   promoteComponentBlocks(parsed as Parent, safeMode, null);
-  stampReparseSource(parsed, reparseSource);
-  return parsed.children || [];
+  const children = parsed.children || [];
+  // These children root a new coordinate space: their offsets index into `reparseSource`.
+  stampReparseSource(children, reparseSource);
+  return children;
 };
 
 // Splices trailing content in as sibling nodes. parseMdChildren has already
@@ -171,15 +148,11 @@ const createComponentNode = ({
   },
 });
 
-// The promoted node inherits the html node's position, so it must also inherit the
-// stamp saying which re-parsed string that position refers to (`reparseSource`).
-const substituteNodeWithMdxNode = (
-  parent: Parent,
-  index: number,
-  mdxNode: MdxJsxFlowElement,
-  reparseSource?: string,
-) => {
-  if (reparseSource) mdxNode.data = { ...mdxNode.data, reparseSource };
+// The promoted node takes over the html node's position, so it also takes over the
+// coordinate space that position belongs to.
+const substituteNodeWithMdxNode = (parent: Parent, index: number, mdxNode: MdxJsxFlowElement) => {
+  const replacedSource = parent.children[index]?.data?.reparseSource;
+  if (replacedSource) stampReparseSource([mdxNode], replacedSource);
   (parent.children as Node[]).splice(index, 1, mdxNode);
 };
 
@@ -289,7 +262,7 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
         // End at the self-closing tag, not at any trailing content.
         endPosition: positionEndingAtConsumed(node.position, value, leadingWhitespace + openingTagEnd),
       });
-      substituteNodeWithMdxNode(parent, index, componentNode, node.data?.reparseSource);
+      substituteNodeWithMdxNode(parent, index, componentNode);
 
       const remainingContent = contentAfterTag.trim();
       if (remainingContent) {
@@ -320,7 +293,10 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
       // phrasing content isn't spuriously block-wrapped.
       let unwrappedSoleParagraph = false;
       if (!isPascal && parsedChildren.length === 1 && parsedChildren[0].type === 'paragraph') {
-        parsedChildren = (parsedChildren[0] as Parent).children as MdxJsxFlowElement['children'];
+        const soleParagraph = parsedChildren[0];
+        parsedChildren = (soleParagraph as Parent).children as MdxJsxFlowElement['children'];
+        // The unwrap drops the stamped root, so its children inherit that coordinate space.
+        if (soleParagraph.data?.reparseSource) stampReparseSource(parsedChildren, soleParagraph.data.reparseSource);
         unwrappedSoleParagraph = true;
       }
       // Without trailing content the whole node position is correct. With it, end
@@ -343,7 +319,7 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
         startPosition: node.position,
         endPosition,
       });
-      substituteNodeWithMdxNode(parent, index, componentNode, node.data?.reparseSource);
+      substituteNodeWithMdxNode(parent, index, componentNode);
 
       // The unwrap reparented the children out of their paragraph, so re-walk them
       // since the children HTML may contain promotable syntax (e.g. `{…}`-attr tags)

--- a/processor/transform/mdxish/components/utils.ts
+++ b/processor/transform/mdxish/components/utils.ts
@@ -42,6 +42,18 @@ export const getInlineMdProcessor = ({ safeMode = false }: { safeMode?: boolean 
 };
 
 /**
+ * Mark re-parsed subtree roots with the string their positions index into, so consumers
+ * slicing by offset use the right source (see `Data.reparseSource`). Only roots are
+ * stamped; descendants resolve via their nearest stamped ancestor. Roots a deeper
+ * re-parse already stamped keep their own string.
+ */
+export const stampReparseSource = (roots: Node[], reparseSource: string) => {
+  roots.forEach(root => {
+    if (!root.data?.reparseSource) root.data = { ...root.data, reparseSource };
+  });
+};
+
+/**
  * True when a tag name starts with an uppercase letter — ReadMe's marker for
  * a custom MDX component (vs a lowercase HTML tag).
  */

--- a/types.d.ts
+++ b/types.d.ts
@@ -105,7 +105,7 @@ export interface EmbedBlock extends Node {
 
 export interface Figure extends Node {
   children: [ImageBlock & { url: string }, FigCaption];
-  data: {
+  data: Data & {
     hName: 'figure';
   };
   type: NodeTypes.figure;
@@ -113,7 +113,7 @@ export interface Figure extends Node {
 
 export interface FigCaption extends Node {
   children: BlockContent[];
-  data: {
+  data: Data & {
     hName: 'figcaption';
   };
   type: NodeTypes.figcaption;
@@ -205,7 +205,7 @@ export interface Variable extends Node {
 }
 
 export interface Glossary extends Node {
-  children: [{ type: 'text'; value: string }];
+  children: [Text];
   data: Data & {
     hName: 'Glossary';
     hProperties: { term: string };
@@ -230,6 +230,16 @@ export interface Anchor extends Node {
 }
 
 declare module 'mdast' {
+  // eslint-disable-next-line @typescript-eslint/no-shadow -- augmenting mdast's `Data` requires reusing the name
+  interface Data {
+    /**
+     * Marks the root of a re-parsed subtree: this node's and its descendants' positions
+     * index into this string rather than the document. Resolve a node's source from its
+     * nearest stamped self-or-ancestor; unstamped means `parserReadyContent`.
+     */
+    reparseSource?: string;
+  }
+
   interface BlockContentMap {
     [NodeTypes.callout]: Callout;
     [NodeTypes.codeTabs]: CodeTabs;

--- a/types.d.ts
+++ b/types.d.ts
@@ -83,12 +83,12 @@ export interface EmbedBlock extends Node {
     hName: 'Embed' | 'embed';
     hProperties: Record<string, unknown> & {
       favicon?: string;
-      height?:string;
+      height?: string;
       href?: string;
       html?: string;
       iframe?: boolean;
       image?: string;
-      provider?:string;
+      provider?: string;
       providerName?: string;
       providerUrl?: string;
       title: string;


### PR DESCRIPTION
| 🎫 Resolve CX-3772 |
| :-----------------: |

## 🎯 What does this PR do?

There is an mdxish editor issue where markdown containing custom components nested inside readme components would break during deserialization, causing the component content to break. 

**Problem:** The deserialiser has a logic to extract the component from the source using the node positions, and unfortunately sometimes they're not accurate and hence splicing the wrong section. The root problematic code is in the component content parsing in the MDX block transformer (`mdx-blocks.ts`), where the `terminateHtmlFlowBlocks & safeDeindent` preprocessing created inaccurate node positions. 

**Fix:** Pass in the pre-preprocessed / original component content to the node.data (under `reparseSource`) so the position offsets are accurate relative to the source document. Then we still need a monorepo change: A small transformer in `deserialize.ts` to push each root's tag down to its descendants; existing readers unchanged.

## 🧪 QA tips

Engine-only; nothing changes here. **Verify in the `readme` repo against the companion PR** — open each doc in the MDXish editor, then edit and copy-paste inside the nested blocks and confirm nothing is mangled or duplicated.

- [ ] Nested components — edit `**body**`, then copy-paste the whole `<Card>`:

```markdown
<Tabs>
  <Tab title="One">
    <Cards columns={2}>
      <Card title="First" icon="fa-rocket">
        Card **body** text
      </Card>
    </Cards>
  </Tab>
</Tabs>
```

- [ ] Irregular spacing (the original repro) — paste it in, then reformat the whitespace:

```markdown
<Tabs>
    <Tab title="Accounts">

        ### Common Account Fields

        <ExampleComponent />

    </Tab>
</Tabs>
```

## 📸 Screenshot or Loom

N/A — no rendered output changes; the fix is position metadata. Visual QA belongs on the `readme` PR.
