### PR TITLE
feat(tabs): restart GIF playback when a tab is selected

### DIFF
--- a/__tests__/components/Accordion.test.tsx
+++ b/__tests__/components/Accordion.test.tsx
@@ -2,9 +2,10 @@ import '@testing-library/jest-dom/vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { expect, vi } from 'vitest';
+import { expect } from 'vitest';
 
 import Accordion from '../../components/Accordion';
+import { gifRestartWrites, spyOnImageSrc } from '../helpers';
 
 import { renderingEngines } from './utils';
 
@@ -115,14 +116,12 @@ describe('Accordion', () => {
           <img alt="demo" src="https://example.com/demo.gif" />
         </Accordion>,
       );
-      const gif = container.querySelector('img') as HTMLImageElement;
-      const setSrc = vi.spyOn(gif, 'src', 'set');
+      const srcSpy = spyOnImageSrc(container.querySelector('img') as HTMLImageElement);
 
       open(container);
 
-      // Cleared then restored: the only way to rewind an animated image to frame 0
-      expect(setSrc.mock.calls.map(([value]) => value)).toStrictEqual(['', 'https://example.com/demo.gif']);
-      setSrc.mockRestore();
+      expect(srcSpy.writes).toStrictEqual(gifRestartWrites('https://example.com/demo.gif'));
+      srcSpy.restore();
     });
 
     it('leaves a still image alone when the accordion is opened', () => {
@@ -131,13 +130,12 @@ describe('Accordion', () => {
           <img alt="still" src="https://example.com/still.png" />
         </Accordion>,
       );
-      const png = container.querySelector('img') as HTMLImageElement;
-      const setSrc = vi.spyOn(png, 'src', 'set');
+      const srcSpy = spyOnImageSrc(container.querySelector('img') as HTMLImageElement);
 
       open(container);
 
-      expect(setSrc).not.toHaveBeenCalled();
-      setSrc.mockRestore();
+      expect(srcSpy.writes).toStrictEqual([]);
+      srcSpy.restore();
     });
 
     it('does not restart playback when the accordion is closed again', () => {
@@ -149,13 +147,12 @@ describe('Accordion', () => {
       const details = container.querySelector('details') as HTMLDetailsElement;
       open(container);
 
-      const gif = container.querySelector('img') as HTMLImageElement;
-      const setSrc = vi.spyOn(gif, 'src', 'set');
+      const srcSpy = spyOnImageSrc(container.querySelector('img') as HTMLImageElement);
       details.open = false;
       fireEvent(details, new Event('toggle'));
 
-      expect(setSrc).not.toHaveBeenCalled();
-      setSrc.mockRestore();
+      expect(srcSpy.writes).toStrictEqual([]);
+      srcSpy.restore();
     });
   });
 

--- a/__tests__/components/Accordion.test.tsx
+++ b/__tests__/components/Accordion.test.tsx
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 
-import { expect } from 'vitest';
+import { expect, vi } from 'vitest';
 
 import Accordion from '../../components/Accordion';
 
@@ -99,6 +99,63 @@ describe('Accordion', () => {
         </Accordion>,
       );
       expect(container.querySelector('i.Accordion-icon')).toBeNull();
+    });
+  });
+
+  describe('animated images', () => {
+    const open = (container: HTMLElement) => {
+      const details = container.querySelector('details') as HTMLDetailsElement;
+      details.open = true;
+      fireEvent(details, new Event('toggle'));
+    };
+
+    it('restarts GIF playback when the accordion is opened', () => {
+      const { container } = render(
+        <Accordion title="Section">
+          <img alt="demo" src="https://example.com/demo.gif" />
+        </Accordion>,
+      );
+      const gif = container.querySelector('img') as HTMLImageElement;
+      const setSrc = vi.spyOn(gif, 'src', 'set');
+
+      open(container);
+
+      // Cleared then restored: the only way to rewind an animated image to frame 0
+      expect(setSrc.mock.calls.map(([value]) => value)).toStrictEqual(['', 'https://example.com/demo.gif']);
+      setSrc.mockRestore();
+    });
+
+    it('leaves a still image alone when the accordion is opened', () => {
+      const { container } = render(
+        <Accordion title="Section">
+          <img alt="still" src="https://example.com/still.png" />
+        </Accordion>,
+      );
+      const png = container.querySelector('img') as HTMLImageElement;
+      const setSrc = vi.spyOn(png, 'src', 'set');
+
+      open(container);
+
+      expect(setSrc).not.toHaveBeenCalled();
+      setSrc.mockRestore();
+    });
+
+    it('does not restart playback when the accordion is closed again', () => {
+      const { container } = render(
+        <Accordion title="Section">
+          <img alt="demo" src="https://example.com/demo.gif" />
+        </Accordion>,
+      );
+      const details = container.querySelector('details') as HTMLDetailsElement;
+      open(container);
+
+      const gif = container.querySelector('img') as HTMLImageElement;
+      const setSrc = vi.spyOn(gif, 'src', 'set');
+      details.open = false;
+      fireEvent(details, new Event('toggle'));
+
+      expect(setSrc).not.toHaveBeenCalled();
+      setSrc.mockRestore();
     });
   });
 

--- a/__tests__/components/Tabs.test.tsx
+++ b/__tests__/components/Tabs.test.tsx
@@ -129,6 +129,47 @@ describe('Tabs', () => {
       expect(container.querySelector('a')).toHaveTextContent('link');
     });
 
+    it('restarts GIF playback when a tab becomes active', () => {
+      const md = `
+<Tabs>
+  <Tab title="First">First tab content</Tab>
+  <Tab title="Second">![demo](https://example.com/demo.gif)</Tab>
+</Tabs>
+`;
+      const Component = renderContent(md);
+      const { container } = render(<Component />);
+
+      const gif = container.querySelector('img[src$=".gif"]') as HTMLImageElement;
+      expect(gif).toBeInTheDocument();
+      const setSrc = vi.spyOn(gif, 'src', 'set');
+
+      fireEvent.click(container.querySelectorAll('.TabGroup-nav button')[1]);
+
+      // Cleared then restored: the only way to rewind an animated image to frame 0
+      expect(setSrc.mock.calls.map(([value]) => value)).toStrictEqual(['', 'https://example.com/demo.gif']);
+      expect(gif.src).toBe('https://example.com/demo.gif');
+      setSrc.mockRestore();
+    });
+
+    it('leaves non-animated images alone when a tab becomes active', () => {
+      const md = `
+<Tabs>
+  <Tab title="First">First tab content</Tab>
+  <Tab title="Second">![still](https://example.com/still.png)</Tab>
+</Tabs>
+`;
+      const Component = renderContent(md);
+      const { container } = render(<Component />);
+
+      const png = container.querySelector('img[src$=".png"]') as HTMLImageElement;
+      const setSrc = vi.spyOn(png, 'src', 'set');
+
+      fireEvent.click(container.querySelectorAll('.TabGroup-nav button')[1]);
+
+      expect(setSrc).not.toHaveBeenCalled();
+      setSrc.mockRestore();
+    });
+
     it('renders Tabs after sibling content without crashing', () => {
       const md = `
 Hello

--- a/__tests__/components/Tabs.test.tsx
+++ b/__tests__/components/Tabs.test.tsx
@@ -151,18 +151,24 @@ describe('Tabs', () => {
       setSrc.mockRestore();
     });
 
-    it('leaves non-animated images alone when a tab becomes active', () => {
+    it.each([
+      ['png', 'https://example.com/still.png'],
+      // .webp and .png are almost always static, so they're left alone even though
+      // both formats can hold an animation
+      ['webp', 'https://example.com/still.webp'],
+      ['jpg with a query string', 'https://example.com/still.jpg?w=200'],
+    ])('leaves a %s alone when a tab becomes active', (_, src) => {
       const md = `
 <Tabs>
   <Tab title="First">First tab content</Tab>
-  <Tab title="Second">![still](https://example.com/still.png)</Tab>
+  <Tab title="Second">![still](${src})</Tab>
 </Tabs>
 `;
       const Component = renderContent(md);
       const { container } = render(<Component />);
 
-      const png = container.querySelector('img[src$=".png"]') as HTMLImageElement;
-      const setSrc = vi.spyOn(png, 'src', 'set');
+      const image = container.querySelector('img') as HTMLImageElement;
+      const setSrc = vi.spyOn(image, 'src', 'set');
 
       fireEvent.click(container.querySelectorAll('.TabGroup-nav button')[1]);
 

--- a/__tests__/components/Tabs.test.tsx
+++ b/__tests__/components/Tabs.test.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import Tabs, { Tab } from '../../components/Tabs';
 import { mdxish } from '../../lib';
 import { mdxishAstProcessor, mdxishMdastToMd } from '../../lib/mdxish';
+import { gifRestartWrites, spyOnImageSrc } from '../helpers';
 
 import { captureMdxishProps, renderingEngines } from './utils';
 
@@ -141,14 +142,13 @@ describe('Tabs', () => {
 
       const gif = container.querySelector('img[src$=".gif"]') as HTMLImageElement;
       expect(gif).toBeInTheDocument();
-      const setSrc = vi.spyOn(gif, 'src', 'set');
+      const srcSpy = spyOnImageSrc(gif);
 
       fireEvent.click(container.querySelectorAll('.TabGroup-nav button')[1]);
 
-      // Cleared then restored: the only way to rewind an animated image to frame 0
-      expect(setSrc.mock.calls.map(([value]) => value)).toStrictEqual(['', 'https://example.com/demo.gif']);
+      expect(srcSpy.writes).toStrictEqual(gifRestartWrites('https://example.com/demo.gif'));
       expect(gif.src).toBe('https://example.com/demo.gif');
-      setSrc.mockRestore();
+      srcSpy.restore();
     });
 
     it.each([
@@ -167,13 +167,12 @@ describe('Tabs', () => {
       const Component = renderContent(md);
       const { container } = render(<Component />);
 
-      const image = container.querySelector('img') as HTMLImageElement;
-      const setSrc = vi.spyOn(image, 'src', 'set');
+      const srcSpy = spyOnImageSrc(container.querySelector('img') as HTMLImageElement);
 
       fireEvent.click(container.querySelectorAll('.TabGroup-nav button')[1]);
 
-      expect(setSrc).not.toHaveBeenCalled();
-      setSrc.mockRestore();
+      expect(srcSpy.writes).toStrictEqual([]);
+      srcSpy.restore();
     });
 
     it('renders Tabs after sibling content without crashing', () => {

--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -139,3 +139,24 @@ export const collectNodes = <T extends Node = Node>(
   });
   return out;
 };
+
+/**
+ * Spies on an <img>'s `src` setter so tests can assert whether `useRestartAnimatedImages`
+ * rewound it (see `gifRestartWrites`) or left it untouched (no writes).
+ */
+export const spyOnImageSrc = (img: HTMLImageElement) => {
+  const spy = vi.spyOn(img, 'src', 'set');
+  return {
+    /** Every value written to `src`, in order. */
+    get writes(): string[] {
+      return spy.mock.calls.map(([value]) => value);
+    },
+    restore: () => spy.mockRestore(),
+  };
+};
+
+/**
+ * The `src` writes a GIF restart produces: cleared, then restored. Reassigning `src` is the
+ * only way to rewind an animated image to frame 0.
+ */
+export const gifRestartWrites = (src: string) => ['', src];

--- a/components/Accordion/index.tsx
+++ b/components/Accordion/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import { useRestartAnimatedImagesOnReveal } from '../../hooks/useRestartAnimatedImages';
 import Icon from '../Icon';
 
 import './style.scss';
@@ -8,6 +9,7 @@ interface Props extends React.PropsWithChildren<{ icon?: string; iconColor?: str
 
 const Accordion = ({ children, icon, iconColor, title }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
+  const contentRef = useRestartAnimatedImagesOnReveal<HTMLDivElement>(isOpen);
 
   return (
     <details className="Accordion" onToggle={() => setIsOpen(!isOpen)}>
@@ -16,7 +18,9 @@ const Accordion = ({ children, icon, iconColor, title }: Props) => {
         {icon && <Icon className="Accordion-icon" icon={icon} iconColor={iconColor} />}
         {title}
       </summary>
-      <div className="Accordion-content">{children}</div>
+      <div ref={contentRef} className="Accordion-content">
+        {children}
+      </div>
     </details>
   );
 };

--- a/components/Tabs/index.tsx
+++ b/components/Tabs/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 
+import useRestartAnimatedImages from '../../hooks/useRestartAnimatedImages';
 import Icon from '../Icon';
 
 import './style.scss';
@@ -14,6 +15,7 @@ interface TabsProps {
 
 const Tabs = ({ children }: TabsProps) => {
   const [activeTab, setActiveTab] = useState(0);
+  const panelRefs = useRestartAnimatedImages(activeTab);
   // React passes `children` as a single element when there's only one child, so normalize.
   const tabs = React.Children.toArray(children) as React.ReactElement[];
 
@@ -38,7 +40,13 @@ const Tabs = ({ children }: TabsProps) => {
       <section>
         {/* Keep every panel mounted so runtime Tailwind can scan inactive tabs' classes on first paint */}
         {tabs.map((tab, index: number) => (
-          <div key={tab.key} hidden={index !== activeTab}>
+          <div
+            key={tab.key}
+            ref={el => {
+              panelRefs.current[index] = el;
+            }}
+            hidden={index !== activeTab}
+          >
             {tab}
           </div>
         ))}

--- a/hooks/useRestartAnimatedImages/index.tsx
+++ b/hooks/useRestartAnimatedImages/index.tsx
@@ -7,34 +7,57 @@ import { useEffect, useRef } from 'react';
  */
 const ANIMATED_IMAGE_SRC = /\.gif(\?|#|$)/i;
 
-/**
- * Restarts GIF playback inside the panel that just became active.
- *
- * Tabs keep every panel mounted, so an <img> is never re-created and a GIF is
- * shown mid-loop (or frozen on its last frame) when its tab is re-selected.
- * There's no seek API for animated images; reassigning `src` is the only reset,
- * and the reload is served from cache.
- *
- * @returns a ref to attach to each panel element, indexed by tab.
- */
-export default function useRestartAnimatedImages(activeIndex: number) {
-  const panelRefs = useRef<(HTMLDivElement | null)[]>([]);
+const restartAnimatedImages = (root: HTMLElement | null | undefined) => {
+  root?.querySelectorAll('img').forEach(img => {
+    if (!ANIMATED_IMAGE_SRC.test(img.src)) return;
+    const { src } = img;
+    // There's no seek API for animated images; reassigning `src` is the only reset
+    img.src = '';
+    img.src = src;
+  });
+};
+const useRestartAfterFirstPaint = (revealKey: unknown, restart: () => void) => {
   const isFirstRender = useRef(true);
+  const latestRestart = useRef(restart);
+  latestRestart.current = restart;
 
   useEffect(() => {
-    // Skip the initial paint: those images are loading for the first time anyway.
     if (isFirstRender.current) {
       isFirstRender.current = false;
       return;
     }
 
-    panelRefs.current[activeIndex]?.querySelectorAll('img').forEach(img => {
-      if (!ANIMATED_IMAGE_SRC.test(img.src)) return;
-      const { src } = img;
-      img.src = '';
-      img.src = src;
-    });
-  }, [activeIndex]);
+    latestRestart.current();
+  }, [revealKey]);
+};
+
+/**
+ * Restarts GIF playback inside the panel that just became active.
+ *
+ * Tabs keep every panel mounted, so an <img> is never re-created and a GIF is
+ * shown mid-loop (or frozen on its last frame) when its tab is re-selected.
+ *
+ * @returns a ref to attach to each panel element, indexed by tab.
+ */
+export default function useRestartAnimatedImages(activeIndex: number) {
+  const panelRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useRestartAfterFirstPaint(activeIndex, () => restartAnimatedImages(panelRefs.current[activeIndex]));
 
   return panelRefs;
+}
+
+/**
+ * Restarts GIF playback inside an element that has just been revealed after being hidden —
+ * a collapsed <details>, whose images have been animating out of sight since page load.
+ */
+export function useRestartAnimatedImagesOnReveal<T extends HTMLElement>(isRevealed: boolean) {
+  const contentRef = useRef<T | null>(null);
+
+  useRestartAfterFirstPaint(isRevealed, () => {
+    // Rewinding content the reader just hid would be wasted work
+    if (isRevealed) restartAnimatedImages(contentRef.current);
+  });
+
+  return contentRef;
 }

--- a/hooks/useRestartAnimatedImages/index.tsx
+++ b/hooks/useRestartAnimatedImages/index.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useRef } from 'react';
+
+/** Animated formats whose playback position we can only reset by reloading the element. */
+const ANIMATED_IMAGE_SRC = /\.(gif|webp|apng)(\?|#|$)/i;
+
+/**
+ * Restarts animated images inside the panel that just became active.
+ *
+ * Tabs keep every panel mounted, so an <img> is never re-created and a GIF is
+ * shown mid-loop (or frozen on its last frame) when its tab is re-selected.
+ * There's no seek API for animated images; reassigning `src` is the only reset,
+ * and the reload is served from cache.
+ *
+ * @returns a ref to attach to each panel element, indexed by tab.
+ */
+export default function useRestartAnimatedImages(activeIndex: number) {
+  const panelRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const isFirstRender = useRef(true);
+
+  useEffect(() => {
+    // Skip the initial paint: those images are loading for the first time anyway.
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+
+    panelRefs.current[activeIndex]?.querySelectorAll('img').forEach(img => {
+      if (!ANIMATED_IMAGE_SRC.test(img.src)) return;
+      const { src } = img;
+      img.src = '';
+      img.src = src;
+    });
+  }, [activeIndex]);
+
+  return panelRefs;
+}

--- a/hooks/useRestartAnimatedImages/index.tsx
+++ b/hooks/useRestartAnimatedImages/index.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useRef } from 'react';
 
-/** Animated formats whose playback position we can only reset by reloading the element. */
-const ANIMATED_IMAGE_SRC = /\.(gif|webp|apng)(\?|#|$)/i;
+/**
+ * GIF is the one extension that implies animation. `.webp` and `.png` (the extension an APNG
+ * ships under) are overwhelmingly static, so matching them would reload far more images than
+ * it rewinds; telling those apart needs the bytes, not the URL.
+ */
+const ANIMATED_IMAGE_SRC = /\.gif(\?|#|$)/i;
 
 /**
- * Restarts animated images inside the panel that just became active.
+ * Restarts GIF playback inside the panel that just became active.
  *
  * Tabs keep every panel mounted, so an <img> is never re-created and a GIF is
  * shown mid-loop (or frozen on its last frame) when its tab is re-selected.


### PR DESCRIPTION
| 🎫 Resolve CX-3887 |
| :-----------------: |

## 🎯 What does this PR do?

**Problem**
GIFs inside `<Tab>` never restart. `Tabs` keeps every panel mounted and toggles `hidden` (deliberate — 9499ed3b added it so runtime Tailwind can scan inactive tabs' classes on first paint), so the `<img>` is never re-created. Playback position lives in the image element: a looping GIF keeps advancing while hidden, and a non-looping one is stuck on its last frame. Re-selecting a tab shows the animation mid-loop or already over

**Fix**
New `hooks/useRestartAnimatedImages` takes the active index and returns a ref array to attach to each panel. When the active index changes, it walks that panel's `<img>` elements and, for any whose src matches `.gif`/`.webp`/`.apng`, clears and restores `src`

**Tradeoff**
Detection is by URL extension, so a GIF behind a signed or proxied URL with no `.gif` in the path won't be caught. The alternative, resetting every `<img>` in the panel, covers those but risks a visible reflash on large uncached images. Happy to switch if reviewers prefer the broader net


## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ]

## 📸 Screenshot or Loom

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/274c80d6-59e8-4039-9ba7-1112cb1027ed

</td>
<td>

https://github.com/user-attachments/assets/8d0d00e2-83aa-451b-a2d7-7ebf46897e10

</td>
</tr>
</table>

<!-- all PRs should have a Loom or screenshot! -->
