### PR TITLE
fix(mdxish): don't serialise GFM tables -> JSX because of line breaks

### DIFF
--- a/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
+++ b/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
@@ -1103,6 +1103,42 @@ describe('mdxishMdastToMd', () => {
 
       expect(mdxishMdastToMd(mdast)).toContain('<Table');
     });
+
+    it('turns consecutive newlines into consecutive breaks', () => {
+      const mdast = tableWithCellChildren([{ type: 'text', value: 'one\n\ntwo' }]);
+
+      expect(mdxishMdastToMd(mdast)).toMatchInlineSnapshot(`
+        "| Field       | Required           |
+        | :---------- | :----------------- |
+        | postal_code | one<br /><br />two |
+        "
+      `);
+    });
+
+    it('keeps an empty task-list item as JSX, preserving its checkbox', () => {
+      const mdast = tableWithCellChildren([
+        { type: 'list', ordered: false, start: null, spread: false, children: [{ type: 'listItem', spread: false, checked: false, children: [] }] },
+      ]);
+
+      expect(mdxishMdastToMd(mdast)).toContain('<Table');
+    });
+
+    it('keeps multiple empty list items as JSX, preserving their count', () => {
+      const mdast = tableWithCellChildren([
+        {
+          type: 'list',
+          ordered: false,
+          start: null,
+          spread: false,
+          children: [
+            { type: 'listItem', spread: false, checked: null, children: [] },
+            { type: 'listItem', spread: false, checked: null, children: [] },
+          ],
+        },
+      ]);
+
+      expect(mdxishMdastToMd(mdast)).toContain('<Table');
+    });
   });
 
   describe('underscores serialization', () => {

--- a/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
+++ b/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
@@ -1115,7 +1115,28 @@ describe('mdxishMdastToMd', () => {
       `);
     });
 
-    it('keeps an empty task-list item as JSX, preserving its checkbox', () => {
+    it.each([
+      ['an unchecked', false, '[ ]'],
+      ['a checked', true, '[x]'],
+    ])('keeps %s empty task-list item as JSX, preserving its checkbox', (_label, checked, marker) => {
+      const mdast = tableWithCellChildren([
+        {
+          type: 'list',
+          ordered: false,
+          start: null,
+          spread: false,
+          children: [{ type: 'listItem', spread: false, checked, children: [{ type: 'paragraph', children: [] }] }],
+        },
+      ]);
+      const serialized = mdxishMdastToMd(mdast);
+
+      expect(serialized).toContain('<Table');
+      expect(serialized).toContain(`- ${marker}`);
+    });
+
+    // The checkbox itself is dropped by remark-stringify for a childless item (pre-existing),
+    // so this only asserts the routing: a task item must never collapse to a bare `-` cell.
+    it('keeps a childless task-list item as JSX', () => {
       const mdast = tableWithCellChildren([
         { type: 'list', ordered: false, start: null, spread: false, children: [{ type: 'listItem', spread: false, checked: false, children: [] }] },
       ]);
@@ -1136,8 +1157,10 @@ describe('mdxishMdastToMd', () => {
           ],
         },
       ]);
+      const serialized = mdxishMdastToMd(mdast);
 
-      expect(mdxishMdastToMd(mdast)).toContain('<Table');
+      expect(serialized).toContain('<Table');
+      expect(serialized.match(/^\s*-\s*$/gm)).toHaveLength(2);
     });
   });
 

--- a/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
+++ b/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
@@ -145,7 +145,7 @@ describe('mdxishMdastToMd', () => {
   });
 
   describe('tables with flow content', () => {
-    it('should serialize a table with newlines in cells to JSX <Table>', () => {
+    it('should serialize a table with a fenced code block in a cell to JSX <Table>', () => {
       const mdast: MdastRoot = {
         type: 'root',
         children: [
@@ -217,7 +217,7 @@ describe('mdxishMdastToMd', () => {
       `);
     });
 
-    it('should serialize a table with newlines in cells to JSX <Table> and separate the lines with an empty line between them', () => {
+    it('should serialize a table with multiple paragraphs in a cell to JSX <Table> and separate the lines with an empty line between them', () => {
       const mdast: MdastRoot = {
         type: 'root',
         children: [
@@ -1014,6 +1014,94 @@ describe('mdxishMdastToMd', () => {
         | Alice | 30  |
         "
       `);
+    });
+  });
+
+  /**
+   * CX-3773: pasting multi-line text into a cell, or typing a bare `-` placeholder, used to
+   * promote the whole table to `<Table>` for good. Both are representable inline in GFM, so
+   * these build the mdast the editor hands to save and assert a pipe table comes back.
+   */
+  describe('cell content that stays a GFM table (CX-3773)', () => {
+    const tableWithCellChildren = (children: RootContent[]): MdastRoot => ({
+      type: 'root',
+      children: [
+        {
+          type: 'table',
+          align: ['left', 'left'],
+          children: [
+            {
+              type: 'tableRow',
+              children: [
+                { type: 'tableCell', children: [{ type: 'text', value: 'Field' }] },
+                { type: 'tableCell', children: [{ type: 'text', value: 'Required' }] },
+              ],
+            },
+            {
+              type: 'tableRow',
+              children: [
+                { type: 'tableCell', children: [{ type: 'text', value: 'postal_code' }] },
+                { type: 'tableCell', children },
+              ],
+            },
+          ],
+        } as Table,
+      ],
+    });
+
+    it('turns a pasted break node into <br />', () => {
+      const mdast = tableWithCellChildren([
+        { type: 'text', value: 'Required for US' },
+        { type: 'break' },
+        { type: 'text', value: 'Ignored elsewhere' },
+      ]);
+
+      expect(mdxishMdastToMd(mdast)).toMatchInlineSnapshot(`
+        "| Field       | Required                               |
+        | :---------- | :------------------------------------- |
+        | postal_code | Required for US<br />Ignored elsewhere |
+        "
+      `);
+    });
+
+    it('turns a pasted newline inside a text node into <br />', () => {
+      const mdast = tableWithCellChildren([{ type: 'text', value: 'Required for US\nIgnored elsewhere' }]);
+
+      expect(mdxishMdastToMd(mdast)).toMatchInlineSnapshot(`
+        "| Field       | Required                               |
+        | :---------- | :------------------------------------- |
+        | postal_code | Required for US<br />Ignored elsewhere |
+        "
+      `);
+    });
+
+    it('turns a bare list marker placeholder into text', () => {
+      const mdast = tableWithCellChildren([
+        { type: 'list', ordered: false, start: null, spread: false, children: [{ type: 'listItem', spread: false, checked: null, children: [] }] },
+      ]);
+
+      expect(mdxishMdastToMd(mdast)).toMatchInlineSnapshot(`
+        "| Field       | Required |
+        | :---------- | :------- |
+        | postal_code | -        |
+        "
+      `);
+    });
+
+    it('still promotes a cell holding a list with real content', () => {
+      const mdast = tableWithCellChildren([
+        {
+          type: 'list',
+          ordered: false,
+          start: null,
+          spread: false,
+          children: [
+            { type: 'listItem', spread: false, checked: null, children: [{ type: 'paragraph', children: [{ type: 'text', value: 'yes' }] }] },
+          ],
+        },
+      ]);
+
+      expect(mdxishMdastToMd(mdast)).toContain('<Table');
     });
   });
 

--- a/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
+++ b/__tests__/lib/mdxish/mdxishMdastToMd.test.ts
@@ -1018,9 +1018,9 @@ describe('mdxishMdastToMd', () => {
   });
 
   /**
-   * CX-3773: pasting multi-line text into a cell, or typing a bare `-` placeholder, used to
-   * promote the whole table to `<Table>` for good. Both are representable inline in GFM, so
-   * these build the mdast the editor hands to save and assert a pipe table comes back.
+   * CX-3773: pasting multi-line text into a cell used to promote the whole table to `<Table>`
+   * for good. Line breaks are representable inline in GFM as `<br />`, so these build the
+   * mdast the editor hands to save and assert a pipe table comes back.
    */
   describe('cell content that stays a GFM table (CX-3773)', () => {
     const tableWithCellChildren = (children: RootContent[]): MdastRoot => ({
@@ -1075,17 +1075,12 @@ describe('mdxishMdastToMd', () => {
       `);
     });
 
-    it('turns a bare list marker placeholder into text', () => {
+    it('keeps a bare list marker placeholder as JSX', () => {
       const mdast = tableWithCellChildren([
         { type: 'list', ordered: false, start: null, spread: false, children: [{ type: 'listItem', spread: false, checked: null, children: [] }] },
       ]);
 
-      expect(mdxishMdastToMd(mdast)).toMatchInlineSnapshot(`
-        "| Field       | Required |
-        | :---------- | :------- |
-        | postal_code | -        |
-        "
-      `);
+      expect(mdxishMdastToMd(mdast)).toContain('<Table');
     });
 
     it('still promotes a cell holding a list with real content', () => {
@@ -1113,54 +1108,6 @@ describe('mdxishMdastToMd', () => {
         | postal_code | one<br /><br />two |
         "
       `);
-    });
-
-    it.each([
-      ['an unchecked', false, '[ ]'],
-      ['a checked', true, '[x]'],
-    ])('keeps %s empty task-list item as JSX, preserving its checkbox', (_label, checked, marker) => {
-      const mdast = tableWithCellChildren([
-        {
-          type: 'list',
-          ordered: false,
-          start: null,
-          spread: false,
-          children: [{ type: 'listItem', spread: false, checked, children: [{ type: 'paragraph', children: [] }] }],
-        },
-      ]);
-      const serialized = mdxishMdastToMd(mdast);
-
-      expect(serialized).toContain('<Table');
-      expect(serialized).toContain(`- ${marker}`);
-    });
-
-    // The checkbox itself is dropped by remark-stringify for a childless item (pre-existing),
-    // so this only asserts the routing: a task item must never collapse to a bare `-` cell.
-    it('keeps a childless task-list item as JSX', () => {
-      const mdast = tableWithCellChildren([
-        { type: 'list', ordered: false, start: null, spread: false, children: [{ type: 'listItem', spread: false, checked: false, children: [] }] },
-      ]);
-
-      expect(mdxishMdastToMd(mdast)).toContain('<Table');
-    });
-
-    it('keeps multiple empty list items as JSX, preserving their count', () => {
-      const mdast = tableWithCellChildren([
-        {
-          type: 'list',
-          ordered: false,
-          start: null,
-          spread: false,
-          children: [
-            { type: 'listItem', spread: false, checked: null, children: [] },
-            { type: 'listItem', spread: false, checked: null, children: [] },
-          ],
-        },
-      ]);
-      const serialized = mdxishMdastToMd(mdast);
-
-      expect(serialized).toContain('<Table');
-      expect(serialized.match(/^\s*-\s*$/gm)).toHaveLength(2);
     });
   });
 

--- a/__tests__/transformers/mdxish-tables-to-jsx.test.ts
+++ b/__tests__/transformers/mdxish-tables-to-jsx.test.ts
@@ -5,7 +5,34 @@ import remarkParse from 'remark-parse';
 import { unified } from 'unified';
 
 import mdxishTablesToJsx from '../../processor/transform/mdxish/tables/mdxish-tables-to-jsx';
-import { collectNodes } from '../helpers';
+import { collectNodes, roundTripMdxish } from '../helpers';
+
+/**
+ * A pipe table cannot express a multi-line cell, so the CX-3773 cases have to start
+ * from `<Table>` and be round-tripped back through the serializer.
+ */
+const tableWithCell = (cell: string): string =>
+  [
+    '<Table align={["left","left"]}>',
+    '<thead>',
+    '<tr>',
+    '<th>Field</th>',
+    '<th>Notes</th>',
+    '</tr>',
+    '</thead>',
+    '<tbody>',
+    '<tr>',
+    '<td>',
+    cell,
+    '</td>',
+    '<td>x</td>',
+    '</tr>',
+    '</tbody>',
+    '</Table>',
+    '',
+  ].join('\n');
+
+const stayedJsx = (markdown: string): boolean => /^<Table/m.test(markdown);
 
 const parseWithPlugin = (markdown: string): Root => {
   const processor = unified()
@@ -16,6 +43,9 @@ const parseWithPlugin = (markdown: string): Root => {
   processor.runSync(tree);
   return tree as Root;
 };
+
+/** The first body cell of a two-column table — indexes 0 and 1 are the header cells. */
+const firstBodyCell = (markdown: string): Parent => collectNodes<Parent>(parseWithPlugin(markdown), 'tableCell')[2];
 
 describe('mdxish-tables-to-jsx', () => {
   describe('plain GFM tables (no flow content)', () => {
@@ -67,24 +97,95 @@ describe('mdxish-tables-to-jsx', () => {
     });
   });
 
-  describe('break node replacement', () => {
-    it('replaces break nodes with text newlines', () => {
-      const md = '| Header |\n| --- |\n| line1<br>line2 |';
-      const tree = parseWithPlugin(md);
+  // CX-3773: line breaks and bare list markers are representable inline in GFM, so they
+  // must not silently promote a pipe table to <Table>.
+  describe('line breaks in a cell (CX-3773)', () => {
+    it.each([
+      ['a single soft line break', 'one\ntwo'],
+      ['a hard break written as a trailing backslash', 'one\\\ntwo'],
+      ['a hard break written as two trailing spaces', 'one  \ntwo'],
+    ])('normalizes %s to <br /> and keeps the table as GFM', (_label, cell) => {
+      const markdown = roundTripMdxish(tableWithCell(cell));
 
-      const textNodes: Parent[] = [];
-      const stack = [tree as Parent];
-      while (stack.length) {
-        const node = stack.pop()!;
-        if (node.type === 'text' && 'value' in node && (node as unknown as { value: string }).value.includes('\n')) {
-          textNodes.push(node);
-        }
-        if ('children' in node && Array.isArray(node.children)) {
-          stack.push(...(node.children as Parent[]));
-        }
-      }
+      expect(stayedJsx(markdown)).toBe(false);
+      expect(markdown).toContain('one<br />two');
+    });
 
-      expect(textNodes.length).toBeGreaterThanOrEqual(0);
+    it('emits a br element rather than a newline in the cell AST', () => {
+      const cell = firstBodyCell(roundTripMdxish(tableWithCell('one\ntwo')));
+
+      expect(cell).toMatchObject({
+        type: 'tableCell',
+        children: [
+          { type: 'text', value: 'one' },
+          { type: 'html', value: '<br />' },
+          { type: 'text', value: 'two' },
+        ],
+      });
+    });
+
+    it('leaves an author-written <br /> untouched', () => {
+      const markdown = roundTripMdxish(tableWithCell('one<br />two'));
+
+      expect(stayedJsx(markdown)).toBe(false);
+      expect(markdown).toContain('one<br />two');
+    });
+
+    it('keeps blank-line separated paragraphs as JSX, since a break is not a paragraph', () => {
+      expect(stayedJsx(roundTripMdxish(tableWithCell('one\n\ntwo')))).toBe(true);
+    });
+
+    it('keeps a newline inside inline code as JSX, since it has no inline equivalent', () => {
+      expect(stayedJsx(roundTripMdxish(tableWithCell('`one\ntwo`')))).toBe(true);
+    });
+
+    it('round-trips a normalized break without drifting', () => {
+      const once = roundTripMdxish(tableWithCell('one\ntwo'));
+
+      expect(roundTripMdxish(once)).toBe(once);
+    });
+
+    // Guards the promote path, which must keep collapsing `break` to a newline: leaving the
+    // node intact serializes a dangling `\` into the `<td>`. (That cell's own round trip has
+    // a separate, pre-existing instability, so this asserts the serialized shape only.)
+    it('collapses a break in a cell of a table that still promotes', () => {
+      const source = tableWithCell('one\\\ntwo').replace('<td>x</td>', '<td>\n\n```js\nx\n```\n\n</td>');
+      const serialized = roundTripMdxish(source);
+
+      expect(stayedJsx(serialized)).toBe(true);
+      expect(serialized).not.toContain('\\\n');
+    });
+  });
+
+  describe('bare list markers in a cell (CX-3773)', () => {
+    it.each([
+      ['a hyphen', '-', '-'],
+      ['an asterisk', '*', '-'],
+      ['a plus', '+', '-'],
+      ['an ordered marker', '1.', '1.'],
+    ])('treats %s as text and keeps the table as GFM', (_label, cell, expected) => {
+      const markdown = roundTripMdxish(tableWithCell(cell));
+
+      expect(stayedJsx(markdown)).toBe(false);
+      expect(markdown).toContain(`| ${expected}`);
+    });
+
+    it('replaces the empty list with a text node in the cell AST', () => {
+      const cell = firstBodyCell(roundTripMdxish(tableWithCell('-')));
+
+      expect(cell).toMatchObject({ type: 'tableCell', children: [{ type: 'text', value: '-' }] });
+    });
+
+    it('preserves the start number of an ordered marker', () => {
+      expect(roundTripMdxish(tableWithCell('3.'))).toContain('| 3.');
+    });
+
+    it.each([
+      ['a single item that has content', '- one'],
+      ['multiple items', '- one\n- two'],
+      ['an empty item alongside a real one', '- \n- two'],
+    ])('keeps a list with %s as JSX', (_label, cell) => {
+      expect(stayedJsx(roundTripMdxish(tableWithCell(cell)))).toBe(true);
     });
   });
 

--- a/__tests__/transformers/mdxish-tables-to-jsx.test.ts
+++ b/__tests__/transformers/mdxish-tables-to-jsx.test.ts
@@ -124,6 +124,24 @@ describe('mdxish-tables-to-jsx', () => {
       });
     });
 
+    it('normalizes a line break nested inside strong formatting', () => {
+      const cell = firstBodyCell(roundTripMdxish(tableWithCell('**one\ntwo**')));
+
+      expect(cell).toMatchObject({
+        type: 'tableCell',
+        children: [
+          {
+            type: 'strong',
+            children: [
+              { type: 'text', value: 'one' },
+              { type: 'html', value: '<br />' },
+              { type: 'text', value: 'two' },
+            ],
+          },
+        ],
+      });
+    });
+
     it('leaves an author-written <br /> untouched', () => {
       const markdown = roundTripMdxish(tableWithCell('one<br />two'));
 
@@ -184,6 +202,8 @@ describe('mdxish-tables-to-jsx', () => {
       ['a single item that has content', '- one'],
       ['multiple items', '- one\n- two'],
       ['an empty item alongside a real one', '- \n- two'],
+      ['multiple empty items', '-\n-\n-'],
+      ['a task-list item', '- [ ] done'],
     ])('keeps a list with %s as JSX', (_label, cell) => {
       expect(stayedJsx(roundTripMdxish(tableWithCell(cell)))).toBe(true);
     });

--- a/__tests__/transformers/mdxish-tables-to-jsx.test.ts
+++ b/__tests__/transformers/mdxish-tables-to-jsx.test.ts
@@ -97,8 +97,8 @@ describe('mdxish-tables-to-jsx', () => {
     });
   });
 
-  // CX-3773: line breaks and bare list markers are representable inline in GFM, so they
-  // must not silently promote a pipe table to <Table>.
+  // CX-3773: line breaks are representable inline in GFM as <br />, so they must not
+  // silently promote a pipe table to <Table>.
   describe('line breaks in a cell (CX-3773)', () => {
     it.each([
       ['a single soft line break', 'one\ntwo'],
@@ -175,34 +175,10 @@ describe('mdxish-tables-to-jsx', () => {
     });
   });
 
-  describe('bare list markers in a cell (CX-3773)', () => {
+  describe('lists in a cell', () => {
     it.each([
-      ['a hyphen', '-', '-'],
-      ['an asterisk', '*', '-'],
-      ['a plus', '+', '-'],
-      ['an ordered marker', '1.', '1.'],
-    ])('treats %s as text and keeps the table as GFM', (_label, cell, expected) => {
-      const markdown = roundTripMdxish(tableWithCell(cell));
-
-      expect(stayedJsx(markdown)).toBe(false);
-      expect(markdown).toContain(`| ${expected}`);
-    });
-
-    it('replaces the empty list with a text node in the cell AST', () => {
-      const cell = firstBodyCell(roundTripMdxish(tableWithCell('-')));
-
-      expect(cell).toMatchObject({ type: 'tableCell', children: [{ type: 'text', value: '-' }] });
-    });
-
-    it('preserves the start number of an ordered marker', () => {
-      expect(roundTripMdxish(tableWithCell('3.'))).toContain('| 3.');
-    });
-
-    it.each([
-      ['a single item that has content', '- one'],
-      ['multiple items', '- one\n- two'],
-      ['an empty item alongside a real one', '- \n- two'],
-      ['multiple empty items', '-\n-\n-'],
+      ['a bare marker', '-'],
+      ['an item that has content', '- one'],
       ['a task-list item', '- [ ] done'],
     ])('keeps a list with %s as JSX', (_label, cell) => {
       expect(stayedJsx(roundTripMdxish(tableWithCell(cell)))).toBe(true);

--- a/processor/transform/mdxish/tables/gfm-cell-normalization.ts
+++ b/processor/transform/mdxish/tables/gfm-cell-normalization.ts
@@ -1,8 +1,6 @@
 import type { List, Node, TableCell, Text } from 'mdast';
 import type { MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 
-import { visit } from 'unist-util-visit';
-
 /** `<br />` is the only line break a GFM pipe cell can carry, since cells are single-line. */
 const createLineBreak = (): MdxJsxTextElement => ({
   type: 'mdxJsxTextElement',
@@ -17,19 +15,21 @@ const isText = (node: Node): node is Text => node.type === 'text';
 
 const isList = (node: Node): node is List => node.type === 'list';
 
-const hasChildren = (node: Node): node is Node & { children: Node[] } => 'children' in node;
+export const hasChildren = (node: Node): node is Node & { children: Node[] } => 'children' in node;
 
 /**
- * True for a list whose every item is empty — a bare `-`, `*`, `+` or `1.` used as a
- * "not applicable" placeholder. It carries no structure, so it belongs in a cell as text.
+ * A list holding a single empty, non-task item — a bare `-`, `*`, `+` or `1.` used as a
+ * placeholder. Anything more (task state, multiple items) carries structure a cell cannot keep.
  */
-export const isBareListMarker = (node: Node): node is List =>
-  isList(node) && node.children.length > 0 && node.children.every(item => item.children.length === 0);
+const isBareListMarker = (node: Node): node is List =>
+  isList(node) &&
+  node.children.length === 1 &&
+  node.children[0].checked == null &&
+  node.children[0].children.length === 0;
 
 /** Bullets serialize with the engine's configured `-`, so a bare `*` or `+` normalizes to it. */
-const markerToText = (list: List): Text => createText(list.ordered ? `${list.start ?? 1}.` : '-');
+const bareMarkerToText = (list: List): Text => createText(list.ordered ? `${list.start ?? 1}.` : '-');
 
-/** Splits `one\ntwo` into `one`, `<br />`, `two`, dropping the empty half of a leading break. */
 const splitOnLineBreaks = (value: string): Node[] =>
   value.split('\n').reduce<Node[]>((nodes, segment, index) => {
     if (index > 0) nodes.push(createLineBreak());
@@ -40,31 +40,15 @@ const splitOnLineBreaks = (value: string): Node[] =>
 const normalizeNodes = (nodes: Node[]): Node[] =>
   nodes.flatMap<Node>(node => {
     if (node.type === 'break') return createLineBreak();
-    if (isBareListMarker(node)) return markerToText(node);
+    if (isBareListMarker(node)) return bareMarkerToText(node);
     if (isText(node)) return splitOnLineBreaks(node.value);
-    if (hasChildren(node)) node.children = normalizeNodes(node.children);
+    if (hasChildren(node)) return { ...node, children: normalizeNodes(node.children) };
     return node;
   });
 
 /**
- * Rewrites the two content classes that are representable in a GFM cell but do not survive
- * one: line breaks (`break` nodes and newlines inside text) become `<br />`, and bare list
- * markers become their literal text.
- *
- * Only safe once the whole table has cleared `canCellBeGfm` — rewriting a cell of a table
- * that still promotes would mangle content the `<Table>` can hold as-is.
+ * Returns a copy of the cell's children with line breaks rewritten to `<br />` and a bare list
+ * marker to text — the two content classes representable in a GFM cell but lost by one.
  */
-export const normalizeCellForGfm = (cell: TableCell): void => {
-  cell.children = normalizeNodes(cell.children) as typeof cell.children;
-};
-
-/**
- * The promote path's long-standing handling of `break`, kept unchanged: a bare `\` would
- * serialize into a `<td>` as a dangling escape that does not round-trip, so it collapses to
- * the newline a `<Table>` cell renders as a soft break.
- */
-export const flattenBreaksToNewlines = (cell: TableCell): void => {
-  visit(cell, 'break', (_, index, parent) => {
-    parent.children.splice(index, 1, createText('\n'));
-  });
-};
+export const normalizeCellChildrenForGfm = (cell: TableCell): TableCell['children'] =>
+  normalizeNodes(cell.children) as TableCell['children'];

--- a/processor/transform/mdxish/tables/gfm-cell-normalization.ts
+++ b/processor/transform/mdxish/tables/gfm-cell-normalization.ts
@@ -1,0 +1,70 @@
+import type { List, Node, TableCell, Text } from 'mdast';
+import type { MdxJsxTextElement } from 'mdast-util-mdx-jsx';
+
+import { visit } from 'unist-util-visit';
+
+/** `<br />` is the only line break a GFM pipe cell can carry, since cells are single-line. */
+const createLineBreak = (): MdxJsxTextElement => ({
+  type: 'mdxJsxTextElement',
+  name: 'br',
+  attributes: [],
+  children: [],
+});
+
+const createText = (value: string): Text => ({ type: 'text', value });
+
+const isText = (node: Node): node is Text => node.type === 'text';
+
+const isList = (node: Node): node is List => node.type === 'list';
+
+const hasChildren = (node: Node): node is Node & { children: Node[] } => 'children' in node;
+
+/**
+ * True for a list whose every item is empty — a bare `-`, `*`, `+` or `1.` used as a
+ * "not applicable" placeholder. It carries no structure, so it belongs in a cell as text.
+ */
+export const isBareListMarker = (node: Node): node is List =>
+  isList(node) && node.children.length > 0 && node.children.every(item => item.children.length === 0);
+
+/** Bullets serialize with the engine's configured `-`, so a bare `*` or `+` normalizes to it. */
+const markerToText = (list: List): Text => createText(list.ordered ? `${list.start ?? 1}.` : '-');
+
+/** Splits `one\ntwo` into `one`, `<br />`, `two`, dropping the empty half of a leading break. */
+const splitOnLineBreaks = (value: string): Node[] =>
+  value.split('\n').reduce<Node[]>((nodes, segment, index) => {
+    if (index > 0) nodes.push(createLineBreak());
+    if (segment) nodes.push(createText(segment));
+    return nodes;
+  }, []);
+
+const normalizeNodes = (nodes: Node[]): Node[] =>
+  nodes.flatMap<Node>(node => {
+    if (node.type === 'break') return createLineBreak();
+    if (isBareListMarker(node)) return markerToText(node);
+    if (isText(node)) return splitOnLineBreaks(node.value);
+    if (hasChildren(node)) node.children = normalizeNodes(node.children);
+    return node;
+  });
+
+/**
+ * Rewrites the two content classes that are representable in a GFM cell but do not survive
+ * one: line breaks (`break` nodes and newlines inside text) become `<br />`, and bare list
+ * markers become their literal text.
+ *
+ * Only safe once the whole table has cleared `canCellBeGfm` — rewriting a cell of a table
+ * that still promotes would mangle content the `<Table>` can hold as-is.
+ */
+export const normalizeCellForGfm = (cell: TableCell): void => {
+  cell.children = normalizeNodes(cell.children) as typeof cell.children;
+};
+
+/**
+ * The promote path's long-standing handling of `break`, kept unchanged: a bare `\` would
+ * serialize into a `<td>` as a dangling escape that does not round-trip, so it collapses to
+ * the newline a `<Table>` cell renders as a soft break.
+ */
+export const flattenBreaksToNewlines = (cell: TableCell): void => {
+  visit(cell, 'break', (_, index, parent) => {
+    parent.children.splice(index, 1, createText('\n'));
+  });
+};

--- a/processor/transform/mdxish/tables/gfm-cell-normalization.ts
+++ b/processor/transform/mdxish/tables/gfm-cell-normalization.ts
@@ -1,4 +1,4 @@
-import type { List, Node, TableCell, Text } from 'mdast';
+import type { Node, TableCell, Text } from 'mdast';
 import type { MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 
 /** `<br />` is the only line break a GFM pipe cell can carry, since cells are single-line. */
@@ -13,22 +13,7 @@ const createText = (value: string): Text => ({ type: 'text', value });
 
 const isText = (node: Node): node is Text => node.type === 'text';
 
-const isList = (node: Node): node is List => node.type === 'list';
-
 export const hasChildren = (node: Node): node is Node & { children: Node[] } => 'children' in node;
-
-/**
- * A list holding a single empty, non-task item — a bare `-`, `*`, `+` or `1.` used as a
- * placeholder. Anything more (task state, multiple items) carries structure a cell cannot keep.
- */
-const isBareListMarker = (node: Node): node is List =>
-  isList(node) &&
-  node.children.length === 1 &&
-  node.children[0].checked == null &&
-  node.children[0].children.length === 0;
-
-/** Bullets serialize with the engine's configured `-`, so a bare `*` or `+` normalizes to it. */
-const bareMarkerToText = (list: List): Text => createText(list.ordered ? `${list.start ?? 1}.` : '-');
 
 const splitOnLineBreaks = (value: string): Node[] =>
   value.split('\n').reduce<Node[]>((nodes, segment, index) => {
@@ -40,15 +25,14 @@ const splitOnLineBreaks = (value: string): Node[] =>
 const normalizeNodes = (nodes: Node[]): Node[] =>
   nodes.flatMap<Node>(node => {
     if (node.type === 'break') return createLineBreak();
-    if (isBareListMarker(node)) return bareMarkerToText(node);
     if (isText(node)) return splitOnLineBreaks(node.value);
     if (hasChildren(node)) return { ...node, children: normalizeNodes(node.children) };
     return node;
   });
 
 /**
- * Returns a copy of the cell's children with line breaks rewritten to `<br />` and a bare list
- * marker to text — the two content classes representable in a GFM cell but lost by one.
+ * Returns a copy of the cell's children with line breaks — `break` nodes and newlines inside
+ * text — rewritten to the `<br />` a single-line GFM pipe cell can carry.
  */
 export const normalizeCellChildrenForGfm = (cell: TableCell): TableCell['children'] =>
   normalizeNodes(cell.children) as TableCell['children'];

--- a/processor/transform/mdxish/tables/mdxish-tables-to-jsx.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables-to-jsx.ts
@@ -1,11 +1,13 @@
-import type { Literal, Node, Table, TableCell } from 'mdast';
+import type { Literal, Node, Nodes, Table, TableCell } from 'mdast';
 import type { Transform } from 'mdast-util-from-markdown';
 import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 
 import { phrasing } from 'mdast-util-phrasing';
-import { visit } from 'unist-util-visit';
+import { EXIT, visit } from 'unist-util-visit';
 
 import { NodeTypes } from '../../../../enums';
+
+import { flattenBreaksToNewlines, isBareListMarker, normalizeCellForGfm } from './gfm-cell-normalization';
 
 const SELF_CLOSING_JSX_REGEX = /^\s*<[A-Z][^>]*\/>\s*$/;
 
@@ -27,6 +29,47 @@ const isTableCell = (node: Node) => ['tableHead', 'tableCell'].includes(node.typ
 const isLiteral = (node: Node): node is Literal => 'value' in node;
 
 /**
+ * Block-level content that a single-line GFM cell cannot hold. `phrasing()` returns true
+ * for inline types (text, emphasis, strong, link…), which are safe to keep.
+ */
+const isFlowChild = (child: Nodes): boolean => {
+  if (child.type === 'paragraph' || child.type === 'plain' || child.type === 'escape') return false;
+  if (child.type === NodeTypes.variable) return false;
+  if (phrasing(child)) return false;
+  if (isBareListMarker(child)) return false;
+  if (child.type === 'html') return SELF_CLOSING_JSX_REGEX.test(child.value);
+
+  return true;
+};
+
+/**
+ * Newlines that survive {@link normalizeCellForGfm}. Only `text` newlines become `<br />`;
+ * one inside `inlineCode` or raw `html` is part of the value and has no inline equivalent.
+ */
+const hasUnrepresentableNewline = (cell: TableCell): boolean => {
+  let found = false;
+  visit(cell, isLiteral, (node: Literal & Node) => {
+    if (node.type !== 'text' && node.value.includes('\n')) {
+      found = true;
+      return EXIT;
+    }
+    return undefined;
+  });
+  return found;
+};
+
+/** True when a cell's content round-trips through a GFM pipe cell without losing structure. */
+const canCellBeGfm = (cell: TableCell): boolean => {
+  if (cell.children.length === 0) return true;
+
+  // Multiple paragraphs are distinct blocks; a single-line cell cannot keep them apart.
+  if (cell.children.filter(child => child.type === 'paragraph').length > 1) return false;
+  if (cell.children.some(isFlowChild)) return false;
+
+  return !hasUnrepresentableNewline(cell);
+};
+
+/**
  * Mdxish-specific version of `tablesToJsx`. Differs from the shared MDX version:
  *
  * - Excludes `html` nodes from triggering JSX conversion because raw HTML
@@ -42,53 +85,18 @@ const mdxishTablesToJsx = (): Transform => tree => {
       let hasFlowContent = false;
 
       visit(table, isTableCell, (cell: TableCell) => {
-        if (hasFlowContent || cell.children.length === 0) return;
-
-        visit(cell, 'break', (_, breakIndex, breakParent) => {
-          breakParent.children.splice(breakIndex, 1, { type: 'text', value: '\n' });
-        });
-
-        // A cell with more than one paragraph child cannot be serialized as GFM
-        // (pipe tables are single-line per cell), so force JSX <Table> output to
-        // preserve paragraph separation.
-        const paragraphCount = cell.children.filter(child => child.type === 'paragraph').length;
-        if (paragraphCount > 1) {
-          hasFlowContent = true;
-          return;
-        }
-
-        // Check if any child is "flow" content (block-level) that requires JSX <Table>
-        // serialization instead of GFM. `phrasing()` from mdast-util-phrasing returns
-        // true for inline node types (text, emphasis, strong, link, etc.) which are
-        // safe to keep in GFM cells.
-        const hasFlowChild = (cell.children as Node[]).some(child => {
-          if (child.type === 'paragraph' || child.type === 'plain' || child.type === 'escape') return false;
-          if (child.type === NodeTypes.variable) return false;
-          if (phrasing(child as Parameters<typeof phrasing>[0])) return false;
-          if (child.type === 'html') {
-            return SELF_CLOSING_JSX_REGEX.test((child as Literal).value);
-          }
-
-          return true;
-        });
-
-        if (hasFlowChild) {
-          hasFlowContent = true;
-        }
-
-        if (!hasFlowContent) {
-          visit(cell, isLiteral, (node: Literal) => {
-            if (node.value.match(/\n/)) {
-              hasFlowContent = true;
-            }
-          });
-        }
+        if (canCellBeGfm(cell)) return undefined;
+        hasFlowContent = true;
+        return EXIT;
       });
 
       if (!hasFlowContent) {
+        visit(table, isTableCell, normalizeCellForGfm);
         table.type = 'table';
         return;
       }
+
+      visit(table, isTableCell, flattenBreaksToNewlines);
 
       const styles = table.align.map(alignToStyle);
 

--- a/processor/transform/mdxish/tables/mdxish-tables-to-jsx.ts
+++ b/processor/transform/mdxish/tables/mdxish-tables-to-jsx.ts
@@ -7,7 +7,7 @@ import { EXIT, visit } from 'unist-util-visit';
 
 import { NodeTypes } from '../../../../enums';
 
-import { flattenBreaksToNewlines, isBareListMarker, normalizeCellForGfm } from './gfm-cell-normalization';
+import { hasChildren, normalizeCellChildrenForGfm } from './gfm-cell-normalization';
 
 const SELF_CLOSING_JSX_REGEX = /^\s*<[A-Z][^>]*\/>\s*$/;
 
@@ -36,37 +36,31 @@ const isFlowChild = (child: Nodes): boolean => {
   if (child.type === 'paragraph' || child.type === 'plain' || child.type === 'escape') return false;
   if (child.type === NodeTypes.variable) return false;
   if (phrasing(child)) return false;
-  if (isBareListMarker(child)) return false;
   if (child.type === 'html') return SELF_CLOSING_JSX_REGEX.test(child.value);
 
   return true;
 };
 
-/**
- * Newlines that survive {@link normalizeCellForGfm}. Only `text` newlines become `<br />`;
- * one inside `inlineCode` or raw `html` is part of the value and has no inline equivalent.
- */
-const hasUnrepresentableNewline = (cell: TableCell): boolean => {
-  let found = false;
-  visit(cell, isLiteral, (node: Literal & Node) => {
-    if (node.type !== 'text' && node.value.includes('\n')) {
-      found = true;
-      return EXIT;
-    }
-    return undefined;
-  });
-  return found;
+/** A newline in a normalized cell (e.g. inside `inlineCode`) has no inline equivalent. */
+const containsLiteralNewline = (nodes: Node[]): boolean =>
+  nodes.some(
+    node => (isLiteral(node) && node.value.includes('\n')) || (hasChildren(node) && containsLiteralNewline(node.children)),
+  );
+
+/** True when normalized cell content survives a single-line GFM pipe cell without losing structure. */
+const canCellBeGfm = (children: TableCell['children']): boolean => {
+  // Multiple paragraphs are distinct blocks; a single-line cell cannot keep them apart.
+  if (children.filter(child => child.type === 'paragraph').length > 1) return false;
+  if (children.some(isFlowChild)) return false;
+
+  return !containsLiteralNewline(children);
 };
 
-/** True when a cell's content round-trips through a GFM pipe cell without losing structure. */
-const canCellBeGfm = (cell: TableCell): boolean => {
-  if (cell.children.length === 0) return true;
-
-  // Multiple paragraphs are distinct blocks; a single-line cell cannot keep them apart.
-  if (cell.children.filter(child => child.type === 'paragraph').length > 1) return false;
-  if (cell.children.some(isFlowChild)) return false;
-
-  return !hasUnrepresentableNewline(cell);
+/** On the promote path a `break` would serialize as a dangling `\`, so collapse it to a newline. */
+const flattenBreaksToNewlines = (cell: TableCell): void => {
+  visit(cell, 'break', (_, index, parent) => {
+    parent.children.splice(index, 1, { type: 'text', value: '\n' });
+  });
 };
 
 /**
@@ -82,16 +76,23 @@ const mdxishTablesToJsx = (): Transform => tree => {
     tree,
     (node: Node) => ['table', 'tableau'].includes(node.type),
     (table: Table, index, parent) => {
-      let hasFlowContent = false;
+      const gfmCells: [TableCell, TableCell['children']][] = [];
+      let requiresJsxTable = false;
 
       visit(table, isTableCell, (cell: TableCell) => {
-        if (canCellBeGfm(cell)) return undefined;
-        hasFlowContent = true;
-        return EXIT;
+        const normalized = normalizeCellChildrenForGfm(cell);
+        if (!canCellBeGfm(normalized)) {
+          requiresJsxTable = true;
+          return EXIT;
+        }
+        gfmCells.push([cell, normalized]);
+        return undefined;
       });
 
-      if (!hasFlowContent) {
-        visit(table, isTableCell, normalizeCellForGfm);
+      if (!requiresJsxTable) {
+        gfmCells.forEach(([cell, children]) => {
+          cell.children = children;
+        });
         table.type = 'table';
         return;
       }


### PR DESCRIPTION
| 🎫 Resolve CX-3773 |
| :-----------------: |

## 🎯 What does this PR do?

- Stops line breaks in a table cell from silently promoting the whole GFM table to JSX `<Table>` on save (customer request)
- Line breaks are representable inline in a pipe cell, so the serializer now normalizes them instead: `break` nodes and newlines inside text become `<br />`

## 🧪 QA tips

Link this branch into the app locally (`npm run build && npm link` here, then `npm link @readme/markdown` in the app repo) and test in the **mdxish editor**:

- [ ] Start from a plain pipe table, press shift+enter (or paste multi-line text) inside a cell, save → the doc should stay a pipe table with `<br />` in the cell, not turn into `<Table>`:

  ```md
  | Field       | Required                               |
  | :---------- | :------------------------------------- |
  | postal_code | Required for US<br />Ignored elsewhere |
  ```

- [ ] Re-save the doc a couple of times → output is stable, no drift back to `<Table>`.
- [ ] Sanity-check that real flow content in a cell still converts to `<Table>` on save: use the editor UI to insert a bulleted list (with text in the items), multiple paragraphs, or a code block inside a cell → the saved doc should contain `<Table>`, e.g.:

## 📸 Screenshot or Loom

Before vs After:

https://github.com/user-attachments/assets/4be7cec5-5f6d-42f8-a4d1-3c0178a1c82c

