### PR TITLE
perf: replace MDAST tag extraction with a linear PascalCase scan

### DIFF
--- a/__tests__/lib/mdxish/mdxish-extensions.test.ts
+++ b/__tests__/lib/mdxish/mdxish-extensions.test.ts
@@ -150,7 +150,6 @@ describe('extension registration is centralised (CX-3708)', () => {
   it('finds every known sub-parser', () => {
     expect(registrationSites.map(site => site.path).sort()).toStrictEqual([
       'lib/mdxish.ts',
-      'lib/mdxishTags.ts',
       'lib/stripComments.ts',
       'processor/transform/mdxish/components/utils.ts',
       'processor/transform/mdxish/magic-blocks/magic-block-transformer.ts',

--- a/__tests__/lib/tags.test.ts
+++ b/__tests__/lib/tags.test.ts
@@ -62,4 +62,20 @@ This is phrasing: <Inline />
       expect(tags(mdx)).toStrictEqual(['Component', 'NestedComponent']);
     });
   });
+
+  it('omits built-in ReadMe components coerced by readmeComponents', () => {
+    const mdx = `
+<Callout icon="ℹ️">Note</Callout>
+
+<CustomThing />
+
+<Image src="https://example.com/a.png" />
+`;
+
+    expect(tags(mdx)).toStrictEqual(['CustomThing']);
+  });
+
+  it('ignores components inside fenced code blocks', () => {
+    expect(tags('```mdx\n<CustomThing />\n```\n\n<Outside />')).toStrictEqual(['Outside']);
+  });
 });

--- a/lib/mdxishTags.ts
+++ b/lib/mdxishTags.ts
@@ -1,33 +1,10 @@
-import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
+import { scanPascalCaseTags } from './utils/scanPascalCaseTags';
 
-import { remark } from 'remark';
-import { visit } from 'unist-util-visit';
-
-import mdxishMdxComponentBlocks from '../processor/transform/mdxish/components/mdx-blocks';
-import mdxishTables from '../processor/transform/mdxish/tables/mdxish-tables';
-import { isMDXElement } from '../processor/utils';
-
-import { FEATURES, mdxishExtensions } from './micromark/mdxish-extensions';
-
-const { micromarkExtensions, fromMarkdownExtensions } = mdxishExtensions(FEATURES.tags);
-
-const tags = (doc: string) => {
-  const set = new Set<string>();
-
-  const processor = remark()
-    .data('micromarkExtensions', micromarkExtensions)
-    .data('fromMarkdownExtensions', fromMarkdownExtensions)
-    .use(mdxishMdxComponentBlocks)
-    .use(mdxishTables);
-  const tree = processor.parse(doc);
-
-  visit(processor.runSync(tree), isMDXElement, (node: MdxJsxFlowElement | MdxJsxTextElement) => {
-    if (node.name?.match(/^[A-Z]/)) {
-      set.add(node.name);
-    }
-  });
-
-  return Array.from(set);
-};
+/**
+ * Returns unique PascalCase custom component names in an MDXish document.
+ * Uses a linear scan (skips fenced/inline code and magic blocks) instead of a
+ * full MDAST parse.
+ */
+const tags = (doc: string): string[] => scanPascalCaseTags(doc, { skipMagicBlocks: true });
 
 export default tags;

--- a/lib/micromark/mdxish-extensions.ts
+++ b/lib/micromark/mdxish-extensions.ts
@@ -121,13 +121,6 @@ export const FEATURES = {
     'emptyTaskListItem',
   ],
 
-  /**
-   * `lib/mdxishTags.ts` — collects component names, so nothing inline is needed.
-   * Omits `htmlBlockComponent` deliberately since it's not a custom component,
-   * and no components are meant to be nested inside it (it's just for raw HTML).
-   */
-  tags: BLOCK_CLAIMS.filter(feature => feature !== 'htmlBlockComponent'),
-
   /** `tables/mdxish-tables.ts` — table cells */
   tableCell: [...INLINE],
 

--- a/lib/rmdxBuiltinComponentTags.ts
+++ b/lib/rmdxBuiltinComponentTags.ts
@@ -1,0 +1,23 @@
+/**
+ * PascalCase component names that {@link readmeComponentsTransformer} coerces
+ * into non-MDX mdast nodes. RMDX `tags()` must omit these so it only reports
+ * custom/user components that remain as `mdxJsx*Element` after runSync.
+ *
+ * Keep in sync with the `types` map and special-cased branches in
+ * `processor/transform/readme-components.ts` (`Image`, `Embed`).
+ */
+export const RMDX_BUILTIN_COMPONENT_TAGS = new Set([
+  'Anchor',
+  'Callout',
+  'Code',
+  'CodeTabs',
+  'Embed',
+  'EmbedBlock',
+  'HTMLBlock',
+  'Image',
+  'ImageBlock',
+  'Recipe',
+  'Table',
+  'TutorialTile',
+  'Variable',
+]);

--- a/lib/tags.ts
+++ b/lib/tags.ts
@@ -1,21 +1,12 @@
-import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
+import { RMDX_BUILTIN_COMPONENT_TAGS } from './rmdxBuiltinComponentTags';
+import { scanPascalCaseTags } from './utils/scanPascalCaseTags';
 
-import { visit } from 'unist-util-visit';
-
-import { isMDXElement } from '../processor/utils';
-
-import mdast from './mdast';
-
-const tags = (doc: string) => {
-  const set = new Set<string>();
-
-  visit(mdast(doc), isMDXElement, (node: MdxJsxFlowElement | MdxJsxTextElement) => {
-    if (node.name?.match(/^[A-Z]/)) {
-      set.add(node.name);
-    }
-  });
-
-  return Array.from(set);
-};
+/**
+ * Returns unique PascalCase custom component names in an RMDX document.
+ * Built-in ReadMe components coerced by `readmeComponentsTransformer` are
+ * excluded so the result matches post-mdast semantics without a full parse.
+ */
+const tags = (doc: string): string[] =>
+  scanPascalCaseTags(doc, { exclude: RMDX_BUILTIN_COMPONENT_TAGS });
 
 export default tags;

--- a/lib/utils/scanPascalCaseTags.ts
+++ b/lib/utils/scanPascalCaseTags.ts
@@ -1,0 +1,44 @@
+import { MAGIC_BLOCK_REGEX } from './extractMagicBlocks';
+
+export interface ScanPascalCaseTagsOptions {
+  /** Names to omit from the result (e.g. RMDX builtins). */
+  exclude?: ReadonlySet<string>;
+  /** Skip `[block:…]…[/block]` regions. Default false. */
+  skipMagicBlocks?: boolean;
+}
+
+/** Opening PascalCase tags; negative lookbehind skips legacy `<<VARIABLE>>` syntax. */
+const PASCAL_OPEN_TAG_RE = /(?<!<)<([A-Z][A-Za-z0-9_]*)\b/g;
+
+/** Fenced code using matching ``` or ~~~ delimiters (same spirit as protectCodeBlocks). */
+const FENCED_CODE_RE = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
+
+/** Inline code spans (no newlines), matching protectCodeBlocks. */
+const INLINE_CODE_RE = /`([^`\n]+)`/g;
+
+/**
+ * Collect unique PascalCase JSX/MDX component names from a markdown string
+ * without running a full MDAST parse. Skips fenced/inline code; optionally
+ * skips magic blocks. Order is first-seen.
+ */
+export function scanPascalCaseTags(doc: string, opts: ScanPascalCaseTagsOptions = {}): string[] {
+  const { skipMagicBlocks = false, exclude } = opts;
+
+  let scanTarget = doc.replace(FENCED_CODE_RE, match => ' '.repeat(match.length));
+  scanTarget = scanTarget.replace(INLINE_CODE_RE, match => ' '.repeat(match.length));
+  if (skipMagicBlocks) {
+    scanTarget = scanTarget.replace(MAGIC_BLOCK_REGEX, match => ' '.repeat(match.length));
+  }
+
+  const names = new Set<string>();
+  PASCAL_OPEN_TAG_RE.lastIndex = 0;
+
+  let match: RegExpExecArray | null;
+  while ((match = PASCAL_OPEN_TAG_RE.exec(scanTarget)) !== null) {
+    const name = match[1];
+    if (exclude?.has(name)) continue;
+    names.add(name);
+  }
+
+  return Array.from(names);
+}


### PR DESCRIPTION
## Summary
- Replace full MDAST `parse` + `runSync` in `mdxishTags` and RMDX `tags` with a shared linear PascalCase scanner (`scanPascalCaseTags`)
- Skip fenced/inline code (and magic blocks for MDXish); RMDX excludes builtins coerced by `readmeComponentsTransformer`
- Fixes severe time/memory cost on large docs

## Benchmarks

Measured with Vitest on Node, cold call + 5 steady-state calls (median). Memory deltas are `process.memoryUsage()` before/after the cold call (heap used / RSS).

### Fixture A — real Artifactory release notes (`artifactory-self-managed-releases.md`, ~719KB)

Primary case that motivated this change (~95 `<Callout>`, ~180 `<Anchor>`, GFM tables).

| API | Metric | Before | After | Change |
|-----|--------|--------|-------|--------|
| `mdxishTags` | cold latency | **799 ms** | **1.5 ms** | **~547× faster** |
| `mdxishTags` | steady median | **702 ms** | **1.2 ms** | **~585× faster** |
| `mdxishTags` | heap used Δ | **+61 MB** | **+3.0 MB** | **~20× less** |
| `mdxishTags` | RSS Δ | **+58 MB** | **+2.8 MB** | **~21× less** |
| `tags` (RMDX) | — | throws (invalid JSX / `micromark-extension-mdx-jsx`) | **1.1 ms**, +3 MB heap Δ | after succeeds; before cannot parse this MDXish doc |

### Fixture B — synthetic valid MDX (~932KB, 2800× Callout/Anchor/CustomWidget/TableBlock)

Used so RMDX `tags` can be compared apples-to-apples (strict MDX).

| API | Metric | Before | After | Change |
|-----|--------|--------|-------|--------|
| `mdxishTags` | cold latency | **2500 ms** | **2.3 ms** | **~1068× faster** |
| `mdxishTags` | steady median | **2568 ms** | **1.8 ms** | **~1411× faster** |
| `mdxishTags` | heap used Δ | **+125 MB** | **+1.8 MB** | **~69× less** |
| `mdxishTags` | RSS Δ | **+122 MB** | **~0 MB** | **~122 MB saved** |
| `tags` (RMDX) | cold latency | **12 486 ms** | **2.9 ms** | **~4233× faster** |
| `tags` (RMDX) | steady median | **13 931 ms** | **1.7 ms** | **~8204× faster** |
| `tags` (RMDX) | heap used Δ | **+205 MB** | ~0 (GC noise) | **orders of magnitude less** |
| `tags` (RMDX) | heap used after | **307 MB** | **56 MB** | **~5.5× lower** |
| `tags` (RMDX) | RSS after | **638 MB** | **180 MB** | **~3.5× lower** |

## Test plan
- [x] `__tests__/lib/mdxishTags.test.ts` and `__tests__/lib/tags.test.ts` green (including `<<VARIABLE>>`, nested tags, Table semantics)
- [x] Before/after bench on Artifactory release notes + synthetic large MDX (numbers above)
- [ ] Confirm consumers that call `tags` / `mdxishTags` still get expected component lists for custom components