### PR TITLE
fix(mdxish): repair mistaken table closers

### DIFF
--- a/__tests__/regression/__snapshots__/equivalence.test.ts.snap
+++ b/__tests__/regression/__snapshots__/equivalence.test.ts.snap
@@ -645,6 +645,29 @@ exports[`MDX↔MDXish equivalence > magic-blocks-table 1`] = `
 }
 `;
 
+exports[`MDX↔MDXish equivalence > mistaken-table-closer 1`] = `
+{
+  "changes": [
+    {
+      "kind": "extra",
+      "left": null,
+      "path": "/div[0]",
+      "right": "<div class="rdmd-table">…(1 children)…</div>",
+      "severity": "structural",
+    },
+    {
+      "kind": "extra",
+      "left": null,
+      "path": "/blockquote[1]",
+      "right": "<blockquote>…(2 children)…</blockquote>",
+      "severity": "structural",
+    },
+  ],
+  "severity": "structural",
+  "status": "differ",
+}
+`;
+
 exports[`MDX↔MDXish equivalence > rich 1`] = `
 {
   "changes": [

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -572,6 +572,19 @@ exports[`Render engine regressions tests > magic-blocks-table (mdxish) 1`] = `
 <div class="rdmd-table"><div class="rdmd-table-inner"><table><thead><tr><th style="text-align:left">Field</th><th style="text-align:left">Type</th></tr></thead><tbody><tr><td style="text-align:left">id</td><td style="text-align:left"><p>Number</p></td></tr></tbody></table></div></div>"
 `;
 
+exports[`Render engine regressions tests > mistaken-table-closer (mdx) 1`] = `""`;
+
+exports[`Render engine regressions tests > mistaken-table-closer (mdxish) 1`] = `
+"<div class="rdmd-table"><div class="rdmd-table-inner"><table><tr><th>Option</th><th>Description</th></tr><tr><td>foo</td><td>bar</td></tr></table></div></div>
+<blockquote>
+<p><strong>Notes:</strong></p>
+<ul>
+<li>This behavior is not required for any Enhanced TLS certificates.</li>
+<li>There are no options for this behavior.</li>
+</ul>
+</blockquote>"
+`;
+
 exports[`Render engine regressions tests > rich (mdx) 1`] = `
 "<h1 class="heading heading-1 header-scroll"><div class="heading-anchor anchor waypoint" id="rich-fixture"></div><div class="heading-text">Rich Fixture</div><a aria-label="Skip link to Rich Fixture" class="heading-anchor-icon fa fa-regular fa-anchor" href="#rich-fixture"></a></h1>
 <p>Authentication uses your API key. Use <code class="rdmd-code lang-undefined theme-undefined">Bearer &lt;&lt;apiKey&gt;&gt;</code> for requests originating from the <code class="rdmd-code lang-undefined theme-undefined">&lt;&lt;region&gt;&gt;</code> region.</p>

--- a/__tests__/regression/fixtures/mistaken-table-closer/README.md
+++ b/__tests__/regression/fixtures/mistaken-table-closer/README.md
@@ -1,0 +1,23 @@
+# Mistaken table closer (`<table>` for `</table>`)
+
+Akamai behavior docs typo the table closer as a second opening
+`<table>` instead of `</table>`. Without repair, the HTML flow block
+swallows the following Notes callout as raw text.
+
+## Source bug
+
+- CX-3850 — malformed table close tag breaks Notes callouts across
+  Akamai behavior/criterion docs (all versions)
+
+## MDX side is empty by design
+
+Strict MDX cannot recover the mistyped closer. The MDXish-side snapshot
+is the regression contract — `repairMistakenTableClosers` rewrites the
+bare second `<table>` to `</table>` before `jsxTable` /
+`terminateHtmlFlowBlocks` run.
+
+## What flips this fixture
+
+Any change to `repairMistakenTableClosers`, its placement in
+`preprocessContent`, or the nested-table keep-out heuristic (do not
+rewrite when the next line starts a real nested table body).

--- a/__tests__/regression/fixtures/mistaken-table-closer/README.md
+++ b/__tests__/regression/fixtures/mistaken-table-closer/README.md
@@ -1,13 +1,13 @@
 # Mistaken table closer (`<table>` for `</table>`)
 
-Akamai behavior docs typo the table closer as a second opening
-`<table>` instead of `</table>`. Without repair, the HTML flow block
-swallows the following Notes callout as raw text.
+Customer docs typo the table closer as a second opening `<table>`
+instead of `</table>`. Without repair, the HTML flow block swallows the
+following Notes callout as raw text.
 
 ## Source bug
 
-- CX-3850 — malformed table close tag breaks Notes callouts across
-  Akamai behavior/criterion docs (all versions)
+- CX-3850 — malformed table close tag breaks Notes callouts across a
+  customer's behavior/criterion docs (all versions)
 
 ## MDX side is empty by design
 
@@ -19,5 +19,6 @@ bare second `<table>` to `</table>` before `jsxTable` /
 ## What flips this fixture
 
 Any change to `repairMistakenTableClosers`, its placement in
-`preprocessContent`, or the nested-table keep-out heuristic (do not
-rewrite when the next line starts a real nested table body).
+`preprocessContent`, or the typo heuristic (a bare opener alone on its
+line, at table depth ≥ 1, whose element ends implicitly without table-
+structure children).

--- a/__tests__/regression/fixtures/mistaken-table-closer/body.md
+++ b/__tests__/regression/fixtures/mistaken-table-closer/body.md
@@ -1,0 +1,8 @@
+<table>
+<tr><th>Option</th><th>Description</th></tr>
+<tr><td>foo</td><td>bar</td></tr>
+<table>
+> **Notes:**
+>
+> * This behavior is not required for any Enhanced TLS certificates.
+> * There are no options for this behavior.

--- a/__tests__/regression/fixtures/mistaken-table-closer/context.json
+++ b/__tests__/regression/fixtures/mistaken-table-closer/context.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "defaults": [],
+    "user": {}
+  },
+  "glossary": []
+}

--- a/__tests__/transformers/mdxish-tables.test.ts
+++ b/__tests__/transformers/mdxish-tables.test.ts
@@ -1,5 +1,5 @@
 import type { Html, Root, Text } from 'mdast';
-import type { MdxFlowExpression, MdxJsxTextElement } from 'mdast-util-mdx';
+import type { MdxFlowExpression, MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
 
 import { toHtml } from 'hast-util-to-html';
 
@@ -355,6 +355,50 @@ Just one line.
           ],
         },
       ],
+    });
+  });
+
+  describe('given a mistaken <table> closer', () => {
+    const mistaken = `<table>
+<tr><th>Option</th><th>Description</th></tr>
+<tr><td>foo</td><td>bar</td></tr>
+<table>
+> **Notes:**
+>
+> * This behavior is not required for any Enhanced TLS certificates.
+> * There are no options for this behavior.`;
+
+    it('rewrites the closer in preprocess so Notes is not swallowed', () => {
+      const { parserReadyContent } = mdxishAstProcessor(mistaken);
+      expect(parserReadyContent).toContain('</table>');
+      expect(parserReadyContent).not.toMatch(/<\/tr>\n<table>\n>/);
+    });
+
+    it('parses the table and the following Notes blockquote', () => {
+      const ast = astProcessor(mistaken);
+      expect(ast.children.map(c => c.type)).toEqual(
+        expect.arrayContaining(['mdxJsxFlowElement', 'blockquote']),
+      );
+      const table = ast.children.find(
+        (c): c is MdxJsxFlowElement => c.type === 'mdxJsxFlowElement' && c.name === 'table',
+      );
+      expect(table?.children?.length).toBeGreaterThan(0);
+      const notes = ast.children.find(c => c.type === 'blockquote');
+      expect(notes).toMatchObject({
+        type: 'blockquote',
+        children: expect.arrayContaining([
+          expect.objectContaining({ type: 'paragraph' }),
+          expect.objectContaining({ type: 'list' }),
+        ]),
+      });
+    });
+
+    it('renders table cells and the Notes callout body', () => {
+      const html = toHtml(mdxish(mistaken));
+      expect(html).toContain('Option');
+      expect(html).toContain('foo');
+      expect(html).toContain('Notes:');
+      expect(html).toContain('Enhanced TLS certificates');
     });
   });
 

--- a/__tests__/transformers/repair-mistaken-table-closers.test.ts
+++ b/__tests__/transformers/repair-mistaken-table-closers.test.ts
@@ -2,7 +2,7 @@ import { repairMistakenTableClosers } from '../../processor/transform/mdxish/rep
 
 describe('repairMistakenTableClosers (string-level preprocessor)', () => {
   describe('rewrites a bare <table> that is a missing-slash closer', () => {
-    it('rewrites the Akamai-style closer before a Notes blockquote', () => {
+    it('rewrites the mistyped closer before a Notes blockquote (CX-3850)', () => {
       const input = `<table>
 <tr><th>Option</th><th>Description</th></tr>
 <tr><td>foo</td><td>bar</td></tr>
@@ -57,6 +57,74 @@ describe('repairMistakenTableClosers (string-level preprocessor)', () => {
         '<Table>\n<tr><td>x</td></tr>\n</Table>\n> note',
       );
     });
+
+    it('rewrites a mistyped closer with whitespace in the tag (<table >)', () => {
+      expect(repairMistakenTableClosers('<table>\n<tr><td>x</td></tr>\n<table >\n> note')).toBe(
+        '<table>\n<tr><td>x</td></tr>\n</table>\n> note',
+      );
+    });
+
+    it('rewrites both closers of back-to-back mistyped tables', () => {
+      const input = `<table>
+<tr><td>a</td></tr>
+<table>
+
+<table>
+<tr><td>b</td></tr>
+<table>
+> note`;
+
+      expect(repairMistakenTableClosers(input)).toBe(`<table>
+<tr><td>a</td></tr>
+</table>
+
+<table>
+<tr><td>b</td></tr>
+</table>
+> note`);
+    });
+
+    it('rewrites a mistyped closer inside a component body, preserving indentation', () => {
+      const input = `<Accordion title="t">
+  <table>
+  <tr><td>x</td></tr>
+  <table>
+  note text
+</Accordion>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(`<Accordion title="t">
+  <table>
+  <tr><td>x</td></tr>
+  </table>
+  note text
+</Accordion>`);
+    });
+
+    it('rewrites a mistyped closer inside a Tab panel', () => {
+      const input = `<Tabs>
+<Tab title="a">
+<table>
+<tr><td>x</td></tr>
+<table>
+> note
+</Tab>
+</Tabs>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input.replace('<table>\n> note', '</table>\n> note'));
+    });
+
+    it('rewrites a mistyped closer even when a well-formed table follows', () => {
+      const input = `<table>
+<tr><td>a</td></tr>
+<table>
+> note
+
+<table>
+<tr><td>b</td></tr>
+</table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input.replace('<table>\n> note', '</table>\n> note'));
+    });
   });
 
   describe('leaves real nested tables alone', () => {
@@ -108,6 +176,33 @@ describe('repairMistakenTableClosers (string-level preprocessor)', () => {
       expect(repairMistakenTableClosers('<table>\n<tr><td>x</td></tr>\n</table>')).toBe(
         '<table>\n<tr><td>x</td></tr>\n</table>',
       );
+    });
+
+    it('does not rewrite a nested table whose rows are preceded by a comment', () => {
+      const input = `<table><tr><td>
+<table>
+<!-- c -->
+<tr><td>x</td></tr>
+</table>
+</td></tr></table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not rewrite a nested table whose rows are preceded by a <div>', () => {
+      const input = `<table><tr><td>
+<table>
+<div>heading</div>
+<tr><td>x</td></tr>
+</table>
+</td></tr></table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not rewrite a blockquoted opener (quote prefix means the line is not bare)', () => {
+      const input = '> <table>\n> <tr><td>x</td></tr>\n> <table>\n>\n> note';
+      expect(repairMistakenTableClosers(input)).toBe(input);
     });
   });
 
@@ -201,6 +296,16 @@ payload
 <table class="x">
 > note`;
 
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not let a <table> inside an attribute value pollute table depth', () => {
+      const input = '<div data-x="<table>">\ntext\n\n<table>\ncaption text\n</table>';
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('keeps an HTMLBlock body byte-exact', () => {
+      const input = '<HTMLBlock>{`\n<table>\n<tr><td>x</td></tr>\n<table>\nafter text\n`}</HTMLBlock>';
       expect(repairMistakenTableClosers(input)).toBe(input);
     });
   });

--- a/__tests__/transformers/repair-mistaken-table-closers.test.ts
+++ b/__tests__/transformers/repair-mistaken-table-closers.test.ts
@@ -117,6 +117,53 @@ describe('repairMistakenTableClosers (string-level preprocessor)', () => {
       expect(repairMistakenTableClosers(input)).toBe(input);
     });
 
+    it('does not rewrite <table> payload inside a raw-text element', () => {
+      const input = `<pre>
+<table>
+<tr><td>x</td></tr>
+<table>
+literal payload
+</pre>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not rewrite <table> text inside a <script> body', () => {
+      const input = `<script>
+const html = [
+<table>,
+<table>
+];
+</script>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('ignores raw-text payload when judging table depth after the block', () => {
+      const input = `<pre>
+<table>
+</pre>
+
+<table>
+<tr><td>x</td></tr>
+</table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('still repairs a mistaken closer after a closed raw-text block', () => {
+      const input = `<style>
+.x { color: red; }
+</style>
+
+<table>
+<tr><td>x</td></tr>
+<table>
+> note`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input.replace(/<table>\n> note/, '</table>\n> note'));
+    });
+
     it('does not rewrite a <table> that carries attributes', () => {
       const input = `<table>
 <tr><td>x</td></tr>

--- a/__tests__/transformers/repair-mistaken-table-closers.test.ts
+++ b/__tests__/transformers/repair-mistaken-table-closers.test.ts
@@ -1,0 +1,129 @@
+import { repairMistakenTableClosers } from '../../processor/transform/mdxish/repair-mistaken-table-closers';
+
+describe('repairMistakenTableClosers (string-level preprocessor)', () => {
+  describe('rewrites a bare <table> that is a missing-slash closer', () => {
+    it('rewrites the Akamai-style closer before a Notes blockquote', () => {
+      const input = `<table>
+<tr><th>Option</th><th>Description</th></tr>
+<tr><td>foo</td><td>bar</td></tr>
+<table>
+> **Notes:**
+>
+> * This behavior is not required for any Enhanced TLS certificates.`;
+
+      expect(repairMistakenTableClosers(input)).toBe(`<table>
+<tr><th>Option</th><th>Description</th></tr>
+<tr><td>foo</td><td>bar</td></tr>
+</table>
+> **Notes:**
+>
+> * This behavior is not required for any Enhanced TLS certificates.`);
+    });
+
+    it('rewrites when the next line is a heading', () => {
+      expect(repairMistakenTableClosers('<table>\n<tr><td>x</td></tr>\n<table>\n# After')).toBe(
+        '<table>\n<tr><td>x</td></tr>\n</table>\n# After',
+      );
+    });
+
+    it('rewrites when there is no following line (EOF)', () => {
+      expect(repairMistakenTableClosers('<table>\n<tr><td>x</td></tr>\n<table>')).toBe(
+        '<table>\n<tr><td>x</td></tr>\n</table>',
+      );
+    });
+
+    it('rewrites when the next non-empty line is a cell closer (nested in a cell)', () => {
+      const input = `<table>
+<tr><td>
+<table>
+</td></tr>
+</table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(`<table>
+<tr><td>
+</table>
+</td></tr>
+</table>`);
+    });
+
+    it('preserves indentation on the rewritten closer', () => {
+      expect(repairMistakenTableClosers('<table>\n<tr><td>x</td></tr>\n  <table>\n> note')).toBe(
+        '<table>\n<tr><td>x</td></tr>\n  </table>\n> note',
+      );
+    });
+
+    it('preserves <Table> casing on the rewritten closer', () => {
+      expect(repairMistakenTableClosers('<Table>\n<tr><td>x</td></tr>\n<Table>\n> note')).toBe(
+        '<Table>\n<tr><td>x</td></tr>\n</Table>\n> note',
+      );
+    });
+  });
+
+  describe('leaves real nested tables alone', () => {
+    it('does not rewrite when the next line starts a nested <tr>', () => {
+      const input = `<table>
+<tr><td>
+<table>
+<tr><td>nested</td></tr>
+</table>
+</td></tr>
+</table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not rewrite an empty nested <table></table> pair', () => {
+      const input = `<table>
+<tr><td>
+<table>
+</table>
+</td></tr>
+</table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not rewrite when the next line is <thead>', () => {
+      const input = `<table>
+<tr><td>
+<table>
+<thead><tr><th>h</th></tr></thead>
+</table>
+</td></tr>
+</table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not rewrite a well-formed table with a real </table>', () => {
+      const input = `<table>
+<tr><td>foo</td></tr>
+</table>
+> **Notes:**`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not rewrite a leading <table> at depth 0', () => {
+      expect(repairMistakenTableClosers('<table>\n<tr><td>x</td></tr>\n</table>')).toBe(
+        '<table>\n<tr><td>x</td></tr>\n</table>',
+      );
+    });
+  });
+
+  describe('leaves code and non-bare openers alone', () => {
+    it('does not rewrite <table> inside a fenced code block', () => {
+      const input = '```html\n<table>\n<tr><td>x</td></tr>\n<table>\n```';
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not rewrite a <table> that carries attributes', () => {
+      const input = `<table>
+<tr><td>x</td></tr>
+<table class="x">
+> note`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+  });
+});

--- a/__tests__/transformers/repair-mistaken-table-closers.test.ts
+++ b/__tests__/transformers/repair-mistaken-table-closers.test.ts
@@ -265,6 +265,19 @@ payload
       expect(repairMistakenTableClosers(input)).toBe(input.replace('<table>\n> note', '</table>\n> note'));
     });
 
+    it('still repairs a later typo after an unclosed payload <table> in an opaque block', () => {
+      const input = `<pre>
+<table>
+</pre>
+
+<table>
+<tr><td>x</td></tr>
+<table>
+> note`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input.replace('<table>\n> note', '</table>\n> note'));
+    });
+
     it('ignores raw-text payload when judging table depth after the block', () => {
       const input = `<pre>
 <table>

--- a/__tests__/transformers/repair-mistaken-table-closers.test.ts
+++ b/__tests__/transformers/repair-mistaken-table-closers.test.ts
@@ -139,6 +139,37 @@ const html = [
       expect(repairMistakenTableClosers(input)).toBe(input);
     });
 
+    it('does not count a <table> sharing a line with a raw-text opener (<pre><table>)', () => {
+      const input = `<pre><table></pre>
+
+<table>
+caption text
+</table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('does not count payload in a same-line raw-text span (<script>…</script>)', () => {
+      const input = `<script>render("<table>")</script>
+
+<table>
+caption text
+</table>`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
+    it('counts a <table> opening after a same-line raw-text closer (</pre><table>)', () => {
+      const input = `<pre>
+payload
+</pre><table>
+<tr><td>x</td></tr>
+<table>
+> note`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input.replace('<table>\n> note', '</table>\n> note'));
+    });
+
     it('ignores raw-text payload when judging table depth after the block', () => {
       const input = `<pre>
 <table>

--- a/__tests__/transformers/repair-mistaken-table-closers.test.ts
+++ b/__tests__/transformers/repair-mistaken-table-closers.test.ts
@@ -212,6 +212,17 @@ describe('repairMistakenTableClosers (string-level preprocessor)', () => {
       expect(repairMistakenTableClosers(input)).toBe(input);
     });
 
+    it('does not rewrite <table> inside a tilde-fenced code block', () => {
+      const input = `~~~
+<table>
+<tr><th>Option</th><th>Description</th></tr>
+<tr><td>foo</td><td>bar</td></tr>
+<table>
+~~~`;
+
+      expect(repairMistakenTableClosers(input)).toBe(input);
+    });
+
     it('does not rewrite <table> payload inside a raw-text element', () => {
       const input = `<pre>
 <table>

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -43,6 +43,7 @@ import { normalizeCompactHeadings } from '../processor/transform/mdxish/normaliz
 import normalizeEmphasisAST from '../processor/transform/mdxish/normalize-malformed-md-syntax';
 import normalizeMdxJsxNodes from '../processor/transform/mdxish/normalize-mdx-jsx-nodes';
 import { removeJSXComments } from '../processor/transform/mdxish/remove-jsx-comments';
+import { repairMistakenTableClosers } from '../processor/transform/mdxish/repair-mistaken-table-closers';
 import resolveDeferredAttributeExpressionProps from '../processor/transform/mdxish/resolve-deferred-attribute-expression-props';
 import restoreSnakeCaseComponentNames from '../processor/transform/mdxish/restore-snake-case-component-name';
 import {
@@ -106,6 +107,7 @@ function preprocessContent(
   // Runs first so `jsxTable` sees a literal `</table>` (and the HTML-line
   // classification in `terminateHtmlFlowBlocks` is accurate)
   let result = normalizeClosingTagWhitespace(content);
+  result = repairMistakenTableClosers(result);
   result = normalizeTableSeparator(result);
   // Before terminateHtmlFlowBlocks: a blank line inside an <svg>/<math> island
   // would otherwise fragment it (children spill out as an indented code block once

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -91,12 +91,13 @@ const defaultTransformers: PluggableList = [
  *
  * Runs a series of string-level transformations before micromark/remark parsing:
  * 1. Canonicalize closing tags with stray whitespace (e.g., `</ td >` → `</td>`)
- * 2. Normalize malformed table separator syntax (e.g., `|: ---` → `| :---`)
- * 3. Collapse blank lines inside `<svg>`/`<math>` so their children aren't fragmented
- * 4. Terminate HTML flow blocks so subsequent content isn't swallowed
- * 5. Close invalid "self-closing" HTML tags (e.g., `<i />` → `<i></i>`)
- * 6. Normalize compact ATX headings (e.g., `#Heading` → `# Heading`)
- * 7. Replace snake_case component names with parser-safe placeholders
+ * 2. Repair mistyped table closers (a bare second `<table>` meant as `</table>`)
+ * 3. Normalize malformed table separator syntax (e.g., `|: ---` → `| :---`)
+ * 4. Collapse blank lines inside `<svg>`/`<math>` so their children aren't fragmented
+ * 5. Terminate HTML flow blocks so subsequent content isn't swallowed
+ * 6. Close invalid "self-closing" HTML tags (e.g., `<i />` → `<i></i>`)
+ * 7. Normalize compact ATX headings (e.g., `#Heading` → `# Heading`)
+ * 8. Replace snake_case component names with parser-safe placeholders
  */
 function preprocessContent(
   content: string,

--- a/processor/transform/mdxish/repair-mistaken-table-closers.ts
+++ b/processor/transform/mdxish/repair-mistaken-table-closers.ts
@@ -5,11 +5,7 @@ import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/
 /** A line that is only a bare `<table>` / `<Table>` opener (the common missing-slash typo). */
 const BARE_TABLE_OPENER_RE = /^(\s*)<(table|Table)>\s*$/;
 
-/**
- * Openers that begin a real nested table body. A bare `<table>` followed by one
- * of these is left alone; followed by anything else (markdown, `</td>`, EOF) it
- * is treated as a mistaken `</table>`.
- */
+/** A bare `<table>` followed by one of these starts a real nested table and is left alone. */
 const NESTED_TABLE_BODY_START_RE =
   /^<(?:thead|tbody|tfoot|tr|th|td|caption|colgroup|col|table|Table)(?=[\s/>])/i;
 
@@ -19,10 +15,43 @@ const TABLE_CLOSER_RE = /^<\/table(?=[\s>])/i;
 const TABLE_OPEN_RE = /<(?:table|Table)(?=[\s/>])[^>]*?(?<!\/)>/g;
 const TABLE_CLOSE_RE = /<\/(?:table|Table)(?=[\s>])[^>]*>/g;
 
-const RAW_TEXT_TAG_MATCHERS = htmlRawNames.map(tag => ({
-  open: new RegExp(`<${tag}(?=[\\s/>])[^>]*?(?<!/)>`, 'gi'),
-  close: new RegExp(`</${tag}(?=[\\s>])[^>]*>`, 'gi'),
-}));
+const RAW_TEXT_OPENER_RE = new RegExp(`<(${htmlRawNames.join('|')})(?=[\\s/>])[^>]*?(?<!/)>`, 'i');
+
+const RAW_TEXT_CLOSERS = Object.fromEntries(
+  htmlRawNames.map(tag => [tag, new RegExp(`</${tag}(?=[\\s>])[^>]*>`, 'i')]),
+);
+
+interface StripRawTextResult {
+  openRawTag: string | null;
+  visible: string;
+}
+
+/**
+ * Returns the parts of a line outside raw-text (<pre>/<script>/<style>/<textarea>) payload —
+ * a `<table>` inside those bodies must not count toward table depth. Raw text cannot nest.
+ */
+function stripRawTextPayload(line: string, openRawTag: string | null): StripRawTextResult {
+  let visible = '';
+  let rest = line;
+  let tag = openRawTag;
+
+  while (rest.length > 0) {
+    if (tag !== null) {
+      const closer = RAW_TEXT_CLOSERS[tag].exec(rest);
+      if (!closer) return { visible, openRawTag: tag };
+      rest = rest.slice(closer.index + closer[0].length);
+      tag = null;
+    } else {
+      const opener = RAW_TEXT_OPENER_RE.exec(rest);
+      if (!opener) break;
+      visible += rest.slice(0, opener.index);
+      rest = rest.slice(opener.index + opener[0].length);
+      tag = opener[1].toLowerCase();
+    }
+  }
+
+  return { visible: visible + (tag === null ? rest : ''), openRawTag: tag };
+}
 
 const countTableDelta = (line: string): number => {
   const opens = (line.match(TABLE_OPEN_RE) ?? []).length;
@@ -58,26 +87,15 @@ export function repairMistakenTableClosers(content: string) {
   const { protectedContent, protectedCode } = protectCodeBlocks(content);
   const lines = protectedContent.split('\n');
   let depth = 0;
-  // Per-tag count of still-open raw-text elements at the current line boundary.
-  const rawTextDepths = RAW_TEXT_TAG_MATCHERS.map(() => 0);
+  let openRawTag: string | null = null;
 
   for (let i = 0; i < lines.length; i += 1) {
-    const insideRawText = rawTextDepths.some(d => d > 0);
+    const stripped = stripRawTextPayload(lines[i], openRawTag);
+    // Only a line with no raw-text involvement can be a mistyped closer.
+    const isFullyVisible = openRawTag === null && stripped.visible === lines[i];
+    openRawTag = stripped.openRawTag;
 
-    RAW_TEXT_TAG_MATCHERS.forEach(({ open, close }, tagIndex) => {
-      const opens = (lines[i].match(open) ?? []).length;
-      const closes = (lines[i].match(close) ?? []).length;
-      // Reset lastIndex — module-scoped `/g` regexes.
-      open.lastIndex = 0;
-      close.lastIndex = 0;
-      rawTextDepths[tagIndex] = Math.max(0, rawTextDepths[tagIndex] + opens - closes);
-    });
-
-    // A `<table>` inside a raw-text body is payload text: never rewrite it, and
-    // never let it skew the table depth used to judge later openers.
-    if (insideRawText) continue;
-
-    const match = BARE_TABLE_OPENER_RE.exec(lines[i]);
+    const match = isFullyVisible ? BARE_TABLE_OPENER_RE.exec(lines[i]) : null;
     if (match && depth > 0) {
       const next = nextNonEmptyLine(lines, i + 1);
       const isRealNestedOpener =
@@ -88,7 +106,8 @@ export function repairMistakenTableClosers(content: string) {
       }
     }
 
-    depth = Math.max(0, depth + countTableDelta(lines[i]));
+    // A repaired closer must decrement, so count post-rewrite `lines[i]` when visible.
+    depth = Math.max(0, depth + countTableDelta(isFullyVisible ? lines[i] : stripped.visible));
   }
 
   return restoreCodeBlocks(lines.join('\n'), protectedCode);

--- a/processor/transform/mdxish/repair-mistaken-table-closers.ts
+++ b/processor/transform/mdxish/repair-mistaken-table-closers.ts
@@ -1,0 +1,71 @@
+import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
+
+/** A line that is only a bare `<table>` / `<Table>` opener (the common missing-slash typo). */
+const BARE_TABLE_OPENER_RE = /^(\s*)<(table|Table)>\s*$/;
+
+/**
+ * Openers that begin a real nested table body. A bare `<table>` followed by one
+ * of these is left alone; followed by anything else (markdown, `</td>`, EOF) it
+ * is treated as a mistaken `</table>`.
+ */
+const NESTED_TABLE_BODY_START_RE =
+  /^<(?:thead|tbody|tfoot|tr|th|td|caption|colgroup|col|table|Table)(?=[\s/>])/i;
+
+/** Empty nested `<table>\n</table>` — the opener is intentional. */
+const TABLE_CLOSER_RE = /^<\/table(?=[\s>])/i;
+
+const TABLE_OPEN_RE = /<(?:table|Table)(?=[\s/>])[^>]*?(?<!\/)>/g;
+const TABLE_CLOSE_RE = /<\/(?:table|Table)(?=[\s>])[^>]*>/g;
+
+const countTableDelta = (line: string): number => {
+  const opens = (line.match(TABLE_OPEN_RE) ?? []).length;
+  const closes = (line.match(TABLE_CLOSE_RE) ?? []).length;
+  // Reset lastIndex — these are module-scoped `/g` regexes.
+  TABLE_OPEN_RE.lastIndex = 0;
+  TABLE_CLOSE_RE.lastIndex = 0;
+  return opens - closes;
+};
+
+const nextNonEmptyLine = (lines: string[], from: number): string | undefined => {
+  for (let i = from; i < lines.length; i += 1) {
+    const trimmed = lines[i].trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return undefined;
+};
+
+/**
+ * Rewrites a bare `<table>` that is almost certainly a missing-slash closer
+ * (`</table>` typo) so `jsxTable` / `terminateHtmlFlowBlocks` see a real close.
+ *
+ * Customer docs (CX-3850 / Akamai) close tables with a second `<table>` opener;
+ * without this, the HTML flow block swallows following markdown (Notes callouts).
+ * Real nested tables are preserved: a bare opener followed by row/section tags
+ * (or an immediate `</table>`) is left unchanged.
+ *
+ * @example
+ * repairMistakenTableClosers('<table>\\n<tr><td>x</td></tr>\\n<table>\\n> note')
+ * // '<table>\\n<tr><td>x</td></tr>\\n</table>\\n> note'
+ */
+export function repairMistakenTableClosers(content: string) {
+  const { protectedContent, protectedCode } = protectCodeBlocks(content);
+  const lines = protectedContent.split('\n');
+  let depth = 0;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const match = BARE_TABLE_OPENER_RE.exec(lines[i]);
+    if (match && depth > 0) {
+      const next = nextNonEmptyLine(lines, i + 1);
+      const isRealNestedOpener =
+        next !== undefined && (NESTED_TABLE_BODY_START_RE.test(next) || TABLE_CLOSER_RE.test(next));
+      if (!isRealNestedOpener) {
+        const [, indent, name] = match;
+        lines[i] = `${indent}</${name}>`;
+      }
+    }
+
+    depth = Math.max(0, depth + countTableDelta(lines[i]));
+  }
+
+  return restoreCodeBlocks(lines.join('\n'), protectedCode);
+}

--- a/processor/transform/mdxish/repair-mistaken-table-closers.ts
+++ b/processor/transform/mdxish/repair-mistaken-table-closers.ts
@@ -1,3 +1,5 @@
+import { htmlRawNames } from 'micromark-util-html-tag-name';
+
 import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
 
 /** A line that is only a bare `<table>` / `<Table>` opener (the common missing-slash typo). */
@@ -16,6 +18,11 @@ const TABLE_CLOSER_RE = /^<\/table(?=[\s>])/i;
 
 const TABLE_OPEN_RE = /<(?:table|Table)(?=[\s/>])[^>]*?(?<!\/)>/g;
 const TABLE_CLOSE_RE = /<\/(?:table|Table)(?=[\s>])[^>]*>/g;
+
+const RAW_TEXT_TAG_MATCHERS = htmlRawNames.map(tag => ({
+  open: new RegExp(`<${tag}(?=[\\s/>])[^>]*?(?<!/)>`, 'gi'),
+  close: new RegExp(`</${tag}(?=[\\s>])[^>]*>`, 'gi'),
+}));
 
 const countTableDelta = (line: string): number => {
   const opens = (line.match(TABLE_OPEN_RE) ?? []).length;
@@ -51,8 +58,25 @@ export function repairMistakenTableClosers(content: string) {
   const { protectedContent, protectedCode } = protectCodeBlocks(content);
   const lines = protectedContent.split('\n');
   let depth = 0;
+  // Per-tag count of still-open raw-text elements at the current line boundary.
+  const rawTextDepths = RAW_TEXT_TAG_MATCHERS.map(() => 0);
 
   for (let i = 0; i < lines.length; i += 1) {
+    const insideRawText = rawTextDepths.some(d => d > 0);
+
+    RAW_TEXT_TAG_MATCHERS.forEach(({ open, close }, tagIndex) => {
+      const opens = (lines[i].match(open) ?? []).length;
+      const closes = (lines[i].match(close) ?? []).length;
+      // Reset lastIndex — module-scoped `/g` regexes.
+      open.lastIndex = 0;
+      close.lastIndex = 0;
+      rawTextDepths[tagIndex] = Math.max(0, rawTextDepths[tagIndex] + opens - closes);
+    });
+
+    // A `<table>` inside a raw-text body is payload text: never rewrite it, and
+    // never let it skew the table depth used to judge later openers.
+    if (insideRawText) continue;
+
     const match = BARE_TABLE_OPENER_RE.exec(lines[i]);
     if (match && depth > 0) {
       const next = nextNonEmptyLine(lines, i + 1);

--- a/processor/transform/mdxish/repair-mistaken-table-closers.ts
+++ b/processor/transform/mdxish/repair-mistaken-table-closers.ts
@@ -1,114 +1,92 @@
-import { htmlRawNames } from 'micromark-util-html-tag-name';
-
-import { protectCodeBlocks, restoreCodeBlocks } from '../../../lib/utils/mdxish/protect-code-blocks';
-
-/** A line that is only a bare `<table>` / `<Table>` opener (the common missing-slash typo). */
-const BARE_TABLE_OPENER_RE = /^(\s*)<(table|Table)>\s*$/;
-
-/** A bare `<table>` followed by one of these starts a real nested table and is left alone. */
-const NESTED_TABLE_BODY_START_RE =
-  /^<(?:thead|tbody|tfoot|tr|th|td|caption|colgroup|col|table|Table)(?=[\s/>])/i;
-
-/** Empty nested `<table>\n</table>` — the opener is intentional. */
-const TABLE_CLOSER_RE = /^<\/table(?=[\s>])/i;
-
-const TABLE_OPEN_RE = /<(?:table|Table)(?=[\s/>])[^>]*?(?<!\/)>/g;
-const TABLE_CLOSE_RE = /<\/(?:table|Table)(?=[\s>])[^>]*>/g;
-
-const RAW_TEXT_OPENER_RE = new RegExp(`<(${htmlRawNames.join('|')})(?=[\\s/>])[^>]*?(?<!/)>`, 'i');
-
-const RAW_TEXT_CLOSERS = Object.fromEntries(
-  htmlRawNames.map(tag => [tag, new RegExp(`</${tag}(?=[\\s>])[^>]*>`, 'i')]),
-);
-
-interface StripRawTextResult {
-  openRawTag: string | null;
-  visible: string;
-}
+import { walkTags } from './tables/tag-walker';
+import { applyInserts, tableTags, type Insert } from './tables/utils';
 
 /**
- * Returns the parts of a line outside raw-text (<pre>/<script>/<style>/<textarea>) payload —
- * a `<table>` inside those bodies must not count toward table depth. Raw text cannot nest.
+ * Containers whose bodies must stay byte-exact. htmlparser2 already treats
+ * `<script>`/`<style>`/`<textarea>` bodies as raw text; these still emit inner tag events.
  */
-function stripRawTextPayload(line: string, openRawTag: string | null): StripRawTextResult {
-  let visible = '';
-  let rest = line;
-  let tag = openRawTag;
+const OPAQUE_CONTAINERS = new Set(['pre', 'textarea', 'htmlblock']);
 
-  while (rest.length > 0) {
-    if (tag !== null) {
-      const closer = RAW_TEXT_CLOSERS[tag].exec(rest);
-      if (!closer) return { visible, openRawTag: tag };
-      rest = rest.slice(closer.index + closer[0].length);
-      tag = null;
-    } else {
-      const opener = RAW_TEXT_OPENER_RE.exec(rest);
-      if (!opener) break;
-      visible += rest.slice(0, opener.index);
-      rest = rest.slice(opener.index + opener[0].length);
-      tag = opener[1].toLowerCase();
-    }
-  }
+/** The missing-slash typo shape: an attribute-less, non-self-closing opener. */
+const BARE_OPENER_SOURCE_RE = /^<[A-Za-z]+\s*>$/;
 
-  return { visible: visible + (tag === null ? rest : ''), openRawTag: tag };
+interface OpenTable {
+  end: number;
+  hasStructureChild: boolean;
+  isCandidate: boolean;
+  name: string;
+  start: number;
 }
 
-const countTableDelta = (line: string): number => {
-  const opens = (line.match(TABLE_OPEN_RE) ?? []).length;
-  const closes = (line.match(TABLE_CLOSE_RE) ?? []).length;
-  // Reset lastIndex — these are module-scoped `/g` regexes.
-  TABLE_OPEN_RE.lastIndex = 0;
-  TABLE_CLOSE_RE.lastIndex = 0;
-  return opens - closes;
-};
-
-const nextNonEmptyLine = (lines: string[], from: number): string | undefined => {
-  for (let i = from; i < lines.length; i += 1) {
-    const trimmed = lines[i].trim();
-    if (trimmed.length > 0) return trimmed;
-  }
-  return undefined;
+/** The opener shares its line with nothing but whitespace. */
+const isAloneOnLine = (content: string, start: number, end: number): boolean => {
+  const lineStart = content.lastIndexOf('\n', start - 1) + 1;
+  const lineEnd = content.indexOf('\n', end);
+  return (
+    content.slice(lineStart, start).trim() === '' &&
+    content.slice(end, lineEnd === -1 ? content.length : lineEnd).trim() === ''
+  );
 };
 
 /**
  * Rewrites a bare `<table>` that is almost certainly a missing-slash closer
  * (`</table>` typo) so `jsxTable` / `terminateHtmlFlowBlocks` see a real close.
+ * Customer docs (CX-3850) close tables with a second bare opener; without this,
+ * the never-terminated HTML flow block swallows the markdown that follows.
  *
- * Customer docs (CX-3850 / Akamai) close tables with a second `<table>` opener;
- * without this, the HTML flow block swallows following markdown (Notes callouts).
- * Real nested tables are preserved: a bare opener followed by row/section tags
- * (or an immediate `</table>`) is left unchanged.
- *
- * @example
- * repairMistakenTableClosers('<table>\\n<tr><td>x</td></tr>\\n<table>\\n> note')
- * // '<table>\\n<tr><td>x</td></tr>\\n</table>\\n> note'
+ * A candidate is a bare opener alone on its line while a table is already open.
+ * It is judged a typo only when its element ends implicitly (no explicit
+ * `</table>`) without ever acquiring table-structure children — so genuine
+ * nested tables, whatever precedes their rows, are left alone.
  */
 export function repairMistakenTableClosers(content: string) {
-  const { protectedContent, protectedCode } = protectCodeBlocks(content);
-  const lines = protectedContent.split('\n');
-  let depth = 0;
-  let openRawTag: string | null = null;
+  const stack: OpenTable[] = [];
+  const edits: Insert[] = [];
+  let opaqueDepth = 0;
+  // Tables opened inside an opaque container: skipped, but their close events
+  // still arrive (innermost-first) and must not pop real tables off the stack.
+  let ignoredTables = 0;
 
-  for (let i = 0; i < lines.length; i += 1) {
-    const stripped = stripRawTextPayload(lines[i], openRawTag);
-    // Only a line with no raw-text involvement can be a mistyped closer.
-    const isFullyVisible = openRawTag === null && stripped.visible === lines[i];
-    openRawTag = stripped.openRawTag;
-
-    const match = isFullyVisible ? BARE_TABLE_OPENER_RE.exec(lines[i]) : null;
-    if (match && depth > 0) {
-      const next = nextNonEmptyLine(lines, i + 1);
-      const isRealNestedOpener =
-        next !== undefined && (NESTED_TABLE_BODY_START_RE.test(next) || TABLE_CLOSER_RE.test(next));
-      if (!isRealNestedOpener) {
-        const [, indent, name] = match;
-        lines[i] = `${indent}</${name}>`;
+  walkTags(content, {
+    onOpen({ name, start, end }) {
+      const lower = name.toLowerCase();
+      if (OPAQUE_CONTAINERS.has(lower)) {
+        opaqueDepth += 1;
+      } else if (lower === 'table') {
+        if (opaqueDepth > 0) {
+          ignoredTables += 1;
+          return;
+        }
+        const source = content.slice(start, end);
+        stack.push({
+          name,
+          start,
+          end,
+          hasStructureChild: false,
+          isCandidate:
+            stack.length > 0 && BARE_OPENER_SOURCE_RE.test(source) && isAloneOnLine(content, start, end),
+        });
+      } else if (opaqueDepth === 0 && tableTags.has(lower) && stack.length > 0) {
+        stack[stack.length - 1].hasStructureChild = true;
       }
-    }
+    },
+    onClose({ name, implicit }) {
+      const lower = name.toLowerCase();
+      if (OPAQUE_CONTAINERS.has(lower)) {
+        opaqueDepth = Math.max(0, opaqueDepth - 1);
+        return;
+      }
+      if (lower !== 'table') return;
+      if (ignoredTables > 0) {
+        ignoredTables -= 1;
+        return;
+      }
+      const table = stack.pop();
+      if (table?.isCandidate && implicit && !table.hasStructureChild) {
+        edits.push({ offset: table.start, text: `</${table.name}>`, consumes: table.end - table.start });
+      }
+    },
+  });
 
-    // A repaired closer must decrement, so count post-rewrite `lines[i]` when visible.
-    depth = Math.max(0, depth + countTableDelta(isFullyVisible ? lines[i] : stripped.visible));
-  }
-
-  return restoreCodeBlocks(lines.join('\n'), protectedCode);
+  return applyInserts(content, edits).value;
 }

--- a/processor/transform/mdxish/tables/tag-walker.ts
+++ b/processor/transform/mdxish/tables/tag-walker.ts
@@ -5,7 +5,7 @@ import { Parser } from 'htmlparser2';
  */
 export const maskNonTagRegions = (html: string): string =>
   html
-    .replace(/```[\s\S]*?```|``(?:[^`]|`(?!`))*``|`[^`\n]*`/g, m => ' '.repeat(m.length))
+    .replace(/```[\s\S]*?```|~{3,}[\s\S]*?~{3,}|``(?:[^`]|`(?!`))*``|`[^`\n]*`/g, m => ' '.repeat(m.length))
     // `<<NAME>>` is legacy variable syntax — without masking,
     // htmlparser2 sees the inner `<NAME>` as a tag. Blanking any `<<` also
     // covers malformed variants like `<<string>`.


### PR DESCRIPTION
| 🎫 Resolve CX-3850 |
| :-----------------: |

## 🎯 What does this PR do?

Customer docs typo their table closer as a second `<table>` instead of `</table>`, which made the following Notes callout render as raw text.

- CommonMark HTML flow keeps a `<table>` block open until a blank line or a real `</table>`. A bare second `<table>` is another opener, so the Notes blockquote gets swallowed into the HTML blob.
- `jsxTable` also rejects the block (depth never returns to 0), and `terminateHtmlFlowBlocks` won't insert a blank line after a raw-content opener that still leaves the tag open.
- Adds `repairMistakenTableClosers` in `preprocessContent` (right after `normalizeClosingTagWhitespace`) so `jsxTable` / `terminateHtmlFlowBlocks` see a literal `</table>` before parse.
- Built on the existing `walkTags` infrastructure from the table transformers. The pass keeps a stack of open tables; a **candidate** is a bare, attribute-less opener alone on its line while another table is open, and it's rewritten only when its element **ends implicitly** (no real `</table>` ever arrives) **without acquiring table-structure children** (`<tr>`, `<thead>`, …). Genuine nested tables are judged by their whole element, not the next line, so a comment or `<div>` before the rows no longer matters.
- Payload stays byte-exact: code fences (masked by the walker), `<script>`/`<style>`/`<textarea>` (raw text to htmlparser2), and `<pre>`/`<HTMLBlock>` bodies (tracked as opaque containers) are never rewritten and never skew depth. `<table>` inside attribute values is a non-issue since attributes are actually parsed

## 🧪 QA tips

- [ ] **The bug.** The Notes callout should render as a blockquote *below* the table. Before, it
  was swallowed into the table as raw text:

  ```md
  <table>
  <tr><th>Option</th><th>Description</th></tr>
  <tr><td>foo</td><td>bar</td></tr>
  <table>
  > **Notes:**
  >
  > * This behavior is not required for any Enhanced TLS certificates.
  > * There are no options for this behavior.             
  ```                                                                                        

- [ ] **Genuine nested tables still nest — even with a comment before the rows** (the regression from review):

  ```md
  <table><tr><td>
  <table>                                                 
  <!-- c -->                                                                                 
  <tr><td>x</td></tr>
  </table>
  </td></tr></table>
  ```

  → the inner table renders inside the outer cell; no closer is fabricated.

- [ ] **Back-to-back typo'd tables both repair** — two tables, each closed with the typo, should render as two separate tables with the note below:

  ```md
  <table>
  <tr><td>a</td></tr>                                     
  <table>                                                                                    

  <table>
  <tr><td>b</td></tr>
  <table>
  > note
  ```

- [ ] **The typo works inside components too** — the table inside should close and the note should
render as text below it:                                    
                                                                                             
  ```md
  <Accordion title="Options">
    <table>
    <tr><td>x</td></tr>
    <table>
    note text
  </Accordion>                                            
  ```                                                                                        

- [ ] **Well-formed tables are untouched** — a correct `</table>` followed by a callout renders exactly as before:

  ```md
  <table>
  <tr><td>foo</td></tr>
  </table>
  > **Notes:**
  ```                                                     
                                                                                             
- [ ] **Payload is off-limits** — the mistaken-closer shape inside a fenced ` ```html ` block, a `<pre>`, or an `<HTMLBlock>` stays verbatim:

  ```md
  <table>                                                 
  <tr><td>x</td></tr>                                                                        
  <table>
  ```

## 📸 Screenshot or Loom

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/5e5362cf-e099-4488-89ac-ebd20806aed6
</td>
<td>

https://github.com/user-attachments/assets/6e580874-fbd8-49f5-b2c7-c54164cce97c

</td>
</tr>
</table>
