### PR TITLE
feat: update dark mode mixin

### DIFF
--- a/__tests__/Glossary.test.tsx
+++ b/__tests__/Glossary.test.tsx
@@ -38,3 +38,22 @@ test('should output the term if the definition does not exist', () => {
   expect(container.querySelector('.GlossaryItem-trigger')).not.toBeInTheDocument();
   expect(container.querySelector('span')).toHaveTextContent(term);
 });
+
+test('appends the tooltip inside .rm-ReadMe so dark-mode descendant selectors match', () => {
+  const term = 'acme';
+  const definition = 'This is a definition';
+  const { container } = render(
+    <div className="rm-ReadMe" data-color-mode="dark">
+      <Glossary terms={[{ term, definition }]}>acme</Glossary>
+    </div>,
+  );
+
+  const trigger = container.querySelector('.GlossaryItem-trigger');
+  if (trigger) {
+    fireEvent.mouseEnter(trigger);
+  }
+
+  const tooltip = document.querySelector('.GlossaryItem-tooltip-content');
+  expect(tooltip).toBeInTheDocument();
+  expect(tooltip?.closest('.rm-ReadMe')).toHaveAttribute('data-color-mode', 'dark');
+});

--- a/components/Callout/style.scss
+++ b/components/Callout/style.scss
@@ -1,4 +1,4 @@
-@import '../../styles/mixins/dark-mode.scss';
+@import '../../styles/mixins/when-color-mode-dark.scss';
 
 @mixin callout($l-offset: 1.25rem) {
   --Callout-bg: var(--background);
@@ -21,7 +21,7 @@
     --Callout-border: var(--border, #{lighten(#6a737d, 12.5%)});
     --Callout-title: var(--title, var(--text, var(--color-text-default)));
 
-    @include dark-mode {
+    @include when-color-mode-dark('.rm-ReadMe') {
       --Callout-bg: rgba(var(--gray100-rgb), 0.05);
     }
   }
@@ -31,7 +31,7 @@
     --Callout-border: var(--border, rgba(var(--blue-rgb), 1));
     --Callout-title: var(--title, var(--blue20));
 
-    @include dark-mode {
+    @include when-color-mode-dark('.rm-ReadMe') {
       --Callout-bg: var(--background, rgba(var(--blue-rgb), 0.075));
       --Callout-title: var(--title, var(--blue90));
     }
@@ -43,7 +43,7 @@
     --Callout-border: var(--border, rgba(var(--yellow-rgb), 1));
     --Callout-title: var(--title, var(--yellow10));
 
-    @include dark-mode {
+    @include when-color-mode-dark('.rm-ReadMe') {
       --Callout-bg: var(--background, rgba(var(--yellow-rgb), 0.075));
       --Callout-title: var(--title, var(--yellow70));
     }
@@ -56,7 +56,7 @@
     --Callout-border: var(--border, rgba(var(--green-rgb), 1));
     --Callout-title: var(--title, var(--green10));
 
-    @include dark-mode {
+    @include when-color-mode-dark('.rm-ReadMe') {
       --Callout-bg: var(--background, rgba(var(--green-rgb), 0.075));
       --Callout-title: var(--title, var(--green80));
     }
@@ -68,7 +68,7 @@
     --Callout-border: var(--border, rgba(var(--red-rgb), 1));
     --Callout-title: var(--title, var(--red20));
 
-    @include dark-mode {
+    @include when-color-mode-dark('.rm-ReadMe') {
       --Callout-bg: var(--background, rgba(var(--red-rgb), 0.05));
       --Callout-title: var(--title, var(--red90));
     }

--- a/components/Cards/style.scss
+++ b/components/Cards/style.scss
@@ -1,4 +1,4 @@
-@import '../../styles/mixins/dark-mode.scss';
+@import '../../styles/mixins/when-color-mode-dark.scss';
 
 $iphone-plus: 414px;
 
@@ -46,7 +46,7 @@ $iphone-plus: 414px;
     --Card-layout: column;
     --Card-padding: 1.5em;
 
-    @include dark-mode {
+    @include when-color-mode-dark('.rm-ReadMe') {
       --Card-bg-color: rgba(var(--color-bg-page-inverse-rgb), 0.05);
       --Card-bg-color-hover: rgba(var(--color-bg-page-inverse-rgb), 0.1);
     }

--- a/components/Glossary/index.tsx
+++ b/components/Glossary/index.tsx
@@ -10,6 +10,10 @@ interface Props extends React.PropsWithChildren {
   terms: GlossaryTerm[];
 }
 
+/** Tippy portals to document.body by default, which would break the
+ *  `.rm-ReadMe[data-color-mode] …` descendant selectors in style.scss. */
+const appendToReadMeRoot = (ref: Element) => ref.closest('.rm-ReadMe') ?? document.body;
+
 const Glossary = ({ children, term: termProp, terms }: Props) => {
   const term = (Array.isArray(children) ? children[0] : children) || termProp;
 
@@ -21,6 +25,7 @@ const Glossary = ({ children, term: termProp, terms }: Props) => {
 
   return (
     <Tooltip
+      appendTo={appendToReadMeRoot}
       content={
         <div className="GlossaryItem-tooltip-content">
           <strong className="GlossaryItem-term">{foundTerm.term}</strong> - {foundTerm.definition}

--- a/components/Glossary/style.scss
+++ b/components/Glossary/style.scss
@@ -32,7 +32,8 @@
     }
 
     @media (prefers-color-scheme: dark) {
-      .rm-ReadMe[data-color-mode='auto'] & {
+      .rm-ReadMe[data-color-mode='auto'] &,
+      .rm-ReadMe[data-color-mode='system'] & {
         --Glossary-bg: var(--Tooltip-bg, var(--gray0));
         --Glossary-color: var(--color-text-default, var(--white));
         --Glossary-shadow: var(

--- a/components/Glossary/style.scss
+++ b/components/Glossary/style.scss
@@ -18,8 +18,9 @@
       0 1px 3px rgba(0, 0, 0, 0.025)
     );
 
-    /* what the dark-mode mixin does in the readme project */
-    [data-color-mode='dark'] & {
+    /* Anchored to '.rm-ReadMe' itself, not any ancestor — see the warning on
+       the `dark-mode` mixin in styles/mixins/dark-mode.scss. */
+    .rm-ReadMe[data-color-mode='dark'] & {
       --Glossary-bg: var(--gray15);
       --Glossary-color: var(--color-text-default, var(--white));
       --Glossary-shadow: var(
@@ -31,7 +32,7 @@
     }
 
     @media (prefers-color-scheme: dark) {
-      [data-color-mode='auto'] & {
+      .rm-ReadMe[data-color-mode='auto'] & {
         --Glossary-bg: var(--Tooltip-bg, var(--gray0));
         --Glossary-color: var(--color-text-default, var(--white));
         --Glossary-shadow: var(

--- a/components/Image/style.scss
+++ b/components/Image/style.scss
@@ -1,7 +1,7 @@
 /* stylelint-disable selector-max-compound-selectors */
 /* stylelint-disable no-descending-specificity */
 /* stylelint-disable font-family-no-missing-generic-family-keyword */
-@import '../../styles/mixins/dark-mode.scss';
+@import '../../styles/mixins/when-color-mode-dark.scss';
 %img-align {
   &-right {
     float: right;
@@ -147,7 +147,7 @@
     padding: var(--size-12);
     max-width: 100%;
 
-    @include dark-mode($global: true) {
+    @include when-color-mode-dark('.rm-ReadMe', $global: true) {
       background: rgba(var(--color-bg-page-inverse-rgb), 0.1);
     }
 

--- a/example/Header.tsx
+++ b/example/Header.tsx
@@ -5,11 +5,11 @@ interface HeaderProps {
   theme: 'dark' | 'light' | 'system';
 }
 
-const THEME_OPTIONS: { icon: string; label: string; value: 'dark' | 'light' | 'system' }[] = [
+const THEME_OPTIONS = [
   { icon: 'fa-regular fa-sun', label: 'Light', value: 'light' },
   { icon: 'fa-regular fa-moon', label: 'Dark', value: 'dark' },
   { icon: 'fa-regular fa-desktop', label: 'System', value: 'system' },
-];
+] as const;
 
 function Header({ theme, setTheme }: HeaderProps) {
   return (

--- a/example/Header.tsx
+++ b/example/Header.tsx
@@ -5,6 +5,12 @@ interface HeaderProps {
   theme: 'dark' | 'light' | 'system';
 }
 
+const THEME_OPTIONS: { icon: string; label: string; value: 'dark' | 'light' | 'system' }[] = [
+  { icon: 'fa-regular fa-sun', label: 'Light', value: 'light' },
+  { icon: 'fa-regular fa-moon', label: 'Dark', value: 'dark' },
+  { icon: 'fa-regular fa-desktop', label: 'System', value: 'system' },
+];
+
 function Header({ theme, setTheme }: HeaderProps) {
   return (
     <header className="rdmd-demo--header">
@@ -18,11 +24,21 @@ function Header({ theme, setTheme }: HeaderProps) {
         <a className={'Header-button'} href="https://rdmd.readme.io" id="docsLink" rel="noreferrer" target="_blank">
           Docs <i aria-label="Opens in a new tab" className="fa-regular fa-arrow-up-right" />
         </a>
-        <select className={'Header-select'} onChange={(e) => setTheme(e.target.value as 'dark' | 'light' | 'system')} value={theme}>
-          <option value="light">Light</option>
-          <option value="dark">Dark</option>
-          <option value="system">System</option>
-        </select>
+        <div aria-label="Theme" className="Header-theme-group" role="group">
+          {THEME_OPTIONS.map(option => (
+            <button
+              key={option.value}
+              aria-label={option.label}
+              aria-pressed={theme === option.value}
+              className={`Header-theme-button${theme === option.value ? ' Header-theme-button_active' : ''}`}
+              onClick={() => setTheme(option.value)}
+              title={option.label}
+              type="button"
+            >
+              <i aria-hidden="true" className={option.icon} />
+            </button>
+          ))}
+        </div>
       </div>
     </header>
   );

--- a/example/Root.tsx
+++ b/example/Root.tsx
@@ -11,7 +11,7 @@ const Root = () => {
   const ci = searchParams.has('ci');
 
   return (
-    <div data-color-mode={theme}>
+    <div className="rm-ReadMe" data-color-mode={theme}>
       {!ci && <Header setTheme={setTheme} theme={theme} />}
       <div className="rdmd-demo--container">
         <div className="rdmd-demo--content">

--- a/example/styles/header.scss
+++ b/example/styles/header.scss
@@ -1,6 +1,5 @@
 .Header {
-  &-button,
-  &-select {
+  &-button {
     background: transparent;
     border: 1px solid transparent;
     border-radius: var(--border-radius);
@@ -24,7 +23,39 @@
     }
   }
 
-  &-select {
-    appearance: none;
+  &-theme-group {
+    background-color: var(--color-bg-page-muted);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--border-radius);
+    display: flex;
+    gap: 2px;
+    padding: 2px;
+  }
+
+  &-theme-button {
+    align-items: center;
+    background-color: transparent;
+    border: none;
+    border-radius: var(--border-radius);
+    color: var(--color-text-minimum);
+    cursor: pointer;
+    display: flex;
+    font-size: 13px;
+    height: 24px;
+    justify-content: center;
+    line-height: 1;
+    text-align: center;
+    width: 24px;
+
+    &:hover {
+      color: var(--color-text-default);
+    }
+
+    &:active,
+    &:focus,
+    &_active {
+      background: var(--color-bg-page);
+      color: var(--color-text-default);
+    }
   }
 }

--- a/styles/mixins/dark-mode.scss
+++ b/styles/mixins/dark-mode.scss
@@ -7,6 +7,19 @@
       April 2025
 */
 
+/**
+ * When nested inside a selector, this matches ANY ancestor with the attribute
+ * — not the nearest one. That's wrong once a consuming app can have two
+ * independent `data-color-mode` scopes in the same tree (e.g. readme's
+ * SuperHub admin shell sets it on `<html>` for the admin's own UI theme,
+ * while `.rm-ReadMe` independently carries the hub's own): a component
+ * nested in a light `.rm-ReadMe` can still match a dark `<html>` ancestor
+ * and render dark. None of this package's components carry `data-color-mode`
+ * on their own root, so use `when-color-mode-dark($root)` instead, passing
+ * the selector for whichever wrapper actually carries it in the consuming
+ * app — it anchors to that element specifically, so the nearest declared
+ * value always wins.
+ */
 @mixin dark-mode($global: false) {
   $root: &;
 

--- a/styles/mixins/when-color-mode-dark.scss
+++ b/styles/mixins/when-color-mode-dark.scss
@@ -1,0 +1,48 @@
+/**
+ * Dark styles keyed off `$root`'s own `data-color-mode`, not any ancestor.
+ * Unlike `dark-mode` (which matches ANY ancestor carrying the attribute —
+ * see the warning on that mixin), this only fires when `$root` itself
+ * declares the dark/system mode. None of this package's components carry
+ * `data-color-mode` on their own root, so callers must pass the selector
+ * for whichever wrapper actually carries it in their consuming app — there
+ * is no default.
+ *
+ * IMPORTANT: this package ships one precompiled `dist/main.css` — there is
+ * no build step where a consumer can supply their own value for `$root`.
+ * Whatever gets passed at each `@include` call site below is permanent for
+ * every installer of this package. Call sites currently hardcode
+ * `'.rm-ReadMe'`, readme's hub color-mode wrapper, because readme is this
+ * package's only real consumer today. If that ever changes, this becomes
+ * silently wrong (not an error — dark mode just never activates) for any
+ * consumer without that exact class in their DOM, and `$root` should be
+ * dropped in favor of each component resolving its own nearest
+ * `[data-color-mode]` ancestor at mount via `Element.closest()` and
+ * stamping it onto its own root, so the CSS can self-anchor with no
+ * hardcoded selector at all.
+ *
+ * $global: wrap the root-anchor selector in :global(), for use when this
+ * file is imported into a CSS-module context (mirrors `dark-mode`'s param).
+ */
+@mixin when-color-mode-dark($root, $global: false) {
+  @if $global {
+    :global(#{$root}[data-color-mode='dark']) & {
+      @content;
+    }
+
+    :global(#{$root}[data-color-mode='system']) & {
+      @media (prefers-color-scheme: dark) {
+        @content;
+      }
+    }
+  } @else {
+    #{$root}[data-color-mode='dark'] & {
+      @content;
+    }
+
+    #{$root}[data-color-mode='system'] & {
+      @media (prefers-color-scheme: dark) {
+        @content;
+      }
+    }
+  }
+}


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

Fixes dark-mode CSS in `Card`, `Callout`, `Glossary`, and `Image` bleeding in from the wrong place when they're rendered inside an app that has more than one independent `data-color-mode` scope on the page.

**The core issue:** our `dark-mode` mixin, when used inside a nested selector, compiles to an ancestor-descendant selector — `[data-color-mode='dark'] & { }`. That matches when *any* ancestor, at *any* depth, carries `data-color-mode='dark']` — not the nearest one. That's fine as long as a page only ever has one `data-color-mode` declaration. It breaks once a consumer has two independent scopes that can disagree.

That's exactly what happens in readme's SuperHub: the admin shell sets its own theme preference on `<html data-color-mode>`, while the hub content the admin is previewing carries its *own*, independent preference on `.rm-ReadMe[data-color-mode]`. Because our selector doesn't care about proximity, a `Card`/`Callout`/`Glossary`/`Image` rendered inside a *light* `.rm-ReadMe` still matched the *dark* `<html>` ancestor and rendered dark — an admin browsing in dark mode would see dark-mode cards and callouts even while previewing a project whose hub is set to light.

**The fix:** a new mixin, `when-color-mode-dark($root)`, that anchors to a specific wrapper's own attribute (`#{$root}[data-color-mode='dark'] & { }`) instead of matching any ancestor — so only that one wrapper's declared mode matters, no matter what any other ancestor says. `Card`, `Callout` (all 5 variants), and `Image` now use it via their existing `@include`; `Glossary`, which hand-inlined the same buggy selector, was fixed the same way directly. All four are anchored to `'.rm-ReadMe'`, readme's hub color-mode root — see the comment on `when-color-mode-dark` for why that's currently hardcoded (readme is this package's only real consumer today) and what to do instead if that ever stops being true. Added a warning comment to the existing `dark-mode` mixin so this doesn't get reached for by default the next time someone adds dark-mode CSS to a component that needs to be scoped this way.

Also includes two small demo-app changes:
- `example/Root.tsx`'s theme-toggle wrapper now carries the `.rm-ReadMe` class, so the local demo (`npm start`) actually exercises the anchored selector above — without it, toggling the demo's theme selector would have silently stopped affecting these four components.
- `example/Header.tsx` / `example/styles/header.scss`: replaced the theme `<select>` dropdown with a segmented icon-button group (sun/moon/desktop), unrelated to the bug fix but bundled in since it touches the same theme-toggle UI.

## 🧪 QA tips

- [ ] `npm start`, open the demo, toggle the theme selector between Light / Dark / System — confirm `Card`, `Callout` (all variants), the image frame background, and the Glossary tooltip all follow the toggle correctly in each state.
- [ ] In readme: set the admin's own theme to Dark, open a project whose hub is set to Light, and preview a doc with a Card/Callout — confirm they render light, not dark. (This is the scenario that was broken before this fix.)
- [ ] Confirm nothing regressed for the case where `.rm-ReadMe` and `<html>` agree (both light or both dark) — should look identical to before.

## 📸 Screenshot or Loom

<!-- add a before/after of the demo's theme toggle, and/or the readme admin-dark/hub-light repro -->
