### PR TITLE
feat(tabs): restart GIF playback when a tab is selected

### DIFF
--- a/__tests__/components/Tabs.test.tsx
+++ b/__tests__/components/Tabs.test.tsx
@@ -129,6 +129,47 @@ describe('Tabs', () => {
       expect(container.querySelector('a')).toHaveTextContent('link');
     });
 
+    it('restarts GIF playback when a tab becomes active', () => {
+      const md = `
+<Tabs>
+  <Tab title="First">First tab content</Tab>
+  <Tab title="Second">![demo](https://example.com/demo.gif)</Tab>
+</Tabs>
+`;
+      const Component = renderContent(md);
+      const { container } = render(<Component />);
+
+      const gif = container.querySelector('img[src$=".gif"]') as HTMLImageElement;
+      expect(gif).toBeInTheDocument();
+      const setSrc = vi.spyOn(gif, 'src', 'set');
+
+      fireEvent.click(container.querySelectorAll('.TabGroup-nav button')[1]);
+
+      // Cleared then restored: the only way to rewind an animated image to frame 0
+      expect(setSrc.mock.calls.map(([value]) => value)).toStrictEqual(['', 'https://example.com/demo.gif']);
+      expect(gif.src).toBe('https://example.com/demo.gif');
+      setSrc.mockRestore();
+    });
+
+    it('leaves non-animated images alone when a tab becomes active', () => {
+      const md = `
+<Tabs>
+  <Tab title="First">First tab content</Tab>
+  <Tab title="Second">![still](https://example.com/still.png)</Tab>
+</Tabs>
+`;
+      const Component = renderContent(md);
+      const { container } = render(<Component />);
+
+      const png = container.querySelector('img[src$=".png"]') as HTMLImageElement;
+      const setSrc = vi.spyOn(png, 'src', 'set');
+
+      fireEvent.click(container.querySelectorAll('.TabGroup-nav button')[1]);
+
+      expect(setSrc).not.toHaveBeenCalled();
+      setSrc.mockRestore();
+    });
+
     it('renders Tabs after sibling content without crashing', () => {
       const md = `
 Hello

--- a/__tests__/lib/mdxish/utils/mdxish-expression.test.ts
+++ b/__tests__/lib/mdxish/utils/mdxish-expression.test.ts
@@ -1,0 +1,32 @@
+import { jsxComponentNames } from '../../../../lib/utils/mdxish/mdxish-expression';
+
+describe('jsxComponentNames', () => {
+  it.each([
+    ['a bare tag', '<Foo />', ['Foo']],
+    ['a tag with children', '<Foo>bar</Foo>', ['Foo']],
+    ['nested tags', '<Foo><Bar /></Foo>', ['Foo', 'Bar']],
+    ['tags in both branches of a ternary', 'ok ? <Foo /> : <Bar />', ['Foo', 'Bar']],
+    ['tags returned from a callback', '[1, 2].map(i => <Foo key={i} />)', ['Foo']],
+    ['a tag inside a fragment', '<><Foo /></>', ['Foo']],
+    ['a tag in an attribute value', '<Foo bar={<Baz />} />', ['Foo', 'Baz']],
+    ['a member expression tag', '<Foo.Bar />', ['Foo']],
+    ['a namespaced tag, through its namespace', '<Foo:Bar />', ['Foo']],
+  ])('should collect %s', (_label, expression, expected) => {
+    expect(jsxComponentNames(expression)).toStrictEqual(expected);
+  });
+
+  it('should report each name once', () => {
+    expect(jsxComponentNames('<Foo><Foo /></Foo>')).toStrictEqual(['Foo']);
+  });
+
+  it.each([
+    ['an expression with no JSX', 'Math.max(1, 2)'],
+    ['a capitalized right operand of a comparison', 'count < Max ? 1 : 2'],
+    ['a capitalized identifier outside tag position', 'Foo.bar(Baz)'],
+    ['a lowercase tag, which compiles to a string type', '<div><span /></div>'],
+    ['an unparseable expression', '<Foo'],
+    ['a lowercase namespaced tag', '<foo:Bar />'],
+  ])('should collect nothing from %s', (_label, expression) => {
+    expect(jsxComponentNames(expression)).toStrictEqual([]);
+  });
+});

--- a/__tests__/transformers/evaluate-expressions.test.ts
+++ b/__tests__/transformers/evaluate-expressions.test.ts
@@ -132,6 +132,39 @@ describe('evaluateExpressions', () => {
       ]);
     });
 
+    it('should keep the blocks around a multiline expression intact', () => {
+      const tree = mdxish(['# Title', '', '{true', '  ? <Callout theme="info">inside</Callout>', '  : null}', '', '## After'].join('\n'));
+
+      expect(tree.children.filter(child => child.type === 'element')).toMatchObject([
+        { tagName: 'h1', children: [{ type: 'text', value: 'Title' }] },
+        { tagName: 'Callout', properties: { theme: 'info' } },
+        { tagName: 'h2', children: [{ type: 'text', value: 'After' }] },
+      ]);
+    });
+
+    it('should evaluate a multiline expression inside a list item', () => {
+      const tree = mdxish(['- one', '- {true', '  ? <Callout theme="info">inside</Callout>', '  : null}', '- three'].join('\n'));
+
+      const items = findAllElementsByTagName(tree, 'li');
+      expect(items).toHaveLength(3);
+      expect(items[1].children.filter(child => child.type === 'element')).toMatchObject([
+        { tagName: 'Callout', properties: { theme: 'info' } },
+      ]);
+    });
+
+    it('should keep a failed multiline expression literal without breaking the blocks around it', () => {
+      const tree = mdxish(['Before', '', '{nope', '  ? <Callout theme="info">inside</Callout>', '  : null}', '', 'After'].join('\n'));
+
+      const paragraphs = tree.children.filter(child => child.type === 'element');
+      expect(paragraphs).toMatchObject([
+        { tagName: 'p', children: [{ type: 'text', value: 'Before' }] },
+        { tagName: 'p' },
+        { tagName: 'p', children: [{ type: 'text', value: 'After' }] },
+      ]);
+      // The whole run stays as one literal block rather than half-evaluating into the document.
+      expect(findElementByTagName(tree, 'Callout')).toBeNull();
+    });
+
     it('should lift a block-level result out of the paragraph it was parsed in', () => {
       // `<p>` holds phrasing content only, so a browser closes it before the `<div>` a component
       // renders. Leaving the wrapper in place reparents the DOM and breaks hydration.

--- a/__tests__/transformers/evaluate-expressions.test.ts
+++ b/__tests__/transformers/evaluate-expressions.test.ts
@@ -150,6 +150,16 @@ describe('evaluateExpressions', () => {
       expect(html).toContain('Anon!');
     });
 
+    it('should resolve a component whose registered key differs only in casing', () => {
+      // `getComponentName` matches case-insensitively, so `<MyComponent/>` finds `mycomponent`
+      // as a plain tag; an expression has to reach the same component.
+      const Block = () => React.createElement('span', { className: 'custom-block' }, 'custom');
+      const html = mix('{<MyComponent />}', { components: { mycomponent: asModule(Block) } });
+
+      expect(html).toContain('custom-block');
+      expect(html).not.toContain('{<MyComponent />}');
+    });
+
     it('should ignore component names that are not valid JS identifiers', () => {
       // Every scope key becomes a `new Function` parameter, so an unbindable name must be
       // skipped rather than turned into a syntax error for every expression on the page.

--- a/__tests__/transformers/evaluate-expressions.test.ts
+++ b/__tests__/transformers/evaluate-expressions.test.ts
@@ -1,3 +1,7 @@
+import type { RMDXModule } from '../../types';
+
+import React from 'react';
+
 import { mix } from '../../lib';
 
 describe('evaluateExpressions', () => {
@@ -69,5 +73,73 @@ describe('evaluateExpressions', () => {
     const content = 'Hello {nonexistent}!';
     const html = mix(content);
     expect(html).toContain('{nonexistent}');
+  });
+
+  describe('component and variable scope', () => {
+    const asModule = (Component: React.ComponentType): RMDXModule =>
+      ({ default: Component, Toc: null, toc: [] }) as unknown as RMDXModule;
+
+    const variables = { user: { name: 'Dee', apps: [{ client_id: '1', name: 'Widgets' }] }, defaults: [] };
+
+    it('should render a built-in component referenced inside an expression', () => {
+      const html = mix('{true ? <Callout theme="info">yes</Callout> : null}');
+
+      expect(html).toContain('callout_info');
+      expect(html).toContain('yes');
+      expect(html).not.toContain('{true ?');
+    });
+
+    it('should render components returned from an iterator', () => {
+      const html = mix('{[1, 2].map(i => <Callout theme="info" key={i}>{i}</Callout>)}');
+
+      expect(html.match(/callout_info/g)).toHaveLength(2);
+      expect(html).not.toContain('.map(');
+    });
+
+    it('should render a caller-supplied component inside an expression', () => {
+      const Block = () => React.createElement('span', { className: 'custom-block' }, 'custom');
+      const html = mix('{<MyBlock />}', { components: { MyBlock: asModule(Block) } });
+
+      expect(html).toContain('custom-block');
+      expect(html).not.toContain('{<MyBlock />}');
+    });
+
+    it('should bind a snake_case component under its PascalCase name', () => {
+      const Block = () => React.createElement('span', { className: 'custom-block' }, 'custom');
+      const html = mix('{<MyBlock />}', { components: { my_block: asModule(Block) } });
+
+      expect(html).toContain('custom-block');
+    });
+
+    it('should expose the user variables object to expressions', () => {
+      const html = mix('{user.apps.map(app => <Callout theme="info" key={app.name}>{app.name}</Callout>)}', {
+        variables,
+      });
+
+      expect(html).toContain('Widgets');
+      expect(html).toContain('callout_info');
+    });
+
+    it('should keep expressions literal when no variables are supplied', () => {
+      const html = mix('{user.apps.length}');
+
+      expect(html).toContain('{user.apps.length}');
+    });
+
+    it('should keep expressions literal in safeMode', () => {
+      const html = mix('{true ? <Callout theme="info">yes</Callout> : null}', { safeMode: true });
+
+      expect(html).toContain('{true ?');
+      expect(html).not.toContain('callout_info');
+    });
+
+    it('should ignore component names that are not valid JS identifiers', () => {
+      // Every scope key becomes a `new Function` parameter, so an unbindable name must be
+      // skipped rather than turned into a syntax error for every expression on the page.
+      const Block = () => React.createElement('span', null, 'custom');
+      const html = mix('{1 + 1}', { components: { 'my-block': asModule(Block) } });
+
+      expect(html).toContain('2');
+    });
   });
 });

--- a/__tests__/transformers/evaluate-expressions.test.ts
+++ b/__tests__/transformers/evaluate-expressions.test.ts
@@ -2,7 +2,8 @@ import type { RMDXModule } from '../../types';
 
 import React from 'react';
 
-import { mix } from '../../lib';
+import { mix, mdxish } from '../../lib';
+import { findAllElementsByTagName, findElementByTagName } from '../helpers';
 
 describe('evaluateExpressions', () => {
   it('should evaluate numeric operations', () => {
@@ -76,48 +77,145 @@ describe('evaluateExpressions', () => {
   });
 
   describe('component and variable scope', () => {
-    const asModule = (Component: React.ComponentType): RMDXModule =>
-      ({ default: Component, Toc: null, toc: [] }) as unknown as RMDXModule;
+    const asModule = (Component: unknown): RMDXModule => ({ default: Component, Toc: null, toc: [] }) as RMDXModule;
 
     const variables = { user: { name: 'Dee', apps: [{ client_id: '1', name: 'Widgets' }] }, defaults: [] };
 
-    it('should render a built-in component referenced inside an expression', () => {
-      const html = mix('{true ? <Callout theme="info">yes</Callout> : null}');
+    const Block = () => React.createElement('span', { className: 'custom-block' }, 'custom');
 
-      expect(html).toContain('callout_info');
-      expect(html).toContain('yes');
-      expect(html).not.toContain('{true ?');
+    it('should render a built-in component referenced inside an expression', () => {
+      const tree = mdxish('{true ? <Callout theme="info">yes</Callout> : null}');
+
+      expect(findElementByTagName(tree, 'Callout')).toMatchObject({
+        type: 'element',
+        tagName: 'Callout',
+        properties: { theme: 'info' },
+        children: [{ type: 'element', tagName: 'p', children: [{ type: 'text', value: 'yes' }] }],
+      });
+    });
+
+    it('should emit the same tree for an expression as for the equivalent plain tag', () => {
+      const fromExpression = findElementByTagName(mdxish('{<Callout theme="info">yes</Callout>}'), 'Callout');
+      const fromTag = findElementByTagName(mdxish('<Callout theme="info">yes</Callout>'), 'Callout');
+
+      expect(fromExpression).toMatchObject({ tagName: 'Callout', properties: { theme: 'info' } });
+      expect(fromExpression?.children).toStrictEqual(fromTag?.children);
+    });
+
+    it('should parse markdown in the children of a component inside an expression', () => {
+      // The tag reaches `rehypeMdxishComponents` unrendered, so its children go through the same
+      // markdown pass a plain tag's would.
+      const tree = mdxish('{<Callout theme="info">**yes**</Callout>}');
+
+      expect(findElementByTagName(tree, 'strong')).toMatchObject({
+        tagName: 'strong',
+        children: [{ type: 'text', value: 'yes' }],
+      });
     });
 
     it('should render components returned from an iterator', () => {
-      const html = mix('{[1, 2].map(i => <Callout theme="info" key={i}>{i}</Callout>)}');
+      const tree = mdxish('{[1, 2].map(i => <Callout theme="info" key={i}>{i}</Callout>)}');
 
-      expect(html.match(/callout_info/g)).toHaveLength(2);
-      expect(html).not.toContain('.map(');
+      expect(findAllElementsByTagName(tree, 'Callout')).toMatchObject([
+        { properties: { theme: 'info' }, children: [{ tagName: 'p', children: [{ value: '1' }] }] },
+        { properties: { theme: 'info' }, children: [{ tagName: 'p', children: [{ value: '2' }] }] },
+      ]);
+    });
+
+    it('should evaluate an expression that spans several lines without leaking into the document', () => {
+      const tree = mdxish(['Before', '', '{true', '  ? <Callout theme="info">inside</Callout>', '  : null}', '', 'After'].join('\n'));
+
+      expect(tree.children.filter(child => child.type === 'element')).toMatchObject([
+        { tagName: 'p', children: [{ type: 'text', value: 'Before' }] },
+        { tagName: 'Callout', properties: { theme: 'info' } },
+        { tagName: 'p', children: [{ type: 'text', value: 'After' }] },
+      ]);
+    });
+
+    it('should lift a block-level result out of the paragraph it was parsed in', () => {
+      // `<p>` holds phrasing content only, so a browser closes it before the `<div>` a component
+      // renders. Leaving the wrapper in place reparents the DOM and breaks hydration.
+      const expression = mdxish('{true ? <Tabs><Tab title="One">a</Tab></Tabs> : null}');
+      const tag = mdxish('<Tabs>\n<Tab title="One">\na\n</Tab>\n</Tabs>');
+
+      expect(expression.children.filter(child => child.type === 'element')).toMatchObject([{ tagName: 'Tabs' }]);
+      expect(findElementByTagName(expression, 'Tabs')).toStrictEqual(findElementByTagName(tag, 'Tabs'));
+    });
+
+    it('should keep an inline result in its paragraph', () => {
+      const html = mix('Total: {5 * 10} items');
+
+      expect(html).toBe('<p>Total: 50 items</p>');
     });
 
     it('should render a caller-supplied component inside an expression', () => {
-      const Block = () => React.createElement('span', { className: 'custom-block' }, 'custom');
-      const html = mix('{<MyBlock />}', { components: { MyBlock: asModule(Block) } });
+      const tree = mdxish('{<MyBlock />}', { components: { MyBlock: asModule(Block) } });
 
-      expect(html).toContain('custom-block');
-      expect(html).not.toContain('{<MyBlock />}');
+      expect(findElementByTagName(tree, 'MyBlock')).toMatchObject({ tagName: 'MyBlock' });
     });
 
     it('should bind a snake_case component under its PascalCase name', () => {
-      const Block = () => React.createElement('span', { className: 'custom-block' }, 'custom');
-      const html = mix('{<MyBlock />}', { components: { my_block: asModule(Block) } });
+      const tree = mdxish('{<MyBlock />}', { components: { my_block: asModule(Block) } });
 
-      expect(html).toContain('custom-block');
+      expect(findElementByTagName(tree, 'my_block')).toMatchObject({ tagName: 'my_block' });
+    });
+
+    it('should resolve a component whose registered key differs only in casing', () => {
+      // `getComponentName` matches case-insensitively, so `<MyComponent/>` finds `mycomponent`
+      // as a plain tag; an expression has to reach the same component.
+      const tree = mdxish('{<MyComponent />}', { components: { mycomponent: asModule(Block) } });
+
+      expect(findElementByTagName(tree, 'mycomponent')).toMatchObject({ tagName: 'mycomponent' });
+    });
+
+    it.each([
+      ['React.memo', React.memo(Block)],
+      ['React.forwardRef', React.forwardRef(Block as never)],
+    ])('should bind a component wrapped in %s', (_label, Wrapped) => {
+      // Wrapped components are objects, not functions, so binding has to key off the components
+      // hash rather than the shape of the entry.
+      const tree = mdxish('{<Wrapped />}', { components: { Wrapped: asModule(Wrapped) } });
+
+      expect(findElementByTagName(tree, 'Wrapped')).toMatchObject({ tagName: 'Wrapped' });
+    });
+
+    it('should prefer an exact component key over a name another key normalizes onto', () => {
+      const tree = mdxish('{<CodeTabs />}', {
+        components: { CodeTabs: asModule(Block), code_tabs: asModule(Block) },
+      });
+
+      expect(findElementByTagName(tree, 'CodeTabs')).toMatchObject({ tagName: 'CodeTabs' });
+      expect(findElementByTagName(tree, 'code_tabs')).toBeNull();
+    });
+
+    it('should let an in-document export shadow a component of the same name', () => {
+      const html = mix('export const Callout = () => <span className="from-export">export</span>\n\n{<Callout />}');
+
+      expect(html).toContain('from-export');
+      expect(html).not.toContain('<Callout');
+    });
+
+    it('should resolve a sub-component off an exported object', () => {
+      const html = mix('export const Foo = { Bar: () => <span className="sub">sub</span> }\n\n{<Foo.Bar />}');
+
+      expect(html).toContain('class="sub"');
+      expect(html).not.toContain('{<Foo.Bar />}');
     });
 
     it('should expose the user variables object to expressions', () => {
-      const html = mix('{user.apps.map(app => <Callout theme="info" key={app.name}>{app.name}</Callout>)}', {
+      const tree = mdxish('{user.apps.map(app => <Callout theme="info" key={app.name}>{app.name}</Callout>)}', {
         variables,
       });
 
-      expect(html).toContain('Widgets');
-      expect(html).toContain('callout_info');
+      expect(findAllElementsByTagName(tree, 'Callout')).toMatchObject([
+        { properties: { theme: 'info' }, children: [{ tagName: 'p', children: [{ value: 'Widgets' }] }] },
+      ]);
+    });
+
+    it('should apply variable defaults for a user property that is not set', () => {
+      const html = mix("{user.name + '!'}", { variables: { user: {}, defaults: [{ default: 'Anon', name: 'name' }] } });
+
+      expect(html).toContain('Anon!');
     });
 
     it('should keep expressions literal when no variables are supplied', () => {
@@ -129,40 +227,14 @@ describe('evaluateExpressions', () => {
     it('should keep expressions literal in safeMode', () => {
       const html = mix('{true ? <Callout theme="info">yes</Callout> : null}', { safeMode: true });
 
+      // The braces survive, so nothing was evaluated; the tag inside them is still picked up by
+      // the ordinary component pass, as it would be in any other literal text.
       expect(html).toContain('{true ?');
-      expect(html).not.toContain('callout_info');
-    });
-
-    it('should prefer an exact component key over a name another key normalizes onto', () => {
-      const Exact = () => React.createElement('span', { className: 'exact' }, 'exact');
-      const Normalized = () => React.createElement('span', { className: 'normalized' }, 'normalized');
-      const html = mix('{<CodeTabs />}', {
-        components: { CodeTabs: asModule(Exact), code_tabs: asModule(Normalized) },
-      });
-
-      expect(html).toContain('exact');
-      expect(html).not.toContain('normalized');
-    });
-
-    it('should apply variable defaults for a user property that is not set', () => {
-      const html = mix("{user.name + '!'}", { variables: { user: {}, defaults: [{ default: 'Anon', name: 'name' }] } });
-
-      expect(html).toContain('Anon!');
-    });
-
-    it('should resolve a component whose registered key differs only in casing', () => {
-      // `getComponentName` matches case-insensitively, so `<MyComponent/>` finds `mycomponent`
-      // as a plain tag; an expression has to reach the same component.
-      const Block = () => React.createElement('span', { className: 'custom-block' }, 'custom');
-      const html = mix('{<MyComponent />}', { components: { mycomponent: asModule(Block) } });
-
-      expect(html).toContain('custom-block');
-      expect(html).not.toContain('{<MyComponent />}');
+      expect(html).toContain(': null}');
     });
 
     it('should not let a component shadow a same-named JS global', () => {
       // Only names in tag position are bound, so a `math` component can't capture `Math`.
-      const Block = () => React.createElement('span', null, 'custom');
       const html = mix('{Math.max(1, 2)}', { components: { math: asModule(Block) } });
 
       expect(html).toContain('<p>2</p>');
@@ -170,20 +242,10 @@ describe('evaluateExpressions', () => {
     });
 
     it('should not treat a less-than comparison as a JSX tag', () => {
-      const Block = () => React.createElement('span', null, 'custom');
       const html = mix("{1 < Infinity ? 'yes' : 'no'}", { components: { infinity: asModule(Block) } });
 
       expect(html).toContain('yes');
       expect(html).not.toContain('no');
-    });
-
-    it('should ignore component names that are not valid JS identifiers', () => {
-      // Every scope key becomes a `new Function` parameter, so an unbindable name must be
-      // skipped rather than turned into a syntax error for every expression on the page.
-      const Block = () => React.createElement('span', null, 'custom');
-      const html = mix('{1 + 1}', { components: { 'my-block': asModule(Block) } });
-
-      expect(html).toContain('2');
     });
   });
 });

--- a/__tests__/transformers/evaluate-expressions.test.ts
+++ b/__tests__/transformers/evaluate-expressions.test.ts
@@ -133,6 +133,23 @@ describe('evaluateExpressions', () => {
       expect(html).not.toContain('callout_info');
     });
 
+    it('should prefer an exact component key over a name another key normalizes onto', () => {
+      const Exact = () => React.createElement('span', { className: 'exact' }, 'exact');
+      const Normalized = () => React.createElement('span', { className: 'normalized' }, 'normalized');
+      const html = mix('{<CodeTabs />}', {
+        components: { CodeTabs: asModule(Exact), code_tabs: asModule(Normalized) },
+      });
+
+      expect(html).toContain('exact');
+      expect(html).not.toContain('normalized');
+    });
+
+    it('should apply variable defaults for a user property that is not set', () => {
+      const html = mix("{user.name + '!'}", { variables: { user: {}, defaults: [{ default: 'Anon', name: 'name' }] } });
+
+      expect(html).toContain('Anon!');
+    });
+
     it('should ignore component names that are not valid JS identifiers', () => {
       // Every scope key becomes a `new Function` parameter, so an unbindable name must be
       // skipped rather than turned into a syntax error for every expression on the page.

--- a/__tests__/transformers/evaluate-expressions.test.ts
+++ b/__tests__/transformers/evaluate-expressions.test.ts
@@ -160,6 +160,15 @@ describe('evaluateExpressions', () => {
       expect(html).not.toContain('{<MyComponent />}');
     });
 
+    it('should not let a component shadow a same-named JS global', () => {
+      // Only names in tag position are bound, so a `math` component can't capture `Math`.
+      const Block = () => React.createElement('span', null, 'custom');
+      const html = mix('{Math.max(1, 2)}', { components: { math: asModule(Block) } });
+
+      expect(html).toContain('<p>2</p>');
+      expect(html).not.toContain('{Math.max');
+    });
+
     it('should ignore component names that are not valid JS identifiers', () => {
       // Every scope key becomes a `new Function` parameter, so an unbindable name must be
       // skipped rather than turned into a syntax error for every expression on the page.

--- a/__tests__/transformers/evaluate-expressions.test.ts
+++ b/__tests__/transformers/evaluate-expressions.test.ts
@@ -169,6 +169,14 @@ describe('evaluateExpressions', () => {
       expect(html).not.toContain('{Math.max');
     });
 
+    it('should not treat a less-than comparison as a JSX tag', () => {
+      const Block = () => React.createElement('span', null, 'custom');
+      const html = mix("{1 < Infinity ? 'yes' : 'no'}", { components: { infinity: asModule(Block) } });
+
+      expect(html).toContain('yes');
+      expect(html).not.toContain('no');
+    });
+
     it('should ignore component names that are not valid JS identifiers', () => {
       // Every scope key becomes a `new Function` parameter, so an unbindable name must be
       // skipped rather than turned into a syntax error for every expression on the page.

--- a/components/Tabs/index.tsx
+++ b/components/Tabs/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import useRestartAnimatedImages from '../../hooks/useRestartAnimatedImages';
 import Icon from '../Icon';
 
 import './style.scss';
@@ -14,6 +15,7 @@ interface TabsProps {
 
 const Tabs = ({ children }: TabsProps) => {
   const [activeTab, setActiveTab] = useState(0);
+  const panelRefs = useRestartAnimatedImages(activeTab);
   // React passes `children` as a single element when there's only one child, so normalize.
   const tabs = React.Children.toArray(children) as React.ReactElement[];
 
@@ -38,7 +40,13 @@ const Tabs = ({ children }: TabsProps) => {
       <section>
         {/* Keep every panel mounted so runtime Tailwind can scan inactive tabs' classes on first paint */}
         {tabs.map((tab, index: number) => (
-          <div key={tab.key} hidden={index !== activeTab}>
+          <div
+            key={tab.key}
+            ref={el => {
+              panelRefs.current[index] = el;
+            }}
+            hidden={index !== activeTab}
+          >
             {tab}
           </div>
         ))}

--- a/hooks/useRestartAnimatedImages/index.tsx
+++ b/hooks/useRestartAnimatedImages/index.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+
+/** Animated formats whose playback position we can only reset by reloading the element. */
+const ANIMATED_IMAGE_SRC = /\.(gif|webp|apng)(\?|#|$)/i;
+
+/**
+ * Restarts animated images inside the panel that just became active.
+ *
+ * Tabs keep every panel mounted, so an <img> is never re-created and a GIF is
+ * shown mid-loop (or frozen on its last frame) when its tab is re-selected.
+ * There's no seek API for animated images; reassigning `src` is the only reset,
+ * and the reload is served from cache.
+ *
+ * @returns a ref to attach to each panel element, indexed by tab.
+ */
+export default function useRestartAnimatedImages(activeIndex: number) {
+  const panelRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    // Skip the initial paint: those images are loading for the first time anyway.
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    panelRefs.current[activeIndex]?.querySelectorAll('img').forEach(img => {
+      if (!ANIMATED_IMAGE_SRC.test(img.src)) return;
+      const { src } = img;
+      img.src = '';
+      img.src = src;
+    });
+  }, [activeIndex]);
+
+  return panelRefs;
+}

--- a/lib/mdxish.ts
+++ b/lib/mdxish.ts
@@ -234,7 +234,8 @@ export function mdxish(mdContent: string, opts: MdxishOpts = {}): Root {
   processor
     .use(safeMode ? undefined : evaluateExports) // Evaluate `export const/function` and stash scope on file.data.mdxishScope
     .use(hardBreaks) // Must precede evaluateExpressions to avoid splitting the \n in an evaluated template literal into a <br> node
-    .use(safeMode ? undefined : evaluateExpressions) // Evaluate self-contained MDX expressions (e.g. `{1+1}`)
+    // `undefined` short-circuits `.use` before it reads the options, so safeMode still skips this
+    .use(safeMode ? undefined : evaluateExpressions, { components, variables }) // Evaluate self-contained MDX expressions (e.g. `{1+1}`)
     .use(safeMode ? undefined : evaluateStyleBlockExpressions) // Evaluate `<style>{`...`}</style>` template literals into plain CSS
     .use(variablesCodeResolver, { variables }) // Resolve <<...>> and {user.*} inside code and inline code nodes
     .use(remarkRehype, { allowDangerousHtml: true, handlers: mdxComponentHandlers })

--- a/lib/utils/mdxish/mdxish-expression.ts
+++ b/lib/utils/mdxish/mdxish-expression.ts
@@ -21,6 +21,54 @@ const containsJsxNode = (value: unknown): boolean => {
   return Object.values(value).some(containsJsxNode);
 };
 
+/** Read the component name off a JSX element name node (`Foo`, `Foo.Bar`, `foo:Bar`). */
+const jsxElementName = (name: unknown): string | undefined => {
+  if (name === null || typeof name !== 'object') return undefined;
+  const node = name as { name?: unknown; namespace?: unknown; object?: unknown; type?: string };
+
+  if (node.type === 'JSXIdentifier') return typeof node.name === 'string' ? node.name : undefined;
+  // `<Foo.Bar/>` and `<foo:Bar/>` resolve through their leftmost part.
+  if (node.type === 'JSXMemberExpression') return jsxElementName(node.object);
+  if (node.type === 'JSXNamespacedName') return jsxElementName(node.namespace);
+  return undefined;
+};
+
+/**
+ * Collect the capitalized names an expression uses as JSX tags. Parsed rather than pattern
+ * matched: `{count < Max ? <Foo/> : <Bar/>}` puts a capitalized name straight after a `<` without
+ * it being a tag, and only the parser can tell the two apart. Unparseable input yields nothing —
+ * evaluation is about to throw on it anyway.
+ */
+export const jsxComponentNames = (expression: string): string[] => {
+  let program: Program;
+  try {
+    program = parseExpression(expression);
+  } catch {
+    return [];
+  }
+
+  const names = new Set<string>();
+  const walk = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(walk);
+      return;
+    }
+    if (value === null || typeof value !== 'object') return;
+
+    const node = value as { name?: unknown; type?: string };
+    if (node.type === 'JSXOpeningElement') {
+      const name = jsxElementName(node.name);
+      // Lowercase tags compile to a string type, never a variable reference.
+      if (name && /^[A-Z]/.test(name)) names.add(name);
+    }
+
+    Object.values(node).forEach(walk);
+  };
+
+  walk(program);
+  return Array.from(names);
+};
+
 /** Convert a program's JSX into `React.createElement` calls and evaluate it. `scope` must provide `React`. */
 const evalJsxProgram = (program: Program, scope: Record<string, unknown>) => {
   buildJsx(program, { runtime: 'classic', pragma: 'React.createElement', pragmaFrag: 'React.Fragment' });

--- a/lib/utils/mdxish/mdxish-get-component-name.ts
+++ b/lib/utils/mdxish/mdxish-get-component-name.ts
@@ -1,7 +1,7 @@
 import type { CustomComponents } from '../../../types';
 
 /** Convert a string to PascalCase */
-function toPascalCase(str: string): string {
+export function toPascalCase(str: string): string {
   return str
     .split(/[-_]/)
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))

--- a/processor/transform/mdxish/evaluate-expressions.ts
+++ b/processor/transform/mdxish/evaluate-expressions.ts
@@ -1,3 +1,4 @@
+import type { CustomComponents, Variables } from '../../../types';
 import type { Root, Text } from 'mdast';
 import type { MdxFlowExpression, MdxTextExpression } from 'mdast-util-mdx-expression';
 import type { Plugin } from 'unified';
@@ -8,8 +9,45 @@ import React from 'react';
 import { visit } from 'unist-util-visit';
 
 import { evalExpression } from '../../../lib/utils/mdxish/mdxish-expression';
+import { toPascalCase } from '../../../lib/utils/mdxish/mdxish-get-component-name';
 
 import { reactElementToHast } from './react-element-to-hast';
+
+interface Options {
+  components?: CustomComponents;
+  variables?: Variables;
+}
+
+/**
+ * JSX only compiles a *capitalized* tag to a variable reference (`<Callout/>` becomes
+ * `React.createElement(Callout)`), so those are the only component names an expression can fail
+ * to resolve; a lowercase tag becomes a string type and is matched against the components hash
+ * later by `rehypeMdxishComponents`. Binding only capitalized names also keeps reserved words
+ * (`default`, `class`) out of the scope, which matters because `evaluate` passes every scope key
+ * as a `new Function` parameter — one invalid identifier is a syntax error for the whole page.
+ */
+const COMPONENT_IDENTIFIER = /^[A-Z][A-Za-z0-9_$]*$/;
+
+/**
+ * Bind the components hash to the identifiers an author writes in JSX. Without this a
+ * component inside `{...}` is an unresolved reference, the evaluation throws, and the
+ * expression falls back to literal text. snake_case keys are bound under their PascalCase
+ * form too, mirroring how `getComponentName` resolves tag names.
+ */
+const componentScope = (components: CustomComponents = {}): Record<string, unknown> => {
+  const scope: Record<string, unknown> = {};
+
+  Object.entries(components).forEach(([name, mod]) => {
+    const Component = mod?.default;
+    if (typeof Component !== 'function') return;
+
+    [name, toPascalCase(name)].forEach(binding => {
+      if (COMPONENT_IDENTIFIER.test(binding)) scope[binding] = Component;
+    });
+  });
+
+  return scope;
+};
 
 /**
  * We divide the result of an expression into two categories:
@@ -31,43 +69,54 @@ const createTextNode = (result: unknown, position: Position | undefined): Text =
 /**
  * AST transformer to evaluate MDX expressions.
  * Replaces mdxFlowExpression and mdxTextExpression nodes with their evaluated values.
- * Self-contained expressions resolve directly (e.g. `{1+1}`); expressions that
- * reference identifiers can resolve if those identifiers were introduced by an
- * earlier `export const/function` (collected onto `file.data.mdxishScope`).
- * Anything else falls through to the error branch and is kept as literal `{...}` text.
+ * Self-contained expressions resolve directly (e.g. `{1+1}`); expressions that reference
+ * identifiers can resolve if those identifiers are a custom component, the `user` variables
+ * object, or were introduced by an earlier `export const/function` (collected onto
+ * `file.data.mdxishScope`). Anything else falls through to the error branch and is kept as
+ * literal `{...}` text.
  */
-const evaluateExpressions: Plugin<[], Root> = () => (tree, file: VFile) => {
-  const scope: Record<string, unknown> = { ...(file.data.mdxishScope ), React };
+const evaluateExpressions: Plugin<[Options?], Root> =
+  ({ components, variables }: Options = {}) =>
+  (tree, file: VFile) => {
+    const scope: Record<string, unknown> = {
+      ...componentScope(components),
+      // Only bound when the caller supplied variables at all, so surfaces that render without
+      // them keep the existing literal-text fallback rather than resolving `user` to `{}`.
+      ...(variables ? { user: variables.user } : {}),
+      // In-document exports win over both, matching the precedence `renderMdxish` applies.
+      ...file.data.mdxishScope,
+      React,
+    };
 
-  visit(tree, ['mdxFlowExpression', 'mdxTextExpression'], (node, index, parent) => {
-    if (!parent || index === null || index === undefined) return;
+    visit(tree, ['mdxFlowExpression', 'mdxTextExpression'], (node, index, parent) => {
+      if (!parent || index === null || index === undefined) return;
 
-    const expressionNode = node as MdxFlowExpression | MdxTextExpression;
-    const { value, position } = expressionNode;
-    const expression = value?.trim();
-    if (!expression) return;
+      const expressionNode = node as MdxFlowExpression | MdxTextExpression;
+      const { value, position } = expressionNode;
+      const expression = value?.trim();
+      if (!expression) return;
 
-    try {
-      const result = evalExpression(expression, scope);
-      if (isRenderable(result)) {
-        // Stash hast built straight from the React tree; `mdxExpressionHandler` emits it and it 
-        // passes through rehypeRaw/parse5 step later in the pipeline. This ensures that the 
-        // expression result is not parsed by parse5 and fragmenting the nesting that is valid JSX 
-        // but invalid HTML — e.g. an `<a>` wrapping `<a>`.
-        expressionNode.data = { ...expressionNode.data, hChildren: reactElementToHast(result) };
-      } else {
-        parent.children.splice(index, 1, createTextNode(result, position));
+      try {
+        const result = evalExpression(expression, scope);
+        if (isRenderable(result)) {
+          // Stash hast built straight from the React tree; `mdxExpressionHandler` emits it and it 
+          // passes through rehypeRaw/parse5 step later in the pipeline. This ensures that the 
+          // expression result is not parsed by parse5 and fragmenting the nesting that is valid JSX 
+          // but invalid HTML — e.g. an `<a>` wrapping `<a>`.
+          expressionNode.data = { ...expressionNode.data, hChildren: reactElementToHast(result) };
+        } else {
+          parent.children.splice(index, 1, createTextNode(result, position));
+        }
+      } catch (_error) {
+        // Evaluation failed — fall back to literal `{...}` text. The expression
+        // parser treats contents as code, so backslash escapes aren't applied;
+        // restore them here so e.g. `{\!}` round-trips to `{!}`.
+        const processed = expression.replace(/\\([!-/:-@[-`{-~])/g, '$1');
+        parent.children.splice(index, 1, { type: 'text', value: `{${processed}}`, position });
       }
-    } catch (_error) {
-      // Evaluation failed — fall back to literal `{...}` text. The expression
-      // parser treats contents as code, so backslash escapes aren't applied;
-      // restore them here so e.g. `{\!}` round-trips to `{!}`.
-      const processed = expression.replace(/\\([!-/:-@[-`{-~])/g, '$1');
-      parent.children.splice(index, 1, { type: 'text', value: `{${processed}}`, position });
-    }
-  });
+    });
 
-  return tree;
-};
+    return tree;
+  };
 
 export default evaluateExpressions;

--- a/processor/transform/mdxish/evaluate-expressions.ts
+++ b/processor/transform/mdxish/evaluate-expressions.ts
@@ -9,7 +9,7 @@ import React from 'react';
 import { visit } from 'unist-util-visit';
 
 import { evalExpression } from '../../../lib/utils/mdxish/mdxish-expression';
-import { toPascalCase } from '../../../lib/utils/mdxish/mdxish-get-component-name';
+import { getComponentName, toPascalCase } from '../../../lib/utils/mdxish/mdxish-get-component-name';
 import User from '../../../utils/user';
 
 import { reactElementToHast } from './react-element-to-hast';
@@ -20,20 +20,16 @@ interface Options {
 }
 
 /**
- * JSX only compiles a *capitalized* tag to a variable reference (`<Callout/>` becomes
- * `React.createElement(Callout)`), so those are the only component names an expression can fail
- * to resolve; a lowercase tag becomes a string type and is matched against the components hash
- * later by `rehypeMdxishComponents`. Binding only capitalized names also keeps reserved words
- * (`default`, `class`) out of the scope, which matters because `evaluate` passes every scope key
- * as a `new Function` parameter — one invalid identifier is a syntax error for the whole page.
+ * Only capitalized tags compile to a variable reference; a lowercase one becomes a string and is
+ * matched later by `rehypeMdxishComponents`. Also keeps reserved words out of the scope, since
+ * `evaluate` passes every key as a `new Function` parameter and one bad name breaks every
+ * expression on the page.
  */
 const COMPONENT_IDENTIFIER = /^[A-Z][A-Za-z0-9_$]*$/;
 
 /**
- * Bind the components hash to the identifiers an author writes in JSX. Without this a
- * component inside `{...}` is an unresolved reference, the evaluation throws, and the
- * expression falls back to literal text. snake_case keys are bound under their PascalCase
- * form too, mirroring how `getComponentName` resolves tag names.
+ * Bind components to the identifiers an author writes in JSX; without this a component inside
+ * `{...}` is unresolved and the expression falls back to literal text.
  */
 const componentScope = (components: CustomComponents = {}): Record<string, unknown> => {
   const exact: Record<string, unknown> = {};
@@ -49,10 +45,34 @@ const componentScope = (components: CustomComponents = {}): Record<string, unkno
     if (pascalCase !== name && COMPONENT_IDENTIFIER.test(pascalCase)) aliases[pascalCase] = Component;
   });
 
-  // An exact key outranks a name another key normalizes onto, matching `getComponentName`'s
-  // match priority. Without this a caller-supplied `code_tabs` would claim `CodeTabs` and
-  // `{<CodeTabs/>}` would render a different component than a plain `<CodeTabs/>`.
+  // Exact keys outrank normalized ones, matching `getComponentName`'s priority — otherwise a
+  // caller's `code_tabs` claims `CodeTabs` and shadows the built-in.
   return { ...aliases, ...exact };
+};
+
+const CAPITALIZED_IDENTIFIER = /\b[A-Z][A-Za-z0-9_$]*\b/g;
+
+/**
+ * Resolve names the keyed bindings missed. Keys can't cover case-insensitive matches — the map
+ * holds `mycomponent` while the author writes `<MyComponent/>` — so defer to `getComponentName`,
+ * keeping expressions in step with the plain-tag path.
+ */
+const resolveByComponentName = (
+  expression: string,
+  scope: Record<string, unknown>,
+  components: CustomComponents,
+): Record<string, unknown> => {
+  const resolved: Record<string, unknown> = {};
+
+  Array.from(expression.matchAll(CAPITALIZED_IDENTIFIER), match => match[0]).forEach(name => {
+    if (name in scope || name in resolved) return;
+
+    const key = getComponentName(name, components);
+    const Component = key ? components[key]?.default : undefined;
+    if (typeof Component === 'function') resolved[name] = Component;
+  });
+
+  return Object.keys(resolved).length ? { ...scope, ...resolved } : scope;
 };
 
 /**
@@ -86,13 +106,11 @@ const evaluateExpressions: Plugin<[Options?], Root> =
   (tree, file: VFile) => {
     const scope: Record<string, unknown> = {
       ...componentScope(components),
-      // `User` applies the same defaults-then-uppercase fallback the MDX path binds in
-      // `run.tsx`, so a missing property resolves identically on both engines. Only bound when
-      // the caller supplied variables at all: the proxy never throws, so binding it
-      // unconditionally would resolve `user.*` on surfaces that render without variables
-      // instead of leaving the expression as literal text.
+      // `User` matches the fallback the MDX path binds in `run.tsx`. Only when variables were
+      // supplied: the proxy never throws, so an unconditional bind would resolve `user.*` on
+      // surfaces that render without them instead of leaving literal text.
       ...(variables ? { user: User(variables) } : {}),
-      // In-document exports win over both, matching the precedence `renderMdxish` applies.
+      // In-document exports win, matching `renderMdxish`.
       ...file.data.mdxishScope,
       React,
     };
@@ -106,7 +124,7 @@ const evaluateExpressions: Plugin<[Options?], Root> =
       if (!expression) return;
 
       try {
-        const result = evalExpression(expression, scope);
+        const result = evalExpression(expression, resolveByComponentName(expression, scope, components ?? {}));
         if (isRenderable(result)) {
           // Stash hast built straight from the React tree; `mdxExpressionHandler` emits it and it 
           // passes through rehypeRaw/parse5 step later in the pipeline. This ensures that the 

--- a/processor/transform/mdxish/evaluate-expressions.ts
+++ b/processor/transform/mdxish/evaluate-expressions.ts
@@ -9,8 +9,10 @@ import type { VFile } from 'vfile';
 import React from 'react';
 import { visit } from 'unist-util-visit';
 
+import { INLINE_COMPONENT_TAGS } from '../../../lib/constants';
 import { evalExpression, jsxComponentNames } from '../../../lib/utils/mdxish/mdxish-expression';
 import { getComponentName, toPascalCase } from '../../../lib/utils/mdxish/mdxish-get-component-name';
+import { STANDARD_HTML_TAGS } from '../../../utils/common-html-words';
 import User from '../../../utils/user';
 
 import { reactElementToHast } from './react-element-to-hast';

--- a/processor/transform/mdxish/evaluate-expressions.ts
+++ b/processor/transform/mdxish/evaluate-expressions.ts
@@ -10,6 +10,7 @@ import { visit } from 'unist-util-visit';
 
 import { evalExpression } from '../../../lib/utils/mdxish/mdxish-expression';
 import { toPascalCase } from '../../../lib/utils/mdxish/mdxish-get-component-name';
+import User from '../../../utils/user';
 
 import { reactElementToHast } from './react-element-to-hast';
 
@@ -35,18 +36,23 @@ const COMPONENT_IDENTIFIER = /^[A-Z][A-Za-z0-9_$]*$/;
  * form too, mirroring how `getComponentName` resolves tag names.
  */
 const componentScope = (components: CustomComponents = {}): Record<string, unknown> => {
-  const scope: Record<string, unknown> = {};
+  const exact: Record<string, unknown> = {};
+  const aliases: Record<string, unknown> = {};
 
   Object.entries(components).forEach(([name, mod]) => {
     const Component = mod?.default;
     if (typeof Component !== 'function') return;
 
-    [name, toPascalCase(name)].forEach(binding => {
-      if (COMPONENT_IDENTIFIER.test(binding)) scope[binding] = Component;
-    });
+    if (COMPONENT_IDENTIFIER.test(name)) exact[name] = Component;
+
+    const pascalCase = toPascalCase(name);
+    if (pascalCase !== name && COMPONENT_IDENTIFIER.test(pascalCase)) aliases[pascalCase] = Component;
   });
 
-  return scope;
+  // An exact key outranks a name another key normalizes onto, matching `getComponentName`'s
+  // match priority. Without this a caller-supplied `code_tabs` would claim `CodeTabs` and
+  // `{<CodeTabs/>}` would render a different component than a plain `<CodeTabs/>`.
+  return { ...aliases, ...exact };
 };
 
 /**
@@ -80,9 +86,12 @@ const evaluateExpressions: Plugin<[Options?], Root> =
   (tree, file: VFile) => {
     const scope: Record<string, unknown> = {
       ...componentScope(components),
-      // Only bound when the caller supplied variables at all, so surfaces that render without
-      // them keep the existing literal-text fallback rather than resolving `user` to `{}`.
-      ...(variables ? { user: variables.user } : {}),
+      // `User` applies the same defaults-then-uppercase fallback the MDX path binds in
+      // `run.tsx`, so a missing property resolves identically on both engines. Only bound when
+      // the caller supplied variables at all: the proxy never throws, so binding it
+      // unconditionally would resolve `user.*` on surfaces that render without variables
+      // instead of leaving the expression as literal text.
+      ...(variables ? { user: User(variables) } : {}),
       // In-document exports win over both, matching the precedence `renderMdxish` applies.
       ...file.data.mdxishScope,
       React,

--- a/processor/transform/mdxish/evaluate-expressions.ts
+++ b/processor/transform/mdxish/evaluate-expressions.ts
@@ -19,60 +19,29 @@ interface Options {
   variables?: Variables;
 }
 
-/**
- * Only capitalized tags compile to a variable reference; a lowercase one becomes a string and is
- * matched later by `rehypeMdxishComponents`. Also keeps reserved words out of the scope, since
- * `evaluate` passes every key as a `new Function` parameter and one bad name breaks every
- * expression on the page.
- */
-const COMPONENT_IDENTIFIER = /^[A-Z][A-Za-z0-9_$]*$/;
+/** Names in JSX tag position (`<Foo`, `<Foo.Bar`) — the only identifiers that mean a component. */
+const JSX_TAG = /<\s*([A-Z][A-Za-z0-9_$]*)/g;
 
 /**
- * Bind components to the identifiers an author writes in JSX; without this a component inside
- * `{...}` is unresolved and the expression falls back to literal text.
+ * Bind the components a given expression actually references as tags. Scoped per expression on
+ * purpose: binding the whole hash would shadow same-named globals (a `math` component would
+ * break `{Math.max(1, 2)}`) and pad `evaluate`'s `new Function` parameter list. Resolution defers
+ * to `getComponentName` so an expression and a plain tag always reach the same component.
  */
-const componentScope = (components: CustomComponents = {}): Record<string, unknown> => {
-  const exact: Record<string, unknown> = {};
-  const aliases: Record<string, unknown> = {};
+const componentScope = (expression: string, components: CustomComponents): Record<string, unknown> => {
+  const scope: Record<string, unknown> = {};
 
-  Object.entries(components).forEach(([name, mod]) => {
-    const Component = mod?.default;
-    if (typeof Component !== 'function') return;
+  Array.from(expression.matchAll(JSX_TAG), match => match[1]).forEach(name => {
+    if (name in scope) return;
 
-    if (COMPONENT_IDENTIFIER.test(name)) exact[name] = Component;
-
-    const pascalCase = toPascalCase(name);
-    if (pascalCase !== name && COMPONENT_IDENTIFIER.test(pascalCase)) aliases[pascalCase] = Component;
-  });
-
-  // Exact keys outrank normalized ones, matching `getComponentName`'s priority — otherwise a
-  // caller's `code_tabs` claims `CodeTabs` and shadows the built-in.
-  return { ...aliases, ...exact };
-};
-
-const CAPITALIZED_IDENTIFIER = /\b[A-Z][A-Za-z0-9_$]*\b/g;
-
-/**
- * Resolve names the keyed bindings missed. Keys can't cover case-insensitive matches — the map
- * holds `mycomponent` while the author writes `<MyComponent/>` — so defer to `getComponentName`,
- * keeping expressions in step with the plain-tag path.
- */
-const resolveByComponentName = (
-  expression: string,
-  scope: Record<string, unknown>,
-  components: CustomComponents,
-): Record<string, unknown> => {
-  const resolved: Record<string, unknown> = {};
-
-  Array.from(expression.matchAll(CAPITALIZED_IDENTIFIER), match => match[0]).forEach(name => {
-    if (name in scope || name in resolved) return;
-
-    const key = getComponentName(name, components);
+    // `getComponentName` normalizes the tag, never the key, so it can't match `<MyBlock/>` to a
+    // `my_block` entry; compare the key's PascalCase form for that direction.
+    const key = getComponentName(name, components) ?? Object.keys(components).find(k => toPascalCase(k) === name);
     const Component = key ? components[key]?.default : undefined;
-    if (typeof Component === 'function') resolved[name] = Component;
+    if (typeof Component === 'function') scope[name] = Component;
   });
 
-  return Object.keys(resolved).length ? { ...scope, ...resolved } : scope;
+  return scope;
 };
 
 /**
@@ -104,8 +73,7 @@ const createTextNode = (result: unknown, position: Position | undefined): Text =
 const evaluateExpressions: Plugin<[Options?], Root> =
   ({ components, variables }: Options = {}) =>
   (tree, file: VFile) => {
-    const scope: Record<string, unknown> = {
-      ...componentScope(components),
+    const baseScope: Record<string, unknown> = {
       // `User` matches the fallback the MDX path binds in `run.tsx`. Only when variables were
       // supplied: the proxy never throws, so an unconditional bind would resolve `user.*` on
       // surfaces that render without them instead of leaving literal text.
@@ -124,7 +92,8 @@ const evaluateExpressions: Plugin<[Options?], Root> =
       if (!expression) return;
 
       try {
-        const result = evalExpression(expression, resolveByComponentName(expression, scope, components ?? {}));
+        const scope = { ...componentScope(expression, components ?? {}), ...baseScope };
+        const result = evalExpression(expression, scope);
         if (isRenderable(result)) {
           // Stash hast built straight from the React tree; `mdxExpressionHandler` emits it and it 
           // passes through rehypeRaw/parse5 step later in the pipeline. This ensures that the 

--- a/processor/transform/mdxish/evaluate-expressions.ts
+++ b/processor/transform/mdxish/evaluate-expressions.ts
@@ -1,4 +1,5 @@
 import type { CustomComponents, Variables } from '../../../types';
+import type { ElementContent } from 'hast';
 import type { Root, Text } from 'mdast';
 import type { MdxFlowExpression, MdxTextExpression } from 'mdast-util-mdx-expression';
 import type { Plugin } from 'unified';
@@ -31,9 +32,10 @@ const componentScope = (expression: string, components: CustomComponents): Recor
   jsxComponentNames(expression).forEach(name => {
     // `getComponentName` normalizes the tag, never the key, so it can't match `<MyBlock/>` to a
     // `my_block` entry; compare the key's PascalCase form for that direction.
-    const key = getComponentName(name, components) ?? Object.keys(components).find(k => toPascalCase(k) === name);
-    const Component = key ? components[key]?.default : undefined;
-    if (typeof Component === 'function') scope[name] = Component;
+    const tagName = getComponentName(name, components) ?? Object.keys(components).find(k => toPascalCase(k) === name);
+    if (!tagName) return;
+
+    scope[name] = (props: Record<string, unknown>) => React.createElement(tagName, props);
   });
 
   return scope;
@@ -48,6 +50,18 @@ const isRenderable = (value: unknown): boolean => {
   if (React.isValidElement(value)) return true;
   return Array.isArray(value) && value.some(isRenderable);
 };
+
+/**
+ * Whether an expression evaluated to block-level content. Components count as block-level
+ * unless they're on the inline list, matching the assumption the rest of the component
+ * pipeline makes.
+ */
+const isBlockResult = (children: ElementContent[]): boolean =>
+  children.some(child => {
+    if (child.type !== 'element' && child.type !== 'mdx-jsx') return false;
+    const { tagName } = child as { tagName: string };
+    return !STANDARD_HTML_TAGS.has(tagName.toLowerCase()) && !INLINE_COMPONENT_TAGS.has(tagName);
+  });
 
 /** Turn a non-renderable evaluation result into a text node. */
 const createTextNode = (result: unknown, position: Position | undefined): Text => {
@@ -105,6 +119,23 @@ const evaluateExpressions: Plugin<[Options?], Root> =
         const processed = expression.replace(/\\([!-/:-@[-`{-~])/g, '$1');
         parent.children.splice(index, 1, { type: 'text', value: `{${processed}}`, position });
       }
+    });
+
+    // A text expression is parsed inside a paragraph, but its result can be block content: a
+    // `<Tabs>` renders a `<div>`, and a browser closes the `<p>` before it, so the DOM it builds
+    // no longer matches what was rendered and hydration fails. Lift the expression out when
+    // that's all the paragraph holds.
+    visit(tree, 'paragraph', (node, index, parent) => {
+      if (!parent || index === null || index === undefined) return;
+
+      const meaningful = node.children.filter(child => !(child.type === 'text' && !child.value.trim()));
+      const [only] = meaningful;
+      if (meaningful.length !== 1 || only.type !== 'mdxTextExpression') return;
+
+      const hChildren = only.data?.hChildren as ElementContent[] | undefined;
+      if (!hChildren || !isBlockResult(hChildren)) return;
+
+      parent.children.splice(index, 1, only);
     });
 
     return tree;

--- a/processor/transform/mdxish/evaluate-expressions.ts
+++ b/processor/transform/mdxish/evaluate-expressions.ts
@@ -8,7 +8,7 @@ import type { VFile } from 'vfile';
 import React from 'react';
 import { visit } from 'unist-util-visit';
 
-import { evalExpression } from '../../../lib/utils/mdxish/mdxish-expression';
+import { evalExpression, jsxComponentNames } from '../../../lib/utils/mdxish/mdxish-expression';
 import { getComponentName, toPascalCase } from '../../../lib/utils/mdxish/mdxish-get-component-name';
 import User from '../../../utils/user';
 
@@ -19,21 +19,16 @@ interface Options {
   variables?: Variables;
 }
 
-/** Names in JSX tag position (`<Foo`, `<Foo.Bar`) — the only identifiers that mean a component. */
-const JSX_TAG = /<\s*([A-Z][A-Za-z0-9_$]*)/g;
-
 /**
- * Bind the components a given expression actually references as tags. Scoped per expression on
- * purpose: binding the whole hash would shadow same-named globals (a `math` component would
- * break `{Math.max(1, 2)}`) and pad `evaluate`'s `new Function` parameter list. Resolution defers
- * to `getComponentName` so an expression and a plain tag always reach the same component.
+ * Bind the components a given expression actually uses as tags. Scoped per expression on purpose:
+ * binding the whole hash would shadow same-named globals (a `math` component would break
+ * `{Math.max(1, 2)}`) and pad `evaluate`'s `new Function` parameter list. Resolution defers to
+ * `getComponentName` so an expression and a plain tag always reach the same component.
  */
 const componentScope = (expression: string, components: CustomComponents): Record<string, unknown> => {
   const scope: Record<string, unknown> = {};
 
-  Array.from(expression.matchAll(JSX_TAG), match => match[1]).forEach(name => {
-    if (name in scope) return;
-
+  jsxComponentNames(expression).forEach(name => {
     // `getComponentName` normalizes the tag, never the key, so it can't match `<MyBlock/>` to a
     // `my_block` entry; compare the key's PascalCase form for that direction.
     const key = getComponentName(name, components) ?? Object.keys(components).find(k => toPascalCase(k) === name);


### PR DESCRIPTION
| 🎫 Resolve CX-3887 |
| :-----------------: |

## 🎯 What does this PR do?

**Problem**
GIFs inside `<Tab>` never restart. `Tabs` keeps every panel mounted and toggles `hidden` (deliberate — 9499ed3b added it so runtime Tailwind can scan inactive tabs' classes on first paint), so the `<img>` is never re-created. Playback position lives in the image element: a looping GIF keeps advancing while hidden, and a non-looping one is stuck on its last frame. Re-selecting a tab shows the animation mid-loop or already over

**Fix**
New `hooks/useRestartAnimatedImages` takes the active index and returns a ref array to attach to each panel. When the active index changes, it walks that panel's `<img>` elements and, for any whose src matches `.gif`/`.webp`/`.apng`, clears and restores `src`

**Tradeoff**
Detection is by URL extension, so a GIF behind a signed or proxied URL with no `.gif` in the path won't be caught. The alternative, resetting every `<img>` in the panel, covers those but risks a visible reflash on large uncached images. Happy to switch if reviewers prefer the broader net

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ]

## 📸 Screenshot or Loom

<!-- all PRs should have a Loom or screenshot! -->
