### PR TITLE
fix(mdxish): only decode semicolon-less entities the HTML spec allows

### DIFF
--- a/__tests__/lib/mdxish/loose-html-entity.test.ts
+++ b/__tests__/lib/mdxish/loose-html-entity.test.ts
@@ -1,6 +1,7 @@
 import type { Element, Text } from 'hast';
 
-import { mdxish } from '../../../lib/mdxish';
+import { mdxish, mix } from '../../../lib';
+import { collectNodes, roundTripMdxish } from '../../helpers';
 
 describe('HTML entity tokenizer', () => {
   it.each([
@@ -9,10 +10,9 @@ describe('HTML entity tokenizer', () => {
     { name: '&nbsp; with semicolon (no double-convert)', input: 'Hello&nbsp;World', expected: 'Hello\u00a0World' },
     { name: '&amp without semicolon', input: 'Tom&ampJerry', expected: 'Tom&Jerry' },
     { name: '&copy without semicolon', input: '&copy 2025', expected: '\u00a9 2025' },
-    { name: '&hellip without semicolon', input: 'Wait&hellip really?', expected: 'Wait\u2026 really?' },
-    { name: '&mdash without semicolon', input: 'one&mdash two', expected: 'one\u2014 two' },
-    { name: '&ndash without semicolon', input: '1&ndash10', expected: '1\u201310' },
     { name: '&lt without semicolon', input: '1 &lt 2', expected: '1 < 2' },
+    { name: '&sect prefix followed by more letters', input: '&sectionId', expected: '\u00a7ionId' },
+    { name: '&not prefix followed by more letters', input: '&notit', expected: '\u00acit' },
     { name: '&gt without semicolon', input: '2 &gt 1', expected: '2 > 1' },
     { name: '&quot without semicolon', input: '&quot hello &quot', expected: '" hello "' },
     { name: '&#160 decimal nbsp', input: 'Hello&#160World', expected: 'Hello\u00a0World' },
@@ -57,9 +57,7 @@ describe('HTML entity tokenizer', () => {
     const textNode = paragraph.children[0] as Text;
     expect(textNode.value).toContain('\u00a0');
 
-    const codeElement = paragraph.children.find(
-      (c): c is Element => c.type === 'element' && c.tagName === 'code',
-    );
+    const codeElement = paragraph.children.find((c): c is Element => c.type === 'element' && c.tagName === 'code');
     expect((codeElement!.children[0] as Text).value).toBe('&nbsp');
   });
 
@@ -111,5 +109,80 @@ describe('HTML entity tokenizer', () => {
 
     const paragraph = tree.children[0] as Element;
     expect((paragraph.children[0] as Text).value).toContain('&#');
+  });
+});
+
+describe('HTML entity tokenizer: names that require a semicolon', () => {
+  const QUERY_STRING = 'api-base-url?partner_code=xxx&partner_key=xxx';
+
+  it.each([
+    { name: '&partner_key', input: 'a=1&partner_key=2' },
+    { name: '&and', input: 'a=1&and=2' },
+    { name: '&api_key', input: 'a=1&api_key=2' },
+    { name: '&image', input: 'a=1&image=2' },
+    { name: '&int', input: 'a=1&int=2' },
+    { name: '&lang', input: 'a=1&lang=en' },
+    { name: '&nested', input: 'a=1&nested=2' },
+    { name: '&order', input: 'a=1&order=desc' },
+    { name: '&prop', input: 'a=1&prop=2' },
+    { name: '&scope', input: 'a=1&scope=2' },
+    { name: '&startDate', input: 'a=1&startDate=2' },
+    { name: '&sum', input: 'a=1&sum=2' },
+  ])('leaves $name intact because it is not a legacy entity', ({ input }) => {
+    const tree = mdxish(input);
+
+    const paragraph = tree.children[0] as Element;
+    expect((paragraph.children[0] as Text).value).toBe(input);
+  });
+
+  it.each([
+    { name: '&part;', input: 'a&part;b', expected: 'a∂b' },
+    { name: '&and;', input: 'a&and;b', expected: 'a∧b' },
+    { name: '&order;', input: 'a&order;b', expected: 'aℴb' },
+  ])('still converts $name when terminated', ({ input, expected }) => {
+    const tree = mdxish(input);
+
+    const paragraph = tree.children[0] as Element;
+    expect((paragraph.children[0] as Text).value).toBe(expected);
+  });
+
+  it('keeps a query string intact in a table cell', () => {
+    const tree = mdxish(`| Endpoint |\n| --- |\n| ${QUERY_STRING} |`);
+
+    const cell = collectNodes<Element>(tree, node => node.type === 'element' && (node as Element).tagName === 'td');
+    expect(cell).toHaveLength(1);
+    expect(cell[0].children).toMatchObject([{ type: 'text', value: QUERY_STRING }]);
+  });
+
+  it('keeps a query string intact in a condensed table cell', () => {
+    const tree = mdxish(`|Endpoint|\n|-|\n|${QUERY_STRING}|`);
+
+    const cell = collectNodes<Element>(tree, node => node.type === 'element' && (node as Element).tagName === 'td');
+    expect(cell[0].children).toMatchObject([{ type: 'text', value: QUERY_STRING }]);
+  });
+
+  it.each([
+    { name: 'a callout', input: `> 📘 Auth\n>\n> ${QUERY_STRING}` },
+    { name: 'a Tabs component', input: `<Tabs>\n  <Tab title="One">\n    ${QUERY_STRING}\n  </Tab>\n</Tabs>` },
+    { name: 'a list item', input: `- ${QUERY_STRING}` },
+    { name: 'a blockquote with blank lines around it', input: `\n\n> ${QUERY_STRING}\n\n` },
+  ])('keeps a query string intact inside $name', ({ input }) => {
+    const html = mix(input);
+
+    expect(html).toContain('partner_code=xxx&#x26;partner_key=xxx');
+    expect(html).not.toContain('∂');
+  });
+
+  it('keeps a query string intact through a serialization round trip', () => {
+    expect(roundTripMdxish(`| Endpoint |\n| --- |\n| ${QUERY_STRING} |`)).toMatchInlineSnapshot(`
+      "| Endpoint                                       |
+      | ---------------------------------------------- |
+      | api-base-url?partner_code=xxx\\&partner_key=xxx |
+      "
+    `);
+  });
+
+  it('renders the query string as a single unescaped ampersand', () => {
+    expect(mix(QUERY_STRING)).toMatchInlineSnapshot('"<p>api-base-url?partner_code=xxx&#x26;partner_key=xxx</p>"');
   });
 });

--- a/__tests__/lib/mdxish/loose-html-entity.test.ts
+++ b/__tests__/lib/mdxish/loose-html-entity.test.ts
@@ -1,7 +1,26 @@
 import type { Element, Text } from 'hast';
+import type { Text as MdastText } from 'mdast';
 
-import { mdxish, mix } from '../../../lib';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+
+import { hast, mdxish, mix } from '../../../lib';
+import { looseHtmlEntity, looseHtmlEntityFromMarkdown } from '../../../lib/micromark/loose-html-entities';
 import { collectNodes, roundTripMdxish } from '../../helpers';
+
+/**
+ * Runs the tokenizer on its own, without the surrounding MDXish pipeline, and
+ * returns the concatenated text it produced.
+ */
+const tokenizeLoosely = (source: string): string =>
+  collectNodes<MdastText>(
+    fromMarkdown(source, {
+      extensions: [looseHtmlEntity()],
+      mdastExtensions: [looseHtmlEntityFromMarkdown()],
+    }),
+    'text',
+  )
+    .map(node => node.value)
+    .join('');
 
 describe('HTML entity tokenizer', () => {
   it.each([
@@ -112,6 +131,31 @@ describe('HTML entity tokenizer', () => {
   });
 });
 
+// Regression coverage for #1359, which decoded any name in the HTML5 table
+// without a semicolon and so mangled query strings like `&partner_key`.
+describe('looseHtmlEntity tokenizer', () => {
+  it.each([
+    { name: '&nbsp', input: 'Hello&nbspWorld', expected: 'Hello World' },
+    { name: '&amp', input: 'Tom&ampJerry', expected: 'Tom&Jerry' },
+    { name: '&sect as a prefix', input: '&sectionId', expected: '§ionId' },
+    { name: '&not as a prefix', input: '&notit', expected: '¬it' },
+    { name: '&#160', input: 'Hello&#160World', expected: 'Hello World' },
+    { name: '&#xa0', input: 'Hello&#xa0World', expected: 'Hello World' },
+  ])('decodes $name, which the HTML spec allows without a semicolon', ({ input, expected }) => {
+    expect(tokenizeLoosely(input)).toBe(expected);
+  });
+
+  it.each([
+    { name: '&partner_key', input: 'a=1&partner_key=2' },
+    { name: '&part with no terminator', input: 'a&partb' },
+    { name: '&order', input: 'a=1&order=desc' },
+    { name: '&hellip', input: 'Wait&hellip really?' },
+    { name: 'an unknown name', input: 'Hello&xyzzy World' },
+  ])('leaves $name alone, because it needs a semicolon', ({ input }) => {
+    expect(tokenizeLoosely(input)).toBe(input);
+  });
+});
+
 describe('HTML entity tokenizer: names that require a semicolon', () => {
   const QUERY_STRING = 'api-base-url?partner_code=xxx&partner_key=xxx';
 
@@ -171,6 +215,36 @@ describe('HTML entity tokenizer: names that require a semicolon', () => {
 
     expect(html).toContain('partner_code=xxx&#x26;partner_key=xxx');
     expect(html).not.toContain('∂');
+  });
+
+  it.each([
+    { name: 'emphasis', input: `_${QUERY_STRING}_` },
+    { name: 'strong emphasis', input: `**${QUERY_STRING}**` },
+    { name: 'a link label', input: `[${QUERY_STRING}](https://example.com)` },
+    { name: 'a heading', input: `## ${QUERY_STRING}` },
+    { name: 'a list nested inside a callout', input: `> 📘 Auth\n>\n> - ${QUERY_STRING}` },
+    { name: 'a line with trailing whitespace', input: `${QUERY_STRING}   ` },
+  ])('keeps a query string intact inside $name', ({ input }) => {
+    const tree = mdxish(input);
+
+    const text = collectNodes<Text>(tree, 'text')
+      .map(node => node.value)
+      .join('');
+    expect(text).toContain(QUERY_STRING);
+  });
+
+  it('leaves an escaped ampersand as a single literal ampersand', () => {
+    const tree = mdxish('api-base-url?partner_code=xxx\\&partner_key=xxx');
+
+    const paragraph = tree.children[0] as Element;
+    expect((paragraph.children[0] as Text).value).toBe(QUERY_STRING);
+  });
+
+  it('matches the RMDX engine, which never decoded these names', () => {
+    const rmdxTree = hast(QUERY_STRING);
+
+    const paragraph = rmdxTree.children[0] as Element;
+    expect((paragraph.children[0] as Text).value).toBe(QUERY_STRING);
   });
 
   it('keeps a query string intact through a serialization round trip', () => {

--- a/lib/micromark/loose-html-entities/index.ts
+++ b/lib/micromark/loose-html-entities/index.ts
@@ -1,9 +1,10 @@
 /**
  * Micromark extension for HTML entities without semicolons.
  *
- * Handles named entities (e.g. `&nbsp`, `&amp`, `&copy`), decimal numeric
- * references (e.g. `&#160`, `&#169`), and hex numeric references (e.g. `&#xa0`,
- * `&#xA0`). Entities that already include the semicolon are left for the
- * standard parser to handle.
+ * Handles the named entities the HTML spec lets authors write without a
+ * semicolon (e.g. `&nbsp`, `&amp`, `&copy`), decimal numeric references (e.g.
+ * `&#160`, `&#169`), and hex numeric references (e.g. `&#xa0`, `&#xA0`).
+ * Entities that already include the semicolon are left for the standard parser
+ * to handle.
  */
 export { looseHtmlEntity, looseHtmlEntityFromMarkdown } from './syntax';

--- a/lib/micromark/loose-html-entities/syntax.ts
+++ b/lib/micromark/loose-html-entities/syntax.ts
@@ -2,7 +2,7 @@
 import type { CompileContext, Extension as FromMarkdownExtension, Handle } from 'mdast-util-from-markdown';
 import type { Code, Construct, Effects, Extension, State, TokenizeContext } from 'micromark-util-types';
 
-import { decodeHTMLStrict } from 'entities';
+import { decodeHTML } from 'entities';
 import { asciiAlphanumeric, asciiDigit, asciiHexDigit } from 'micromark-util-character';
 import { codes } from 'micromark-util-symbol';
 
@@ -18,13 +18,6 @@ const looseHtmlEntityConstruct: Construct = {
   name: 'looseHtmlEntity',
   tokenize: tokenizeLooseHtmlEntity,
 };
-
-function resolveEntity(name: string): string | undefined {
-  const input = `&${name};`;
-  const decoded = decodeHTMLStrict(input);
-
-  return decoded !== input ? decoded : undefined;
-}
 
 function tokenizeLooseHtmlEntity(this: TokenizeContext, effects: Effects, ok: State, nok: State): State {
   let length = 0;
@@ -101,29 +94,10 @@ function tokenizeLooseHtmlEntity(this: TokenizeContext, effects: Effects, ok: St
 
 function exitLooseHtmlEntity(this: CompileContext, token: Parameters<Handle>[0]): void {
   const raw = this.sliceSerialize(token);
-  const entityChars = raw.slice(1);
 
-  if (entityChars.startsWith('#')) {
-    const decoded = resolveEntity(entityChars);
-    if (decoded) {
-      this.enter({ type: 'text', value: decoded }, token);
-      this.exit(token);
-      return;
-    }
-  } else {
-    for (let len = entityChars.length; len >= 2; len -= 1) {
-      const candidate = entityChars.slice(0, len);
-      const decoded = resolveEntity(candidate);
-      if (decoded) {
-        const remainder = entityChars.slice(len);
-        this.enter({ type: 'text', value: decoded + remainder }, token);
-        this.exit(token);
-        return;
-      }
-    }
-  }
-
-  this.enter({ type: 'text', value: raw }, token);
+  // `decodeHTML` follows the HTML spec's legacy rules, where only a small
+  // whitelist of names may omit the semicolon, so `&partner_key` stays intact.
+  this.enter({ type: 'text', value: decodeHTML(raw) }, token);
   this.exit(token);
 }
 


### PR DESCRIPTION
| 🎫 Resolve [CX-3770](https://linear.app/readme-io/issue/CX-3770/rendered-pages-decode-entities-without-a-terminating-andpart) |
| :-----------------: |

## 🎯 What does this PR do?

- The `looseHtmlEntity` tokenizer greedily matched `&…` against the **full** HTML5 entity table, so `&partner_key` decoded to `∂ner_key` (`&part;` = `∂`, remainder `ner`). I don't think we actually want / need to match the full list as they (~2k of them) overlap with a lot of legitimate content sequences. 
- So I think we should tone it down. It now uses `decodeHTML`, which applies the spec's legacy rules — only the ~106 names authors are actually allowed to write without a `;`. This would still fully resolve #1359 
- ⚠️ Trade-off: `&hellip`, `&mdash` and `&ndash` no longer decode without a semicolon, since they are not on that list. However this actually restores parity with legacy RDMD, which leaves all three raw, and I doubt that's the user expected behaviour anyway.

## 🧪 QA tips

Paste any of these into an MDXish page. **Before:** mangled. **Now:** left exactly as typed.

```
api-base-url?partner_code=xxx&partner_key=xxx   → was: ...xxx∂ner_key=xxx
?a=1&api_key=2                                  → was: ?a=1≈i_key=2
?a=1&order=desc                                 → was: ?a=1ℴ=desc
?a=1&and=2                                      → was: ?a=1∧=2
?a=1&image=2                                    → was: ?a=1ℑ=2
?a=1&startDate=2                                → was: ?a=1☆tDate=2
```

Also worth checking the same string inside a table cell (the reported case), a callout, and `<Tabs>`.

Still works, unchanged:

```
Hello&nbspWorld   → Hello World
Tom&ampJerry      → Tom&Jerry
&copy 2025        → © 2025
1 &lt 2           → 1 < 2
Hello&#160World   → Hello World
Hello&#xa0World   → Hello World
&sectionId        → §ionId      (sect is a legacy name — spec-correct)
&part;            → ∂           (terminated, so still decodes)
```

**Before vs After:**

https://github.com/user-attachments/assets/765747a6-92b6-4d12-b333-3320f5364692

