### PR TITLE
fix: stripped bullet list indent in a jsx block 

### DIFF
--- a/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
+++ b/__tests__/lib/mdxish/mdxishAstProcessor.test.ts
@@ -252,8 +252,11 @@ describe('mdxishAstProcessor', () => {
       const md = ['<Wrapper>', '  <div>A **bold** move</div>', '</Wrapper>'].join('\n');
       const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
+      // The body keeps its indent (RM-17790), and remark reports an indented html node's
+      // position from the line start — so the span opens on the indent, as it does for
+      // indented html outside a component body.
       const div = findJsxChild(findJsxChild(tree, 'Wrapper'), 'div');
-      expect(sliceOf(div)).toBe('<div>A **bold** move</div>');
+      expect(sliceOf(div)).toBe('  <div>A **bold** move</div>');
 
       // A lowercase tag unwraps its sole paragraph, so phrasing sits directly under `div`.
       const strong = (div as Parent).children.find(child => child.type === 'strong')!;
@@ -265,7 +268,7 @@ describe('mdxishAstProcessor', () => {
       const { tree, sliceOf } = parseMdxishWithResolvedSources(md, { newEditorTypes: true });
 
       const button = findJsxChild(findJsxChild(tree, 'Wrapper'), 'button');
-      expect(sliceOf(button)).toBe('<button style={{ color: "red" }}>Click me</button>');
+      expect(sliceOf(button)).toBe('  <button style={{ color: "red" }}>Click me</button>');
     });
 
     it('resolves a component nested inside a list item of a component body', () => {

--- a/__tests__/regression/__snapshots__/equivalence.test.ts.snap
+++ b/__tests__/regression/__snapshots__/equivalence.test.ts.snap
@@ -246,6 +246,29 @@ exports[`MDX↔MDXish equivalence > htmlblock-in-table 1`] = `
 }
 `;
 
+exports[`MDX↔MDXish equivalence > indented-component-body-lists 1`] = `
+{
+  "changes": [
+    {
+      "kind": "tag",
+      "left": "details",
+      "path": "/details[0]",
+      "right": "div",
+      "severity": "structural",
+    },
+    {
+      "kind": "tag",
+      "left": "blockquote",
+      "path": "/blockquote[1]",
+      "right": "div",
+      "severity": "structural",
+    },
+  ],
+  "severity": "structural",
+  "status": "differ",
+}
+`;
+
 exports[`MDX↔MDXish equivalence > indented-content-is-not-code 1`] = `
 {
   "changes": [

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -213,6 +213,48 @@ exports[`Render engine regressions tests > htmlblock-in-table (mdxish) 1`] = `
 <div class="readme-tailwind"><div class="rdmd-table"><div class="rdmd-table-inner"><table><tbody><tr><td><strong>bold</strong> still works</td><td><div class="rdmd-html"><div style="color: red;">Hello</div></div></td></tr></tbody></table></div></div></div>"
 `;
 
+exports[`Render engine regressions tests > indented-component-body-lists (mdx) 1`] = `
+"<details class="Accordion"><summary class="Accordion-title"><i class="Accordion-toggleIcon fa fa-regular fa-chevron-right"></i><i class="Accordion-icon fa-duotone fa-solid fa-regular fa-grid-2"></i>Dashboards</summary><div class="Accordion-content"><ul>
+<li><strong>New Preference Page Dashboard</strong> provides clients with metrics and insight on preference page interactions and performance.</li>
+<li>Filters can be applied across multiple attributes such as page name, source code, browser and device.</li>
+<li>Clients can also compare performance across various metrics using the comparison functionality.</li>
+</ul></div></details>
+<blockquote class="callout callout_okay" theme="👍"><span class="callout-icon">👍</span><ul>
+<li>first</li>
+<li>second<!-- -->
+<ul>
+<li>genuinely nested</li>
+</ul>
+</li>
+<li>third</li>
+</ul></blockquote>
+<ul>
+<li>first</li>
+<li>second</li>
+</ul>"
+`;
+
+exports[`Render engine regressions tests > indented-component-body-lists (mdxish) 1`] = `
+"<div class="readme-tailwind"><details class="Accordion"><summary class="Accordion-title"><i class="Accordion-toggleIcon fa fa-regular fa-chevron-right"></i><i class="Accordion-icon fa-duotone fa-solid fa-regular fa-grid-2"></i>Dashboards</summary><div class="Accordion-content"><ul>
+<li><strong>New Preference Page Dashboard</strong> provides clients with metrics and insight on preference page interactions and performance.</li>
+<li>Filters can be applied across multiple attributes such as page name, source code, browser and device.</li>
+<li>Clients can also compare performance across various metrics using the comparison functionality.</li>
+</ul></div></details></div>
+<div class="readme-tailwind"><blockquote class="callout callout_okay" theme="👍"><span class="callout-icon">👍</span><ul>
+<li>first</li>
+<li>second
+<ul>
+<li>genuinely nested</li>
+</ul>
+</li>
+<li>third</li>
+</ul></blockquote></div>
+<ul>
+<li>first</li>
+<li>second</li>
+</ul>"
+`;
+
 exports[`Render engine regressions tests > indented-content-is-not-code (mdx) 1`] = `
 "<div class="card"><p>Block two — indented 6 spaces after a blank line, so it renders as a raw code block instead of HTML.</p></div>
 <details class="Accordion"><summary class="Accordion-title"><i class="Accordion-toggleIcon fa fa-regular fa-chevron-right"></i><i class="Accordion-icon fa-duotone fa-solid fa-info-circle"></i></summary><div class="Accordion-content"><ol start="4">

--- a/__tests__/regression/fixtures/indented-component-body-lists/README.md
+++ b/__tests__/regression/fixtures/indented-component-body-lists/README.md
@@ -9,7 +9,14 @@ editor save produces.
 - RM-17790 — bullet lists inside `<Accordion>` rendered with each item after
   the first nested a level deeper. `parseMdChildren` ran `.trim()` over the
   component body, which stripped the leading whitespace of the *first* line
-  only; a uniformly two-column body reparsed as `- first` / `  - second`, and
+  only, so a uniformly two-column body reparsed with its first item at column 0
+  and every later item still at column 2:
+
+  ```markdown
+  - first
+    - second
+  ```
+
   CommonMark reads that second line as a nested list. Two-column bodies are
   below `safeDeindent`'s four-column gate, so nothing had dedented them first.
   The `<Accordion>` body here is the customer doc from the ticket.

--- a/__tests__/regression/fixtures/indented-component-body-lists/README.md
+++ b/__tests__/regression/fixtures/indented-component-body-lists/README.md
@@ -1,0 +1,29 @@
+# `indented-component-body-lists` Fixture
+
+A bullet list inside a component body indented by two columns — the shape the
+MDXish serializer writes for every JSX child, and therefore the shape every
+editor save produces.
+
+## Source bugs
+
+- RM-17790 — bullet lists inside `<Accordion>` rendered with each item after
+  the first nested a level deeper. `parseMdChildren` ran `.trim()` over the
+  component body, which stripped the leading whitespace of the *first* line
+  only; a uniformly two-column body reparsed as `- first` / `  - second`, and
+  CommonMark reads that second line as a nested list. Two-column bodies are
+  below `safeDeindent`'s four-column gate, so nothing had dedented them first.
+  The `<Accordion>` body here is the customer doc from the ticket.
+
+## What it proves
+
+- All three items of the accordion list render as siblings in one `<ul>`, not
+  as a chain of nested lists.
+- The callout list keeps its one genuinely deeper item nested — the fix
+  preserves relative indentation rather than flattening everything.
+- The trailing unindented list renders identically to the indented ones,
+  pinning that body indentation is invisible in the output.
+
+## What flips this fixture
+
+`parseMdChildren`'s edge trimming, `safeDeindent`'s four-column gate, or any
+change to how CommonMark list continuation is measured in component bodies.

--- a/__tests__/regression/fixtures/indented-component-body-lists/body.md
+++ b/__tests__/regression/fixtures/indented-component-body-lists/body.md
@@ -1,0 +1,15 @@
+<Accordion title="Dashboards" icon="fa-regular fa-grid-2">
+  - **New Preference Page Dashboard** provides clients with metrics and insight on preference page interactions and performance.
+  - Filters can be applied across multiple attributes such as page name, source code, browser and device.
+  - Clients can also compare performance across various metrics using the comparison functionality.
+</Accordion>
+
+<Callout icon="👍" title="Two-space body">
+  - first
+  - second
+    - genuinely nested
+  - third
+</Callout>
+
+- first
+- second

--- a/__tests__/regression/fixtures/indented-component-body-lists/context.json
+++ b/__tests__/regression/fixtures/indented-component-body-lists/context.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "defaults": [],
+    "user": {}
+  },
+  "glossary": []
+}

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -295,6 +295,20 @@ ${indent}- test 3
         const [accordion] = collectNodes(tree, 'mdxJsxFlowElement') as Parent[];
         expect(accordion.children.map(child => child.type)).toStrictEqual(['paragraph', 'paragraph']);
       });
+
+      it('keeps trailing spaces on the last line of a fence left unclosed by the end tag', () => {
+        const markdown = ['<Callout title="Test">', '  ```', '  value  ', '</Callout>'].join('\n');
+        const [code] = collectNodes(parseWithPlugin(markdown), 'code') as { value: string }[];
+
+        expect(code.value).toBe('value  ');
+      });
+
+      it('keeps a hard break that is interior to an indented body', () => {
+        const markdown = ['<Callout title="Test">', '  one  ', '  two  ', '</Callout>'].join('\n');
+        const [paragraph] = collectNodes(parseWithPlugin(markdown), 'paragraph') as Parent[];
+
+        expect(paragraph.children.map(child => child.type)).toStrictEqual(['text', 'break', 'text']);
+      });
     });
 
     describe('multiple components in combination', () => {

--- a/__tests__/transformers/mdx-component-blocks.test.ts
+++ b/__tests__/transformers/mdx-component-blocks.test.ts
@@ -246,6 +246,57 @@ Second paragraph
       });
     });
 
+    describe('indented component bodies (RM-17790)', () => {
+      // The mdxish serializer writes component children at 2 columns, so this is the
+      // shape every editor save produces — a body whose lines share an indent too
+      // shallow for `safeDeindent` to strip.
+      const listNesting = (markdown: string) => {
+        const lists = collectNodes(parseWithPlugin(markdown), 'list') as Parent[];
+        return {
+          count: lists.length,
+          items: lists[0] ? lists[0].children.length : 0,
+        };
+      };
+
+      it.each([
+        ['unindented', ''],
+        ['two spaces', '  '],
+        ['three spaces', '   '],
+        ['four spaces', '    '],
+        ['a tab', '\t'],
+      ])('keeps a bullet list flat when the body is indented by %s', (_label, indent) => {
+        const markdown = `<Accordion title="Test">
+${indent}- test 1
+${indent}- test 2
+${indent}- test 3
+</Accordion>`;
+
+        expect(listNesting(markdown)).toStrictEqual({ count: 1, items: 3 });
+      });
+
+      it('still nests items indented deeper than their siblings', () => {
+        const markdown = `<Accordion title="Test">
+  - test 1
+    - nested
+  - test 2
+</Accordion>`;
+
+        expect(listNesting(markdown)).toStrictEqual({ count: 2, items: 2 });
+      });
+
+      it('keeps sibling paragraphs at the same level in an indented body', () => {
+        const markdown = `<Accordion title="Test">
+  First paragraph
+
+  Second paragraph
+</Accordion>`;
+        const tree = parseWithPlugin(markdown);
+
+        const [accordion] = collectNodes(tree, 'mdxJsxFlowElement') as Parent[];
+        expect(accordion.children.map(child => child.type)).toStrictEqual(['paragraph', 'paragraph']);
+      });
+    });
+
     describe('multiple components in combination', () => {
       it('should convert outer and nested components to mdxJsxFlowElement nodes', () => {
         const markdown = `
@@ -918,7 +969,7 @@ third\`} />`;
         expect(mdxNodes).toHaveLength(1);
         expect(mdxNodes[0]).toMatchObject({ name: 'MyComponent' });
       });
-    })
+    });
   });
 
   describe('fenced code blocks starting a continuation line', () => {
@@ -968,7 +1019,10 @@ After the callout.`;
       expect(code[0].value).toBe('{');
 
       // ...and `</Callout>` never leaks out as a stray html node.
-      const strayCloser = collectNodes(tree, n => n.type === 'html' && (n as { value?: string }).value === '</Callout>');
+      const strayCloser = collectNodes(
+        tree,
+        n => n.type === 'html' && (n as { value?: string }).value === '</Callout>',
+      );
       expect(strayCloser).toHaveLength(0);
 
       // Trailing content lands as a sibling after the callout, not inside it.
@@ -992,7 +1046,10 @@ After the callout.`;
           type: 'mdxJsxFlowElement',
           name: 'Component',
           children: [
-            { type: 'code', value: '  {' },
+            // The fence keeps its 2-column indent now that the body isn't dedented
+            // lopsidedly (RM-17790), so CommonMark strips that indent off its content —
+            // matching the identically shaped CX-3704 case above.
+            { type: 'code', value: '{' },
             { type: 'paragraph', children: [{ type: 'text', value: 'test' }] },
           ],
         },

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -73,8 +73,12 @@ function safeDeindent(text: string): string {
  * `  - b`, so every sibling after the first nests a level (RM-17790). Bodies shallower
  * than 4 columns keep their indent by design (`safeDeindent`), and CommonMark treats it
  * as insignificant, so preserving it costs nothing.
+ *
+ * Both edges drop whole blank lines only. The trailing side stops at the last content
+ * line's own newline so its trailing spaces survive, they are the content of a fenced
+ * code block left unclosed by the component's end tag.
  */
-const trimBlankEdges = (text: string): string => text.replace(/^(?:[ \t]*\n)+/, '').replace(/\s+$/, '');
+const trimBlankEdges = (text: string): string => text.replace(/^(?:[ \t]*\n)+/, '').replace(/(?:\n[ \t]*)+$/, '');
 
 /**
  * Parse component-body markdown into mdast children. Dedenting shifts columns and

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -66,6 +66,14 @@ function safeDeindent(text: string): string {
     .join('\n');
 }
 
+/**
+ * Drop the blank lines around a component body without touching the indentation of the
+ * first content line. `.trim()` would strip that one line's leading whitespace only,
+ * leaving a uniformly indented body lopsided — `  - a` / `  - b` reparses as `- a` /
+ * `  - b`, so every sibling after the first nests a level (RM-17790). Bodies shallower
+ * than 4 columns keep their indent by design (`safeDeindent`), and CommonMark treats it
+ * as insignificant, so preserving it costs nothing.
+ */
 const trimBlankEdges = (text: string): string => text.replace(/^(?:[ \t]*\n)+/, '').replace(/\s+$/, '');
 
 /**

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -29,6 +29,11 @@ const NESTED_ATTR_EXPRESSION_RE = /[\w-]+\s*=\s*\{/;
 // of a legacy `<<VARIABLE>>`.
 const NESTED_COMPONENT_TAG_RE = /(?<!<)<([A-Z][A-Za-z0-9_]*)[\s/>]/g;
 
+// Whole blank lines at a component body's edges. `\n` sits inside each group so a
+// match can only ever span complete lines, never part of a content line.
+const LEADING_BLANK_LINES_RE = /^(?:[ \t]*\n)+/;
+const TRAILING_BLANK_LINES_RE = /(?:\n[ \t]*)+$/;
+
 // Excludes tags with dedicated transformers (`Table`, `HTMLBlock`, inline
 // components), which expect their wrapper to stay raw.
 const hasNestedGenericComponentTag = (content: string): boolean =>
@@ -67,18 +72,14 @@ function safeDeindent(text: string): string {
 }
 
 /**
- * Drop the blank lines around a component body without touching the indentation of the
- * first content line. `.trim()` would strip that one line's leading whitespace only,
- * leaving a uniformly indented body lopsided — `  - a` / `  - b` reparses as `- a` /
- * `  - b`, so every sibling after the first nests a level (RM-17790). Bodies shallower
- * than 4 columns keep their indent by design (`safeDeindent`), and CommonMark treats it
- * as insignificant, so preserving it costs nothing.
- *
- * Both edges drop whole blank lines only. The trailing side stops at the last content
- * line's own newline so its trailing spaces survive, they are the content of a fenced
- * code block left unclosed by the component's end tag.
+ * Drop the blank lines at a component body's edges, keeping the first content line's
+ * indent: `.trim()` stripped that line alone, so a uniformly indented body reparsed
+ * lopsided and every list item after the first nested. The trailing pattern
+ * takes the last content line's newline but leaves its spaces, which are code content
+ * when a fence runs into the end tag.
  */
-const trimBlankEdges = (text: string): string => text.replace(/^(?:[ \t]*\n)+/, '').replace(/(?:\n[ \t]*)+$/, '');
+const trimBlankEdges = (text: string): string =>
+  text.replace(LEADING_BLANK_LINES_RE, '').replace(TRAILING_BLANK_LINES_RE, '');
 
 /**
  * Parse component-body markdown into mdast children. Dedenting shifts columns and
@@ -288,7 +289,8 @@ function promoteComponentBlocks(tree: Parent, safeMode: boolean, source: string 
     // Case 2: Self-contained block (closing tag in content)
     const closingTagIndex = isPlainLowercaseHtml ? plainClosingTagIndex : contentAfterTag.lastIndexOf(closingTagStr);
     if (closingTagIndex >= 0) {
-      // Untrimmed so parseMdChildren can dedent before trimming.
+      // Left as authored: parseMdChildren needs the original columns to dedent by, and
+      // it clears the blank edges itself.
       const componentInnerContent = contentAfterTag.substring(0, closingTagIndex);
       const contentAfterClose = contentAfterTag.substring(closingTagIndex + closingTagStr.length).trim();
       let parsedChildren: MdxJsxFlowElement['children'] = [];

--- a/processor/transform/mdxish/components/mdx-blocks.ts
+++ b/processor/transform/mdxish/components/mdx-blocks.ts
@@ -66,13 +66,15 @@ function safeDeindent(text: string): string {
     .join('\n');
 }
 
+const trimBlankEdges = (text: string): string => text.replace(/^(?:[ \t]*\n)+/, '').replace(/\s+$/, '');
+
 /**
  * Parse component-body markdown into mdast children. Dedenting shifts columns and
  * stales the top-level `terminateHtmlFlowBlocks` decisions, so that one preprocessor
  * re-runs here; other column-anchored fixups (compact headings, tables) do not.
  */
 const parseMdChildren = (value: string, safeMode: boolean): RootContent[] => {
-  const reparseSource = terminateHtmlFlowBlocks(safeDeindent(value).trim());
+  const reparseSource = terminateHtmlFlowBlocks(trimBlankEdges(safeDeindent(value)));
   const parsed = getInlineMdProcessor({ safeMode }).parse(reparseSource);
   // Promote nested wrappers bottom-up so an outer wrapper sees markdown buried in a
   // child claimed whole (e.g. `<li>` in `<ol>`) before its containsMarkdownConstruct check (RM-17560).


### PR DESCRIPTION
| 🎫 Resolve RM-17790 |
| :-----------------: |

## 🎯 What does this PR do?

 Bullet lists inside `<Accordion>` (and any component) rendered with every item after the first nested a level deeper

- `parseMdChildren` ran `.trim()` over the component body before re-parsing it. `.trim()` strips *characters*, so it removed the leading whitespace of the **first** line only, a uniformly indented body reparsed as `- first` at column 0 with `- second` still at column 2, which CommonMark reads as a nested list.
- Two-column bodies sit below `safeDeindent`'s four-column gate, so nothing had dedented them first. The mdxish serializer writes every JSX child at two columns, so **every editor save produced the broken shape** — the bug window was exactly indents 1–3, and the round trip always lands on 2.
- Replaces the trim with `trimBlankEdges`, which drops whole blank lines at each edge and never touches a content line's own whitespace

## 🧪 QA tips

In the markdown playground:

- [ ] **The bug.** All three items should be siblings in one `<ul>`. Before, items 2 and 3 each nested a level deeper:

  ```md
  <Accordion title="Dashboards" icon="fa-regular fa-grid-2">
    - New Preference Page Dashboard provides clients with metrics and insight.
    - Filters can be applied across multiple attributes.
    - Clients can also compare performance across various metrics.
  </Accordion>
  ```

- [ ] **Genuine nesting still nests** — the fix preserves relative indentation rather than flattening everything:

  ```md
  <Callout icon="👍" title="Two-space body">
    - first
    - second
      - genuinely nested
    - third
  </Callout>
  ```

  → `second` owns a nested `<ul>`; `first` and `third` stay siblings.

- [ ] **Body indentation is invisible in the output** — these should render identically to each other, and to the unindented
version:

  ```md
  <Accordion title="Tab">
      - one
      - two
  </Accordion>

  <Accordion title="Four">
      - one
      - two
  </Accordion>
  ```

## 📸 Screenshot or Loom

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/150cf09e-5372-4661-acf2-fc8b1f776fb7



</td>
<td>

https://github.com/user-attachments/assets/304851c1-9299-4e4b-a1d8-52ac822b2887

62-8221a0cdc7bf

</td>
</tr>
</table>


<!-- all PRs should have a Loom or screenshot! -->
