### PR TITLE
fix: index relevant props of customer's components

### DIFF
--- a/__tests__/lib/plain/custom-components.test.ts
+++ b/__tests__/lib/plain/custom-components.test.ts
@@ -1,4 +1,14 @@
-import { hast, plain } from '../../../index';
+import type { CustomComponents } from '../../../types';
+
+import { describe, it, expect } from 'vitest';
+
+import { hast, mdxish, mdxishTags, plain } from '../../../index';
+
+/** Register a page's custom-component tags so mdxish keeps them (as gitto's indexer does). */
+function mdxishPlain(mdx: string): string {
+  const components = Object.fromEntries(mdxishTags(mdx).map(tag => [tag, {} as CustomComponents[string]]));
+  return plain(mdxish(mdx, { components, safeMode: true }), { preserveVariableSyntax: true }).toString();
+}
 
 describe('plain compiler', () => {
   it('should include the title of Accordion', () => {
@@ -29,5 +39,70 @@ describe('plain compiler', () => {
 `;
 
     expect(plain(hast(mdx))).toContain('Title Body');
+  });
+
+  // Custom components aren't rendered in safeMode, so authored copy passed as props (not just
+  // children) must be pulled off the node or it never reaches the search index.
+  describe('custom components (mdxish)', () => {
+    it('indexes authored text passed as a string prop', () => {
+      const mdx = '<Banner message="This banner is displayed inline." />';
+
+      expect(mdxishPlain(mdx)).toContain('This banner is displayed inline.');
+    });
+
+    it('indexes both props and children', () => {
+      const mdx = '<Note title="Heads up">read this carefully</Note>';
+
+      expect(mdxishPlain(mdx)).toContain('Heads up read this carefully');
+    });
+
+    it('indexes text passed as a static template-literal expression prop', () => {
+      const mdx = '<ContentModal title="Content Modal" content={`Testing search`} buttonColor="#0B1440" />';
+      const result = mdxishPlain(mdx);
+
+      expect(result).toContain('Testing search');
+      expect(result).not.toContain('#0B1440');
+    });
+
+    it('indexes multi-line template-literal expression props', () => {
+      const mdx = `<ContentModal content={\`First line of copy.
+      Second line of copy.\`} />`;
+      const result = mdxishPlain(mdx);
+
+      expect(result).toContain('First line of copy.');
+      expect(result).toContain('Second line of copy.');
+    });
+
+    it('skips interpolated templates and non-string expressions', () => {
+      // The `${user.name}` is intentional literal MDX source under test, not a JS template.
+      // eslint-disable-next-line no-template-curly-in-string
+      const mdx = '<Banner message={`Hello ${user.name}`} count={5} enabled={true} ref={user.id} />';
+      const result = mdxishPlain(mdx);
+
+      expect(result).not.toContain('Hello');
+      expect(result).not.toContain('5');
+      expect(result).not.toContain('true');
+    });
+
+    it('skips styling/config prop values, mirroring built-ins', () => {
+      const mdx =
+        '<Banner message="Real copy" color="#118cfd" fontSize="14px" isInline={true} count={5} link="https://example.com" />';
+      const result = mdxishPlain(mdx);
+
+      expect(result).toContain('Real copy');
+      expect(result).not.toContain('#118cfd');
+      expect(result).not.toContain('14px');
+      expect(result).not.toContain('true');
+      expect(result).not.toContain('example.com');
+    });
+
+    it('skips styling props whose value is a plain word (e.g. fontWeight="bold")', () => {
+      const mdx = '<Banner message="Real copy" fontWeight="bold" textAlign="center" />';
+      const result = mdxishPlain(mdx);
+
+      expect(result).toContain('Real copy');
+      expect(result).not.toContain('bold');
+      expect(result).not.toContain('center');
+    });
   });
 });

--- a/lib/plain.ts
+++ b/lib/plain.ts
@@ -7,6 +7,8 @@ import { fromHtml } from 'hast-util-from-html';
 
 import { MDX_COMMENT_REGEX } from '../processor/transform/stripComments';
 
+import { componentPropText } from './utils/component-prop-text';
+
 /* @note: adapted from https://github.com/rehypejs/rehype-minify/blob/main/packages/hast-util-to-string/index.js
  */
 
@@ -31,6 +33,9 @@ interface Options {
 }
 
 const STRIP_TAGS = ['script', 'style'];
+
+/** MDX/React components are capitalized; intrinsic HTML elements are lowercase. */
+const COMPONENT_TAG_RE = /^[A-Z]/;
 
 /** Valid JS identifier: starts with $, _, or a letter; followed by $, _, letters, digits, etc. */
 const JS_IDENTIFIER_RE = /^[$_\p{L}][$_\p{L}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\u200C\u200D]*$/u;
@@ -123,6 +128,14 @@ function one(node: Nodes, opts: Options) {
       }
       default:
         break;
+    }
+
+    // Custom components (e.g. `<Banner message="…" />`) aren't rendered in safeMode, so
+    // index their authored string props alongside any children, mirroring built-ins above.
+    if (COMPONENT_TAG_RE.test(node.tagName)) {
+      const propText = componentPropText(node);
+      const children = 'children' in node ? all(node, opts) : '';
+      return [propText, children].filter(Boolean).join(' ');
     }
   }
 

--- a/lib/utils/component-prop-text.ts
+++ b/lib/utils/component-prop-text.ts
@@ -1,0 +1,73 @@
+import type { ExpressionStatement, Program, SimpleLiteral, TemplateLiteral } from 'estree';
+
+import { CSS_STYLE_PROP_NAMES } from '../../utils/common-html-words';
+
+import { jsxAcornParser } from './jsx-acorn-parser';
+
+/**
+ * Value shapes that are styling/config rather than authored copy. Styling props are already
+ * skipped by name (see `CSS_STYLE_PROP_NAMES`); this catches custom-named props the name list
+ * can't know about, e.g. `buttonColor="#0B1440"` or `link="https://…"`.
+ */
+const CONFIG_VALUE_PATTERNS = [
+  /^#[0-9a-f]{3,8}$/i, // hex color
+  /^(?:rgb|rgba|hsl|hsla|var|calc|url)\(/i, // CSS function
+  /^-?\d*\.?\d+(?:px|em|rem|%|vh|vw|pt|fr|deg|s|ms)?$/i, // number / dimension
+  /^(?:https?:)?\/\//i, // URL
+  /^(?:true|false)$/i, // boolean
+];
+
+/**
+ * Text inside a JSX attribute expression that safeMode kept literal, e.g. `content={`Hi`}`.
+ * Only a static string or uninterpolated template literal returns text; `{true}`, `{5}`,
+ * `{user.name}`, interpolated templates, and JSX return undefined.
+ */
+function staticExpressionText(value: string): string | undefined {
+  if (!value.startsWith('{') || !value.endsWith('}')) return undefined;
+
+  let program: Program;
+  try {
+    program = jsxAcornParser.parse(value.slice(1, -1), {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    }) as unknown as Program;
+  } catch {
+    return undefined;
+  }
+
+  if (program.body.length !== 1 || program.body[0].type !== 'ExpressionStatement') return undefined;
+  const expr = (program.body[0] as ExpressionStatement).expression;
+
+  if (expr.type === 'Literal') {
+    return typeof (expr as SimpleLiteral).value === 'string' ? ((expr as SimpleLiteral).value as string) : undefined;
+  }
+  if (expr.type === 'TemplateLiteral' && (expr as TemplateLiteral).expressions.length === 0) {
+    return (expr as TemplateLiteral).quasis.map(quasi => quasi.value.cooked ?? quasi.value.raw).join('');
+  }
+  return undefined;
+}
+
+/** Authored copy from a single prop, or undefined when it's styling, config, or a non-static expression. */
+function propCopy(name: string, value: unknown): string | undefined {
+  if (typeof value !== 'string' || CSS_STYLE_PROP_NAMES.has(name)) return undefined;
+
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.startsWith('{')) return staticExpressionText(trimmed)?.trim() || undefined;
+  return CONFIG_VALUE_PATTERNS.some(re => re.test(trimmed)) ? undefined : trimmed;
+}
+
+/**
+ * Authored copy in a custom component's props, e.g. the `message` in `<Banner message="…" />` or
+ * `content={`…`}`. In safeMode the component never renders, so this text survives only on the
+ * node's props — without pulling it out here it's dropped from search. Mirrors how built-in
+ * components index their text props (a Callout's `title`) but not their styling config.
+ */
+export function componentPropText(node: { properties?: Record<string, unknown> | null }): string {
+  if (!node.properties) return '';
+
+  return Object.entries(node.properties)
+    .map(([name, value]) => propCopy(name, value))
+    .filter((copy): copy is string => Boolean(copy))
+    .join(' ');
+}

--- a/utils/common-html-words.ts
+++ b/utils/common-html-words.ts
@@ -45,6 +45,13 @@ export const REACT_HTML_PROP_BOUNDARIES = getWordBoundariesFromProps(reactHtmlAt
 export const CSS_STYLE_PROP_BOUNDARIES = getWordBoundariesFromProps(reactNativeStylingProps as string[]);
 
 /**
+ * Full CSS/styling prop names (e.g. `fontWeight`, `color`, `textAlign`). Used to skip
+ * styling props when extracting authored copy for search — their values (`bold`, `center`)
+ * are config, not content. Excludes web-only `content`, which is a real text prop.
+ */
+export const CSS_STYLE_PROP_NAMES = new Set<string>(reactNativeStylingProps as string[]);
+
+/**
  * Custom component prop word boundaries not in React HTML or CSS boundaries.
  */
 export const CUSTOM_PROP_BOUNDARIES = [


### PR DESCRIPTION
| 🎫 Resolve ISSUE_ID |
| :-----------------: |

## 🎯 What does this PR do?

<!-- What is the reason you did this PR? What does it accomplish? -->

- https://linear.app/readme-io/issue/RM-11201/need-to-index-props-in-readme-built-components-accordion-tab-cards#comment-1d082482

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ]

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
