### PR TITLE
feat(mdxish): render deprecated html tags instead of dropping them

### DIFF
--- a/__tests__/lib/mdxish/deprecated-html-tags.test.tsx
+++ b/__tests__/lib/mdxish/deprecated-html-tags.test.tsx
@@ -7,10 +7,23 @@ import React from 'react';
 import { compile, mdxish, renderMdxish, run } from '../../../lib';
 import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
 
-// Deprecated-but-still-rendered tags (`<center>`, `<font>`, `<big>`, …) are missing
-// from the `html-tags` package, so mdxish treated them as unknown components and
-// removed them from the tree — a `<center>` inside a `<Card>` emptied the whole card.
-// See CX-3699 and DEPRECATED_HTML_TAGS in utils/common-html-words.ts.
+// Samples of deprecated-but-still-rendered tags (`<center>`, `<font>`, `<big>`, …).
+// Mainly using center as an example because it's a commonly used deprecated tag.
+const SAMPLE_LEGACY_TAGS = [
+  'acronym',
+  'applet',
+  'basefont',
+  'big',
+  'center',
+  'dir',
+  'font',
+  'listing',
+  'marquee',
+  'noembed',
+  'rtc',
+  'strike',
+  'xmp',
+];
 const renderToDom = (md: string, components: CustomComponents = {}) => {
   const Content = renderMdxish(mdxish(md, { components }), { components }).default;
   return render(<Content />);
@@ -48,7 +61,11 @@ describe('deprecated html tags', () => {
       const { container } = renderToDom('> 📘 Note\n>\n> <center>**centered**</center>');
 
       const callout = container.querySelector('.callout');
-      expect(within(callout as HTMLElement).getByText('centered').closest('center')).toBeInTheDocument();
+      expect(
+        within(callout as HTMLElement)
+          .getByText('centered')
+          .closest('center'),
+      ).toBeInTheDocument();
     });
 
     it('renders a <center> inside a JSX <Callout> body', () => {
@@ -109,6 +126,23 @@ describe('deprecated html tags', () => {
   });
 
   describe('inside html trees', () => {
+    it.each(SAMPLE_LEGACY_TAGS)('keeps a <%s> instead of dropping it as an unknown component', tag => {
+      const tree = mdxish(`<div class="wrap"><${tag} title="t">kept</${tag}></div>`);
+
+      expect(findElementByTagName(tree, tag)).not.toBeNull();
+    });
+
+    // `param` is declared in HTML_VOID_ELEMENTS and repaired by closeSelfClosingHtmlTags,
+    // so dropping it as an unknown component contradicted the same module. (CX-3699)
+    it('keeps a void <param> inside an <object>', () => {
+      const tree = mdxish('<object data="movie.swf"><param name="quality" value="high" /></object>');
+
+      expect(findElementByTagName(tree, 'param')).toMatchObject({
+        tagName: 'param',
+        properties: { name: 'quality', value: 'high' },
+      });
+    });
+
     it('keeps a <center> nested in plain HTML wrappers', () => {
       const tree = mdxish('<div class="outer">\n  <section>\n    <center>**deep**</center>\n  </section>\n</div>');
 
@@ -151,7 +185,9 @@ describe('deprecated html tags', () => {
       const center = findElementByTagName(tree, 'center');
 
       expect(findElementByTagName(center!, 'a')).toMatchObject({ properties: { href: 'https://example.com' } });
-      expect(findElementByTagName(center!, 'img')).toMatchObject({ properties: { src: 'https://example.com/logo.png' } });
+      expect(findElementByTagName(center!, 'img')).toMatchObject({
+        properties: { src: 'https://example.com/logo.png' },
+      });
     });
 
     it('leaves deprecated tags inside code untouched', () => {

--- a/__tests__/lib/mdxish/deprecated-html-tags.test.tsx
+++ b/__tests__/lib/mdxish/deprecated-html-tags.test.tsx
@@ -1,0 +1,194 @@
+import type { CustomComponents } from '../../../types';
+
+import '@testing-library/jest-dom';
+import { render, within } from '@testing-library/react';
+import React from 'react';
+
+import { compile, mdxish, renderMdxish, run } from '../../../lib';
+import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
+
+// Deprecated-but-still-rendered tags (`<center>`, `<font>`, `<big>`, …) are missing
+// from the `html-tags` package, so mdxish treated them as unknown components and
+// removed them from the tree — a `<center>` inside a `<Card>` emptied the whole card.
+// See CX-3699 and DEPRECATED_HTML_TAGS in utils/common-html-words.ts.
+const renderToDom = (md: string, components: CustomComponents = {}) => {
+  const Content = renderMdxish(mdxish(md, { components }), { components }).default;
+  return render(<Content />);
+};
+
+const bannerComponent = run(
+  compile(`export const Banner = ({ children }) => <section className="banner">{children}</section>;
+
+<Banner />`),
+);
+
+describe('deprecated html tags', () => {
+  describe('inside ReadMe components', () => {
+    // The reported doc: every card rendered blank because its only child was a <center>.
+    it('renders a <center> inside each <Card> of a <Cards> grid', () => {
+      const { container } = renderToDom(`<Cards columns={3} align="center">
+<Card title="">
+<center>**Centralized Model Management and Visibility**</center>
+</Card>
+
+<Card title="">
+<center>**Precise Control Over Model Access**</center>
+</Card>
+</Cards>`);
+
+      const cards = container.querySelectorAll('.Card-content');
+      expect(cards).toHaveLength(2);
+      expect(Array.from(cards).map(card => card.innerHTML)).toStrictEqual([
+        '<center><strong>Centralized Model Management and Visibility</strong></center>',
+        '<center><strong>Precise Control Over Model Access</strong></center>',
+      ]);
+    });
+
+    it('renders a <center> inside a magic-block callout', () => {
+      const { container } = renderToDom('> 📘 Note\n>\n> <center>**centered**</center>');
+
+      const callout = container.querySelector('.callout');
+      expect(within(callout as HTMLElement).getByText('centered').closest('center')).toBeInTheDocument();
+    });
+
+    it('renders a <center> inside a JSX <Callout> body', () => {
+      const { container } = renderToDom(`<Callout icon="👍" theme="okay">
+  ## Nice
+
+  <center>**centered**</center>
+</Callout>`);
+
+      expect(container.querySelector('.callout center')).toHaveTextContent('centered');
+    });
+
+    it('renders deprecated tags inside markdown table cells', () => {
+      const { container } = renderToDom(`| Tag | Example |
+| --- | --- |
+| center | <center>**middle**</center> |
+| font | <font color="red">red</font> |`);
+
+      const cells = container.querySelectorAll('td');
+      expect(cells[1].innerHTML).toBe('<center><strong>middle</strong></center>');
+      expect(cells[3].innerHTML).toBe('<font color="red">red</font>');
+    });
+
+    it('renders a <center> inside an <HTMLBlock> payload', () => {
+      const { container } = renderToDom('<HTMLBlock>{`<center><b>raw html</b></center>`}</HTMLBlock>');
+
+      expect(container.querySelector('.rdmd-html')?.innerHTML).toBe('<center><b>raw html</b></center>');
+    });
+  });
+
+  describe('inside custom components', () => {
+    it('renders a <center> inside a custom component body', () => {
+      const { container } = renderToDom('<Banner>\n<center>**inside custom**</center>\n</Banner>', {
+        Banner: bannerComponent,
+      });
+
+      expect(container.querySelector('.banner')?.innerHTML).toBe('<center><strong>inside custom</strong></center>');
+    });
+
+    // Recognizing `center` as HTML must not steal a registered component of the same
+    // name: both spellings still resolve to it, as they did before.
+    it('lets a registered <Center> component keep precedence over the html tag', () => {
+      const centerComponent = run(
+        compile(`export const Center = ({ children }) => <div className="my-center">{children}</div>;
+
+<Center />`),
+      );
+      const { container } = renderToDom('<Center>hello</Center>\n\n<center>plain</center>', {
+        Center: centerComponent,
+      });
+
+      expect(Array.from(container.querySelectorAll('.my-center')).map(node => node.textContent)).toStrictEqual([
+        'hello',
+        'plain',
+      ]);
+      expect(container.querySelector('center')).toBeNull();
+    });
+  });
+
+  describe('inside html trees', () => {
+    it('keeps a <center> nested in plain HTML wrappers', () => {
+      const tree = mdxish('<div class="outer">\n  <section>\n    <center>**deep**</center>\n  </section>\n</div>');
+
+      expect(findElementByTagName(tree, 'center')).toMatchObject({
+        type: 'element',
+        tagName: 'center',
+        children: [{ type: 'element', tagName: 'strong', children: [{ type: 'text', value: 'deep' }] }],
+      });
+    });
+
+    it('keeps deprecated tags nested inside each other', () => {
+      const tree = mdxish('<center><font color="blue"><big>**stacked**</big></font></center>');
+
+      expect(findElementByTagName(tree, 'center')).toMatchObject({
+        tagName: 'center',
+        children: [
+          {
+            tagName: 'font',
+            properties: { color: 'blue' },
+            children: [{ tagName: 'big', children: [{ tagName: 'strong' }] }],
+          },
+        ],
+      });
+    });
+
+    it('keeps a <center> inside a list item and a blockquote', () => {
+      const listTree = mdxish('- <center>**item**</center>');
+      const quoteTree = mdxish('> <center>**quote**</center>');
+
+      expect(findElementByTagName(listTree, 'li')?.children).toContainEqual(
+        expect.objectContaining({ tagName: 'center' }),
+      );
+      expect(findElementByTagName(quoteTree, 'blockquote')?.children).toContainEqual(
+        expect.objectContaining({ tagName: 'center' }),
+      );
+    });
+
+    it('keeps a <center> that wraps a link and an image', () => {
+      const tree = mdxish('<center>[![logo](https://example.com/logo.png)](https://example.com)</center>');
+      const center = findElementByTagName(tree, 'center');
+
+      expect(findElementByTagName(center!, 'a')).toMatchObject({ properties: { href: 'https://example.com' } });
+      expect(findElementByTagName(center!, 'img')).toMatchObject({ properties: { src: 'https://example.com/logo.png' } });
+    });
+
+    it('leaves deprecated tags inside code untouched', () => {
+      const tree = mdxish('```html\n<center>code</center>\n```\n\n`<tt>inline</tt>`');
+
+      expect(findAllElementsByTagName(tree, 'center')).toHaveLength(0);
+      expect(findAllElementsByTagName(tree, 'tt')).toHaveLength(0);
+    });
+  });
+
+  describe('formatting variations', () => {
+    it.each([
+      ['condensed', '<center>**hi**</center>'],
+      ['padded by blank lines', '<center>\n\n**hi**\n\n</center>'],
+      ['split across lines', '<center>\n**hi**\n</center>'],
+      ['indented', '  <center>**hi**</center>'],
+      ['with whitespace in the closing tag', '<center>**hi**</ center >'],
+    ])('renders a centered bold string when %s', (_label, md) => {
+      const center = findElementByTagName(mdxish(md), 'center');
+
+      expect(center).not.toBeNull();
+      expect(findElementByTagName(center!, 'strong')).toMatchObject({ children: [{ type: 'text', value: 'hi' }] });
+    });
+  });
+
+  describe('engine parity', () => {
+    const renderThroughMdx = (md: string) => {
+      const Content = run(compile(md)).default;
+      return render(<Content />);
+    };
+
+    it.each([
+      ['a block-level <center>', '<center>hello **world**</center>'],
+      ['inline deprecated tags', 'a <big>big</big>, <strike>gone</strike>, <tt>mono</tt>'],
+      ['a <font> with attributes', 'text <font color="red">**red**</font> tail'],
+    ])('matches the mdx engine for %s', (_label, md) => {
+      expect(renderToDom(md).container.innerHTML).toBe(renderThroughMdx(md).container.innerHTML);
+    });
+  });
+});

--- a/__tests__/lib/mdxish/deprecated-html-tags.test.tsx
+++ b/__tests__/lib/mdxish/deprecated-html-tags.test.tsx
@@ -11,6 +11,7 @@ import { findAllElementsByTagName, findElementByTagName } from '../../helpers';
 // Mainly using center as an example because it's a commonly used deprecated tag.
 const SAMPLE_LEGACY_TAGS = [
   'acronym',
+  'blink',
   'applet',
   'basefont',
   'big',

--- a/__tests__/regression/__snapshots__/equivalence.test.ts.snap
+++ b/__tests__/regression/__snapshots__/equivalence.test.ts.snap
@@ -142,6 +142,97 @@ exports[`MDX↔MDXish equivalence > convergent 1`] = `
 }
 `;
 
+exports[`MDX↔MDXish equivalence > deprecated-html-tags 1`] = `
+{
+  "changes": [
+    {
+      "attrName": "class",
+      "kind": "attr",
+      "left": "CardsGrid",
+      "path": "/div[1]",
+      "right": "readme-tailwind",
+      "severity": "structural",
+    },
+    {
+      "attrName": "style",
+      "kind": "attr",
+      "left": "--CardsGrid-cardWidth:200px;--CardsGrid-columns:3",
+      "path": "/div[1]",
+      "right": null,
+      "severity": "structural",
+    },
+    {
+      "attrName": "class",
+      "kind": "attr",
+      "left": "Card Card_card",
+      "path": "/div[1]/div[0]",
+      "right": "CardsGrid",
+      "severity": "structural",
+    },
+    {
+      "attrName": "style",
+      "kind": "attr",
+      "left": null,
+      "path": "/div[1]/div[0]",
+      "right": "--CardsGrid-cardWidth:200px;--CardsGrid-columns:3",
+      "severity": "structural",
+    },
+    {
+      "attrName": "class",
+      "kind": "attr",
+      "left": "Card-content",
+      "path": "/div[1]/div[0]/div[0]",
+      "right": "Card Card_card",
+      "severity": "structural",
+    },
+    {
+      "kind": "tag",
+      "left": "center",
+      "path": "/div[1]/div[0]/div[0]/center[0]",
+      "right": "div",
+      "severity": "structural",
+    },
+    {
+      "kind": "extra",
+      "left": null,
+      "path": "/div[1]/div[0]/div[1]",
+      "right": "<div class="Card Card_card">…(1 children)…</div>",
+      "severity": "structural",
+    },
+    {
+      "kind": "extra",
+      "left": null,
+      "path": "/div[1]/div[0]/div[2]",
+      "right": "<div class="Card Card_card">…(1 children)…</div>",
+      "severity": "structural",
+    },
+    {
+      "kind": "missing",
+      "left": "<div class="Card Card_card">…(1 children)…</div>",
+      "path": "/div[1]/div[1]",
+      "right": null,
+      "severity": "structural",
+    },
+    {
+      "kind": "missing",
+      "left": "<div class="Card Card_card">…(1 children)…</div>",
+      "path": "/div[1]/div[2]",
+      "right": null,
+      "severity": "structural",
+    },
+    {
+      "kind": "extra",
+      "left": null,
+      "path": "/p[3]/br[5]",
+      "right": "<br>",
+      "severity": "structural",
+    },
+  ],
+  "severity": "structural",
+  "status": "differ",
+}
+`;
+
 exports[`MDX↔MDXish equivalence > divergent 1`] = `
 {
   "status": "match",

--- a/__tests__/regression/__snapshots__/equivalence.test.ts.snap
+++ b/__tests__/regression/__snapshots__/equivalence.test.ts.snap
@@ -227,6 +227,13 @@ exports[`MDX↔MDXish equivalence > deprecated-html-tags 1`] = `
       "right": "<br>",
       "severity": "structural",
     },
+    {
+      "kind": "tag",
+      "left": "object",
+      "path": "/object[6]",
+      "right": "p",
+      "severity": "structural",
+    },
   ],
   "severity": "structural",
   "status": "differ",

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -84,6 +84,7 @@ exports[`Render engine regressions tests > deprecated-html-tags (mdx) 1`] = `
 <strike>gone</strike>, <tt>mono</tt>, <acronym title="HyperText Markup Language">HTML</acronym>.</p>
 <div class="rdmd-table"><div class="rdmd-table-inner"><table><thead><tr><th>Tag</th><th>Example</th></tr></thead><tbody><tr><td>center</td><td><center><strong>middle</strong></center></td></tr><tr><td>font</td><td><font color="blue">blue</font></td></tr></tbody></table></div></div>
 <div class="outer"><center><big><strong>nested inside plain HTML</strong></big></center></div>
+<object data="movie.swf"><param name="quality" value="high"/></object>
 <blockquote class="callout callout_info" theme="📘"><span class="callout-icon">📘</span><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="callout"></div><div class="heading-text">Callout</div><a aria-label="Skip link to Callout" class="heading-anchor-icon fa fa-regular fa-anchor" href="#callout"></a></h3><center><strong>centered in a callout</strong></center></blockquote>"
 `;
 
@@ -115,6 +116,7 @@ exports[`Render engine regressions tests > deprecated-html-tags (mdxish) 1`] = `
 
 <div class="rdmd-table"><div class="rdmd-table-inner"><table><thead><tr><th>Tag</th><th>Example</th></tr></thead><tbody><tr><td>center</td><td><center><strong>middle</strong></center></td></tr><tr><td>font</td><td><font color="blue">blue</font></td></tr></tbody></table></div></div>
 <div class="outer"><center><big><strong>nested inside plain HTML</strong></big></center></div>
+<p><object data="movie.swf"><param name="quality" value="high"/></object></p>
 <blockquote class="callout callout_info" theme="📘"><span class="callout-icon">📘</span><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="callout"></div><div class="heading-text">Callout</div><a aria-label="Skip link to Callout" class="heading-anchor-icon fa fa-regular fa-anchor" href="#callout"></a></h3><center><strong>centered in a callout</strong></center></blockquote>"
 `;
 

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -76,6 +76,48 @@ exports[`Render engine regressions tests > convergent (mdxish) 1`] = `
 <p>Both engines should render this identically.</p>"
 `;
 
+exports[`Render engine regressions tests > deprecated-html-tags (mdx) 1`] = `
+"<h1 class="heading heading-1 header-scroll"><div class="heading-anchor anchor waypoint" id="deprecated-html-tags"></div><div class="heading-text">Deprecated HTML tags</div><a aria-label="Skip link to Deprecated HTML tags" class="heading-anchor-icon fa fa-regular fa-anchor" href="#deprecated-html-tags"></a></h1>
+<div class="CardsGrid" style="--CardsGrid-cardWidth:200px;--CardsGrid-columns:3"><div class="Card Card_card"><div class="Card-content"><center><strong>Centralized Model Management and Visibility</strong></center></div></div><div class="Card Card_card"><div class="Card-content"><center><strong>Precise Control Over Model Access</strong></center></div></div><div class="Card Card_card"><div class="Card-content"><center><strong>Unified Security and Permissions in the JFrog Platform</strong></center></div></div></div>
+<center><h2 class="heading heading-2 header-scroll"><div class="heading-anchor anchor waypoint" id="a-blank-line-separated-island-inside-a-center"></div><div class="heading-text">A blank-line separated island inside a <code class="rdmd-code lang-undefined theme-undefined">&lt;center&gt;</code></div><a aria-label="Skip link to A blank-line separated island inside a ,[object Object]" class="heading-anchor-icon fa fa-regular fa-anchor" href="#a-blank-line-separated-island-inside-a-center"></a></h2><p><a href="https://example.com" target="" title=""><span aria-label="Expand image" class="img lightbox closed" role="button" tabindex="0"><span class="lightbox-inner"><img alt="logo" class="img  " height="auto" loading="lazy" src="https://example.com/logo.png" title="" width="auto"/></span></span></a></p></center>
+<p>Inline legacy formatting: <font color="red" size="4"><strong>red</strong></font>, <big>big</big>,
+<strike>gone</strike>, <tt>mono</tt>, <acronym title="HyperText Markup Language">HTML</acronym>.</p>
+<div class="rdmd-table"><div class="rdmd-table-inner"><table><thead><tr><th>Tag</th><th>Example</th></tr></thead><tbody><tr><td>center</td><td><center><strong>middle</strong></center></td></tr><tr><td>font</td><td><font color="blue">blue</font></td></tr></tbody></table></div></div>
+<div class="outer"><center><big><strong>nested inside plain HTML</strong></big></center></div>
+<blockquote class="callout callout_info" theme="📘"><span class="callout-icon">📘</span><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="callout"></div><div class="heading-text">Callout</div><a aria-label="Skip link to Callout" class="heading-anchor-icon fa fa-regular fa-anchor" href="#callout"></a></h3><center><strong>centered in a callout</strong></center></blockquote>"
+`;
+
+exports[`Render engine regressions tests > deprecated-html-tags (mdxish) 1`] = `
+"<h1 class="heading heading-1 header-scroll"><div class="heading-anchor anchor waypoint" id="deprecated-html-tags"></div><div class="heading-text">Deprecated HTML tags</div><a aria-label="Skip link to Deprecated HTML tags" class="heading-anchor-icon fa fa-regular fa-anchor" href="#deprecated-html-tags"></a></h1>
+<div class="readme-tailwind"><div class="CardsGrid" style="--CardsGrid-cardWidth:200px;--CardsGrid-columns:3"><div class="Card Card_card"><div class="Card-content"><center><strong>Centralized Model Management and Visibility</strong></center></div></div><div class="Card Card_card"><div class="Card-content"><center><strong>Precise Control Over Model Access</strong></center></div></div><div class="Card Card_card"><div class="Card-content"><center><strong>Unified Security and Permissions in the JFrog Platform</strong></center></div></div></div></div>
+<center>
+<h2 class="heading heading-2 header-scroll"><div class="heading-anchor anchor waypoint" id="a-blank-line-separated-island-inside-a-center"></div><div class="heading-text">A blank-line separated island inside a <code class="rdmd-code lang-undefined theme-undefined">&lt;center&gt;</code></div><a aria-label="Skip link to A blank-line separated island inside a ,[object Object]" class="heading-anchor-icon fa fa-regular fa-anchor" href="#a-blank-line-separated-island-inside-a-center"></a></h2>
+<p><a href="https://example.com" target="" title=""><span aria-label="Expand image" class="img lightbox closed" role="button" tabindex="0"><span class="lightbox-inner"><img alt="logo" class="img  " height="auto" loading="lazy" src="https://example.com/logo.png" title="" width="auto"/></span></span></a></p>
+</center>
+<p>Inline legacy formatting: <font color="red" size="4"><strong>red</strong></font>, <big>big</big>,<br/>
+<strike>gone</strike>, <tt>mono</tt>, <acronym title="HyperText Markup Language">HTML</acronym>.</p>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div class="rdmd-table"><div class="rdmd-table-inner"><table><thead><tr><th>Tag</th><th>Example</th></tr></thead><tbody><tr><td>center</td><td><center><strong>middle</strong></center></td></tr><tr><td>font</td><td><font color="blue">blue</font></td></tr></tbody></table></div></div>
+<div class="outer"><center><big><strong>nested inside plain HTML</strong></big></center></div>
+<blockquote class="callout callout_info" theme="📘"><span class="callout-icon">📘</span><h3 class="heading heading-3 header-scroll"><div class="heading-anchor anchor waypoint" id="callout"></div><div class="heading-text">Callout</div><a aria-label="Skip link to Callout" class="heading-anchor-icon fa fa-regular fa-anchor" href="#callout"></a></h3><center><strong>centered in a callout</strong></center></blockquote>"
+`;
+
 exports[`Render engine regressions tests > divergent (mdx) 1`] = `
 "<pre class="html-unsafe"><code>&lt;div class=&quot;example&quot;&gt;Hello&lt;/div&gt;</code></pre>
 <p>Some prose after the HTML block.</p>"

--- a/__tests__/regression/fixtures/README.md
+++ b/__tests__/regression/fixtures/README.md
@@ -35,6 +35,7 @@ __tests__/regression/fixtures/
 ├── compact-headings/           ← #Heading-without-space migration coverage
 ├── htmlblock-with-script/      ← <HTMLBlock> static-content parse path
 ├── style-and-jsx-expressions/  ← <style>{`...`}</style>, style={{}}, nested .map() JSX, invalid HTML nesting
+├── deprecated-html-tags/       ← <center>, <font>, <big>… kept instead of dropped as unknown components
 │
 │  ── Table regression fixtures ──
 ├── jsx-table-multiline-cells/  ← blank-line paragraphs preserved in a <Table> cell

--- a/__tests__/regression/fixtures/deprecated-html-tags/README.md
+++ b/__tests__/regression/fixtures/deprecated-html-tags/README.md
@@ -1,0 +1,37 @@
+# `deprecated-html-tags` Fixture
+
+Legacy HTML tags that the `html-tags` package omits — `<center>`, `<font>`,
+`<big>`, `<strike>`, `<tt>`, `<acronym>` — authored across the shapes a real doc
+uses them in: inside `<Card>` bodies, around a blank-line separated markdown
+island, inline in a paragraph, in markdown table cells, nested inside plain HTML,
+and inside a callout.
+
+## Source bugs
+
+- **CX-3699** — `<center>` inside a card body rendered a blank card. MDXish
+  builds its "is this HTML or a custom component?" check from `html-tags`, which
+  excludes deprecated tags, so `<center>` was treated as an unknown component
+  `Center` and removed from the tree by `rehypeMdxishComponents` — taking the
+  card's only child with it. The card body opening is the customer's own doc
+  from the ticket.
+
+## What it proves
+
+- Every deprecated tag survives the tree as a real element with its attributes
+  (`<font color size>`, `<acronym title>`) and its markdown children parsed
+  (`**bold**` → `<strong>`), in both engines.
+- The three `<Card>` bodies render their centered headings instead of collapsing
+  to empty `Card-content` divs.
+- Blank-line islands, table cells, and plain-HTML nesting keep the tag rather
+  than dropping the subtree.
+
+Suite B reports `differ`, but every change is a known engine difference
+unrelated to these tags: MDXish wraps `<Cards>` in `<div
+class="readme-tailwind">` (shifting the card paths) and turns the soft line
+break in the inline-formatting paragraph into a `<br>`.
+
+## What flips this fixture
+
+`DEPRECATED_HTML_TAGS` / `STANDARD_HTML_TAGS` in `utils/common-html-words.ts`,
+the unknown-component removal in `processor/plugin/mdxish-components.ts`, or the
+tag-name normalization in `normalize-mdx-jsx-nodes.ts`.

--- a/__tests__/regression/fixtures/deprecated-html-tags/README.md
+++ b/__tests__/regression/fixtures/deprecated-html-tags/README.md
@@ -1,19 +1,23 @@
 # `deprecated-html-tags` Fixture
 
 Legacy HTML tags that the `html-tags` package omits — `<center>`, `<font>`,
-`<big>`, `<strike>`, `<tt>`, `<acronym>` — authored across the shapes a real doc
-uses them in: inside `<Card>` bodies, around a blank-line separated markdown
-island, inline in a paragraph, in markdown table cells, nested inside plain HTML,
-and inside a callout.
+`<big>`, `<strike>`, `<tt>`, `<acronym>`, `<param>` — authored across the shapes
+a real doc uses them in: inside `<Card>` bodies, around a blank-line separated
+markdown island, inline in a paragraph, in markdown table cells, nested inside
+plain HTML, and inside a callout.
 
 ## Source bugs
 
 - **CX-3699** — `<center>` inside a card body rendered a blank card. MDXish
-  builds its "is this HTML or a custom component?" check from `html-tags`, which
-  excludes deprecated tags, so `<center>` was treated as an unknown component
-  `Center` and removed from the tree by `rehypeMdxishComponents` — taking the
-  card's only child with it. The card body opening is the customer's own doc
-  from the ticket.
+  built its "is this HTML or a custom component?" check from `html-tags` alone,
+  which excludes deprecated tags, so `<center>` was treated as an unknown
+  component `Center` and removed from the tree by `rehypeMdxishComponents` —
+  taking the card's only child with it. The card body opening is the customer's
+  own doc from the ticket. `STANDARD_HTML_TAGS` now unions `html-tags` with
+  parse5's `TAG_NAMES` (the set our own raw-HTML parser recognizes), so the whole
+  legacy family is covered rather than a hand-picked few — `<param>` is here
+  because it was dropped despite already being declared in `HTML_VOID_ELEMENTS`
+  in the same module.
 
 ## What it proves
 
@@ -27,11 +31,14 @@ and inside a callout.
 
 Suite B reports `differ`, but every change is a known engine difference
 unrelated to these tags: MDXish wraps `<Cards>` in `<div
-class="readme-tailwind">` (shifting the card paths) and turns the soft line
-break in the inline-formatting paragraph into a `<br>`.
+class="readme-tailwind">` (shifting the card paths), turns the soft line break in
+the inline-formatting paragraph into a `<br>`, and wraps the single-line
+`<object>` in a `<p>`. The `<param>` inside it survives in both engines, which is
+what this fixture is pinning.
 
 ## What flips this fixture
 
-`DEPRECATED_HTML_TAGS` / `STANDARD_HTML_TAGS` in `utils/common-html-words.ts`,
-the unknown-component removal in `processor/plugin/mdxish-components.ts`, or the
-tag-name normalization in `normalize-mdx-jsx-nodes.ts`.
+`STANDARD_HTML_TAGS` / `PARSE5_NON_HTML_TAG_NAMES` in
+`utils/common-html-words.ts`, the unknown-component removal in
+`processor/plugin/mdxish-components.ts`, or the tag-name normalization in
+`normalize-mdx-jsx-nodes.ts`.

--- a/__tests__/regression/fixtures/deprecated-html-tags/body.md
+++ b/__tests__/regression/fixtures/deprecated-html-tags/body.md
@@ -34,6 +34,8 @@ Inline legacy formatting: <font color="red" size="4">**red**</font>, <big>big</b
   <center><big>**nested inside plain HTML**</big></center>
 </div>
 
+<object data="movie.swf"><param name="quality" value="high" /></object>
+
 > 📘 Callout
 >
 > <center>**centered in a callout**</center>

--- a/__tests__/regression/fixtures/deprecated-html-tags/body.md
+++ b/__tests__/regression/fixtures/deprecated-html-tags/body.md
@@ -1,0 +1,39 @@
+# Deprecated HTML tags
+
+<Cards columns={3} align="center">
+<Card title="">
+<center>**Centralized Model Management and Visibility**</center>
+</Card>
+
+<Card title="">
+<center>**Precise Control Over Model Access**</center>
+</Card>
+
+<Card title="">
+<center>**Unified Security and Permissions in the JFrog Platform**</center>
+</Card>
+</Cards>
+
+<center>
+
+## A blank-line separated island inside a `<center>`
+
+[![logo](https://example.com/logo.png)](https://example.com)
+
+</center>
+
+Inline legacy formatting: <font color="red" size="4">**red**</font>, <big>big</big>,
+<strike>gone</strike>, <tt>mono</tt>, <acronym title="HyperText Markup Language">HTML</acronym>.
+
+| Tag | Example |
+| --- | --- |
+| center | <center>**middle**</center> |
+| font | <font color="blue">blue</font> |
+
+<div class="outer">
+  <center><big>**nested inside plain HTML**</big></center>
+</div>
+
+> 📘 Callout
+>
+> <center>**centered in a callout**</center>

--- a/__tests__/regression/fixtures/deprecated-html-tags/context.json
+++ b/__tests__/regression/fixtures/deprecated-html-tags/context.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "defaults": [],
+    "user": {}
+  },
+  "glossary": []
+}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "micromark-util-html-tag-name": "^2.0.1",
     "micromark-util-subtokenize": "2.0.4",
     "micromark-util-symbol": "^2.0.1",
+    "parse5": "^7.3.0",
     "path-browserify": "^1.0.1",
     "postcss": "^8.5.1",
     "postcss-prefix-selector": "^2.1.0",

--- a/utils/common-html-words.ts
+++ b/utils/common-html-words.ts
@@ -1,4 +1,5 @@
 import htmlTags from 'html-tags';
+import { html as parse5Html } from 'parse5';
 import reactHtmlAttributes from 'react-html-attributes';
 import { allProps as reactNativeStylingProps } from 'react-native-known-styling-properties';
 
@@ -87,28 +88,43 @@ export const CUSTOM_PROP_BOUNDARIES = [
 export const RUNTIME_COMPONENT_TAGS = new Set(['Variable', 'variable', 'html-block', 'rdme-pin']);
 
 /**
- * Deprecated tags the `html-tags` package omits. Browsers (and the MDX engine)
- * still render them, so mdxish must not mistake them for unknown components and
- * drop them from the tree (CX-3699).
+ * Elements that are not actually standard HTML tags, or those that we intentionally
+ * don't want to treat as one & is mute to check with. These include:
+ * - SVG/MathML descendants
+ * - Namespaced foreign content
+ * - `image`, which the HTML tree builder rewrites to `img`
+ * Most of these are bundled in parse5's `TAG_NAMES` set, but we can also add a few more.
  */
-export const DEPRECATED_HTML_TAGS = new Set([
-  'acronym',
-  'big',
-  'blink',
-  'center',
-  'dir',
-  'font',
-  'marquee',
-  'nobr',
-  'strike',
-  'tt',
+const NON_STANDARD_TAGS = new Set<string>([
+  'annotation-xml',
+  'desc',
+  'foreignObject',
+  'image',
+  'malignmark',
+  'mglyph',
+  'mi',
+  'mn',
+  'mo',
+  'ms',
+  'mtext',
 ]);
 
 /**
- * Standard HTML tags that should never be treated as custom components.
- * Uses the html-tags package plus the deprecated tags it omits.
+ * Standard HTML tags list.
+ * A use case of this is to differentiate custom components tag vs standard HTML tags.
+ * 
+ * Unioned from:
+ * - `html-tags`: All modern spec HTML elements
+ * - parse5's `TAG_NAMES`: Elements the HTML tree-construction algorithm has to special-case
+ *   This includes obsolete tags that are still rendered by browsers.
+ * - NON_STANDARD_TAGS: We've had to filter because currently parse5's `TAG_NAMES` set over-enumerates 
+ *   tags that are not actually standard HTML tags. It also allows custom tags to be filtered out.
  */
-export const STANDARD_HTML_TAGS: Set<string> = new Set([...htmlTags, ...DEPRECATED_HTML_TAGS]);
+export const STANDARD_HTML_TAGS: Set<string> = new Set([
+  ...htmlTags,
+  ...Object.values(parse5Html.TAG_NAMES),
+  'acronym',  // Obselete tag not included either of the above sources.
+].filter(tag => !NON_STANDARD_TAGS.has(tag)));
 
 /**
  * Table structural tags. Blank lines inside these carry deliberate meaning for

--- a/utils/common-html-words.ts
+++ b/utils/common-html-words.ts
@@ -123,7 +123,8 @@ const NON_STANDARD_TAGS = new Set<string>([
 export const STANDARD_HTML_TAGS: Set<string> = new Set([
   ...htmlTags,
   ...Object.values(parse5Html.TAG_NAMES),
-  'acronym',  // Obselete tag not included either of the above sources.
+  'acronym',  // Obselete tag not included either of the above sources. Add here if we have missed any.
+  'blink',
 ].filter(tag => !NON_STANDARD_TAGS.has(tag)));
 
 /**

--- a/utils/common-html-words.ts
+++ b/utils/common-html-words.ts
@@ -87,10 +87,28 @@ export const CUSTOM_PROP_BOUNDARIES = [
 export const RUNTIME_COMPONENT_TAGS = new Set(['Variable', 'variable', 'html-block', 'rdme-pin']);
 
 /**
- * Standard HTML tags that should never be treated as custom components.
- * Uses the html-tags package, converted to a Set<string> for efficient lookups.
+ * Deprecated tags the `html-tags` package omits. Browsers (and the MDX engine)
+ * still render them, so mdxish must not mistake them for unknown components and
+ * drop them from the tree (CX-3699).
  */
-export const STANDARD_HTML_TAGS = new Set(htmlTags) as Set<string>;
+export const DEPRECATED_HTML_TAGS = new Set([
+  'acronym',
+  'big',
+  'blink',
+  'center',
+  'dir',
+  'font',
+  'marquee',
+  'nobr',
+  'strike',
+  'tt',
+]);
+
+/**
+ * Standard HTML tags that should never be treated as custom components.
+ * Uses the html-tags package plus the deprecated tags it omits.
+ */
+export const STANDARD_HTML_TAGS: Set<string> = new Set([...htmlTags, ...DEPRECATED_HTML_TAGS]);
 
 /**
  * Table structural tags. Blank lines inside these carry deliberate meaning for


### PR DESCRIPTION
| 🎫 Resolve CX-3699 |
| :----------------: |

## 🎯 What does this PR do?

- Problem: MDXish built its "HTML tag vs. custom component" check from the `html-tags` package, which doesn't include deprecated tags. So `<center>` looked like an unknown component `Center` and `rehypeMdxishComponents` deleted it, emptying any card whose only child was a `<center>`.
- Adds deprecated HTML tags (not only `<center>`) as part of the STANDARD_HTML_TAGS list so they get recognised, don't get dropped and actually render in components. We use the parse5 library which provides these deprecated tags
- This would mean deprecated tags would get rendered more often in docs, matching more of the MDX behaviour

## 🧪 QA tips

- [ ] The reported doc renders three filled cards instead of three blank ones:

  ```md
  <Cards columns={3} align="center">
  <Card title="">
  <center>**Centralized Model Management and Visibility**</center>
  </Card>
  </Cards>
  ```

- [ ] Other legacy tags render inline with their attributes and markdown children:

  ```md
  Inline legacy formatting: <font color="red">**red**</font>, <big>big</big>, <strike>gone</strike>, <tt>mono</tt>.
  ```

- [ ] Nesting, tables and blank-line islands keep the tag:

  ```md
  | Tag | Example |
  | --- | --- |
  | center | <center>**middle**</center> |

  <center>

  ## Centered heading

  </center>
  ```

- [ ] A registered `Center` component still wins over the HTML tag (unchanged behavior).

## 📸 Screenshot or Loom

| before | after |
| ------ | ----- |
|   <img width="1085" height="356" alt="Screenshot 2026-08-25 at 3 16 32 pm" src="https://github.com/user-attachments/assets/fd32c858-e9ed-45c0-9b84-6533fc1b435e" />     |    <img width="1082" height="358" alt="Screenshot 2026-08-25 at 3 17 09 pm" src="https://github.com/user-attachments/assets/63424b2e-b37b-4b44-baaa-bc5191d63e39" />   |