### PR TITLE
fix: keep escaped block markers in GFM table cells in roundtrips

### DIFF
--- a/__tests__/compilers/table-cell-block-markers.test.ts
+++ b/__tests__/compilers/table-cell-block-markers.test.ts
@@ -1,0 +1,120 @@
+import type { Parents, Text } from 'mdast';
+import type { Info, State } from 'mdast-util-to-markdown';
+
+import { mdast, mdx } from '../../index';
+import { escapeCellStartBlockMarker } from '../../processor/compile/table-cell-block-markers';
+import { roundTripMdxish } from '../helpers';
+
+const roundTripMdx = (doc: string) => mdx(mdast(doc));
+
+const roundTrip = (doc: string) => {
+  const mdxishResult = roundTripMdxish(doc);
+  expect(roundTripMdx(doc)).toBe(mdxishResult);
+
+  return mdxishResult;
+};
+
+const table = (cell: string, header = 'a') => `| ${header} |\n| :- |\n| ${cell} |\n`;
+
+describe('table cell block markers', () => {
+  describe('round trips (RM-17203)', () => {
+    it.each([
+      ['a dash bullet', '\\- one'],
+      ['a plus bullet', '\\+ one'],
+      ['an ATX heading', '\\# one'],
+      ['a block quote', '\\> quote'],
+      ['a bare dash', '\\-'],
+    ])('should keep %s escaped in a cell', (_, cell) => {
+      expect(roundTrip(table(cell))).toContain(`| ${cell} |`);
+    });
+
+    it('should keep an escaped marker in a header cell', () => {
+      expect(roundTrip('| \\- h |\n| :- |\n| x |\n')).toContain('| \\- h |');
+    });
+
+    it('should escape a leading marker the author left unescaped', () => {
+      expect(roundTrip(table('- one'))).toContain('| \\- one |');
+    });
+
+    it('should keep an escaped marker after a <br />', () => {
+      expect(roundTrip('| a | b |\n| :- | :- |\n| \\- one<br />\\- two | x |\n')).toContain('| \\- one<br />\\- two |');
+    });
+
+    it('should be stable across a second round trip', () => {
+      const once = roundTrip(table('\\- one'));
+
+      expect(roundTrip(once)).toBe(once);
+    });
+
+    it('should not escape a marker in the middle of a cell', () => {
+      expect(roundTrip(table('foo - bar'))).toContain('| foo - bar |');
+    });
+
+    it('should not escape a dash that cannot open a list', () => {
+      expect(roundTrip(table('-foo'))).toContain('| -foo |');
+    });
+
+    it('should not escape an emphasized marker, which is no longer at the cell start', () => {
+      expect(roundTrip(table('**- one**'))).toContain('| **- one** |');
+    });
+
+    it('should leave an escaped marker outside a table alone', () => {
+      expect(roundTrip('\\- not a list\n')).toBe('\\- not a list\n');
+    });
+
+    it('should leave a real list alone', () => {
+      expect(roundTripMdxish('- one\n- two\n')).toBe('- one\n- two\n');
+    });
+  });
+
+  describe('escapeCellStartBlockMarker', () => {
+    const inCell = { stack: ['table', 'tableRow', 'tableCell', 'phrasing'] } as State;
+    const inParagraph = { stack: ['paragraph', 'phrasing'] } as State;
+    const cellStart = { before: '|', after: '|' } as Info;
+    const midCell = { before: 'x', after: '|' } as Info;
+    const node = { type: 'text', value: '' } satisfies Text;
+    const parent = { type: 'tableCell', children: [node] } as unknown as Parents;
+
+    const escape = (serialized: string, state = inCell, info = cellStart) =>
+      escapeCellStartBlockMarker(serialized, node, parent, state, info);
+
+    it.each(['- one', '+ one', '# one', '###### one', '> quote', '-', '#'])('should escape `%s`', serialized => {
+      expect(escape(serialized)).toBe(`\\${serialized}`);
+    });
+
+    it.each(['-foo', '#foo', 'foo - bar', '* one', '1. one', ''])('should not escape `%s`', serialized => {
+      expect(escape(serialized)).toBe(serialized);
+    });
+
+    it('should not double-escape an already escaped marker', () => {
+      expect(escape('\\- one')).toBe('\\- one');
+    });
+
+    it('should not escape outside a table cell', () => {
+      expect(escape('- one', inParagraph)).toBe('- one');
+    });
+
+    it('should not escape away from the cell start', () => {
+      expect(escape('- one', inCell, midCell)).toBe('- one');
+    });
+
+    it.each([
+      ['a break node', { type: 'break' }],
+      ['a raw <br>', { type: 'html', value: '<br />' }],
+      ['a JSX <br>', { type: 'mdxJsxTextElement', name: 'br', children: [] }],
+    ])('should escape text following %s', (_, previous) => {
+      const withBreak = { type: 'tableCell', children: [previous, node] } as unknown as Parents;
+
+      expect(escapeCellStartBlockMarker('- two', node, withBreak, inCell, midCell)).toBe('\\- two');
+    });
+
+    it('should not escape text following a non-break sibling', () => {
+      const withCode = {
+        type: 'tableCell',
+        children: [{ type: 'inlineCode', value: 'x' }, node],
+      } as unknown as Parents;
+
+      expect(escapeCellStartBlockMarker('- two', node, withCode, inCell, midCell)).toBe('- two');
+    });
+  });
+});

--- a/__tests__/compilers/table-cell-block-markers.test.ts
+++ b/__tests__/compilers/table-cell-block-markers.test.ts
@@ -1,4 +1,4 @@
-import type { Parents, Text } from 'mdast';
+import type { PhrasingContent, TableCell, Text } from 'mdast';
 import type { Info, State } from 'mdast-util-to-markdown';
 
 import { mdast, mdx } from '../../index';
@@ -14,7 +14,15 @@ const roundTrip = (doc: string) => {
   return mdxishResult;
 };
 
-const table = (cell: string, header = 'a') => `| ${header} |\n| :- |\n| ${cell} |\n`;
+/**
+ * Builds a one-column table in the exact layout the serializer emits (columns padded to the
+ * widest cell, delimiter row stretched to match), so a round trip can be asserted as identity.
+ */
+const table = (cell: string, header = 'a') => {
+  const width = Math.max(cell.length, header.length);
+
+  return `| ${header.padEnd(width)} |\n| :${'-'.repeat(width - 1)} |\n| ${cell.padEnd(width)} |\n`;
+};
 
 describe('table cell block markers', () => {
   describe('round trips (RM-17203)', () => {
@@ -25,37 +33,33 @@ describe('table cell block markers', () => {
       ['a block quote', '\\> quote'],
       ['a bare dash', '\\-'],
     ])('should keep %s escaped in a cell', (_, cell) => {
-      expect(roundTrip(table(cell))).toContain(`| ${cell} |`);
+      expect(roundTrip(table(cell))).toBe(table(cell));
     });
 
     it('should keep an escaped marker in a header cell', () => {
-      expect(roundTrip('| \\- h |\n| :- |\n| x |\n')).toContain('| \\- h |');
+      expect(roundTrip(table('x', '\\- h'))).toBe(table('x', '\\- h'));
     });
 
     it('should escape a leading marker the author left unescaped', () => {
-      expect(roundTrip(table('- one'))).toContain('| \\- one |');
+      expect(roundTrip(table('- one'))).toBe(table('\\- one'));
     });
 
     it('should keep an escaped marker after a <br />', () => {
-      expect(roundTrip('| a | b |\n| :- | :- |\n| \\- one<br />\\- two | x |\n')).toContain('| \\- one<br />\\- two |');
-    });
+      const doc = '| a                  | b  |\n| :----------------- | :- |\n| \\- one<br />\\- two | x  |\n';
 
-    it('should be stable across a second round trip', () => {
-      const once = roundTrip(table('\\- one'));
-
-      expect(roundTrip(once)).toBe(once);
+      expect(roundTrip(doc)).toBe(doc);
     });
 
     it('should not escape a marker in the middle of a cell', () => {
-      expect(roundTrip(table('foo - bar'))).toContain('| foo - bar |');
+      expect(roundTrip(table('foo - bar'))).toBe(table('foo - bar'));
     });
 
     it('should not escape a dash that cannot open a list', () => {
-      expect(roundTrip(table('-foo'))).toContain('| -foo |');
+      expect(roundTrip(table('-foo'))).toBe(table('-foo'));
     });
 
     it('should not escape an emphasized marker, which is no longer at the cell start', () => {
-      expect(roundTrip(table('**- one**'))).toContain('| **- one** |');
+      expect(roundTrip(table('**- one**'))).toBe(table('**- one**'));
     });
 
     it('should leave an escaped marker outside a table alone', () => {
@@ -72,11 +76,11 @@ describe('table cell block markers', () => {
     const inParagraph = { stack: ['paragraph', 'phrasing'] } as State;
     const cellStart = { before: '|', after: '|' } as Info;
     const midCell = { before: 'x', after: '|' } as Info;
-    const node = { type: 'text', value: '' } satisfies Text;
-    const parent = { type: 'tableCell', children: [node] } as unknown as Parents;
+    const node: Text = { type: 'text', value: '' };
+    const cell = (...children: PhrasingContent[]): TableCell => ({ type: 'tableCell', children });
 
     const escape = (serialized: string, state = inCell, info = cellStart) =>
-      escapeCellStartBlockMarker(serialized, node, parent, state, info);
+      escapeCellStartBlockMarker(serialized, node, cell(node), state, info);
 
     it.each(['- one', '+ one', '# one', '###### one', '> quote', '-', '#'])('should escape `%s`', serialized => {
       expect(escape(serialized)).toBe(`\\${serialized}`);
@@ -98,21 +102,16 @@ describe('table cell block markers', () => {
       expect(escape('- one', inCell, midCell)).toBe('- one');
     });
 
-    it.each([
+    it.each<[string, PhrasingContent]>([
       ['a break node', { type: 'break' }],
       ['a raw <br>', { type: 'html', value: '<br />' }],
-      ['a JSX <br>', { type: 'mdxJsxTextElement', name: 'br', children: [] }],
+      ['a JSX <br>', { type: 'mdxJsxTextElement', name: 'br', attributes: [], children: [] }],
     ])('should escape text following %s', (_, previous) => {
-      const withBreak = { type: 'tableCell', children: [previous, node] } as unknown as Parents;
-
-      expect(escapeCellStartBlockMarker('- two', node, withBreak, inCell, midCell)).toBe('\\- two');
+      expect(escapeCellStartBlockMarker('- two', node, cell(previous, node), inCell, midCell)).toBe('\\- two');
     });
 
     it('should not escape text following a non-break sibling', () => {
-      const withCode = {
-        type: 'tableCell',
-        children: [{ type: 'inlineCode', value: 'x' }, node],
-      } as unknown as Parents;
+      const withCode = cell({ type: 'inlineCode', value: 'x' }, node);
 
       expect(escapeCellStartBlockMarker('- two', node, withCode, inCell, midCell)).toBe('- two');
     });

--- a/__tests__/compilers/table-cell-block-markers.test.ts
+++ b/__tests__/compilers/table-cell-block-markers.test.ts
@@ -40,10 +40,6 @@ describe('table cell block markers', () => {
       expect(roundTrip(table('x', '\\- h'))).toBe(table('x', '\\- h'));
     });
 
-    it('should escape a leading marker the author left unescaped', () => {
-      expect(roundTrip(table('- one'))).toBe(table('\\- one'));
-    });
-
     it('should keep an escaped marker after a <br />', () => {
       const doc = '| a                  | b  |\n| :----------------- | :- |\n| \\- one<br />\\- two | x  |\n';
 

--- a/processor/compile/index.ts
+++ b/processor/compile/index.ts
@@ -11,7 +11,7 @@ import htmlBlock from './html-block';
 import list from './list';
 import listItem from './list-item';
 import plain from './plain';
-import text from './text';
+import mdxishText, { text } from './text';
 import variable from './variable';
 
 function compilers(this: Processor, mdxish = false) {
@@ -33,12 +33,13 @@ function compilers(this: Processor, mdxish = false) {
     html: compatibility,
     i: compatibility,
     plain,
+    text,
     yaml: compatibility,
 
     // needed only for mdxish
     ...(mdxish && { list }),
     ...(mdxish && { listItem }),
-    ...(mdxish && { text }),
+    ...(mdxish && { text: mdxishText }),
     ...(mdxish && { [NodeTypes.variable]: variable }),
   };
 

--- a/processor/compile/list-item.ts
+++ b/processor/compile/list-item.ts
@@ -1,5 +1,5 @@
-import type { List, ListItem } from 'mdast';
-import type { Info, State } from 'mdast-util-to-markdown';
+import type { ListItem, Parents } from 'mdast';
+import type { Handle, Info, State } from 'mdast-util-to-markdown';
 
 import { defaultHandlers } from 'mdast-util-to-markdown';
 
@@ -18,7 +18,7 @@ const listMarkerRegex = /^(?:[*+-]|\d+[.)])(?:([\r\n]| {1,3})|$)/;
  * with their checkbox intact (for example, `- [ ]`) instead of dropping it
  * We can add more adjustments if needed
  */
-const listItem = (node: ListItem, parent?: List, state?: State, info?: Info) => {
+const listItem = ((node: ListItem, parent: Parents | undefined, state: State, info: Info) => {
   const head = node.children[0];
   const isCheckbox = typeof node.checked === 'boolean' && head && head.type === 'paragraph';
   if (!isCheckbox) {
@@ -46,6 +46,6 @@ const listItem = (node: ListItem, parent?: List, state?: State, info?: Info) => 
   });
 
   return value;
-};
+}) satisfies Handle;
 
 export default listItem;

--- a/processor/compile/table-cell-block-markers.ts
+++ b/processor/compile/table-cell-block-markers.ts
@@ -1,0 +1,40 @@
+import type { Nodes, Parents, Text } from 'mdast';
+import type { Info, State } from 'mdast-util-to-markdown';
+
+const CELL_START_BLOCK_MARKER = /^(?:[-+](?=\s|$)|#{1,6}(?=\s|$)|>)/;
+const BR_HTML = /^\s*<br\s*\/?>\s*$/i;
+
+const isLineBreak = (node: Nodes): boolean => {
+  if (node.type === 'break') return true;
+  if (node.type === 'html') return BR_HTML.test(node.value);
+
+  return node.type === 'mdxJsxTextElement' && 'name' in node && node.name?.toLowerCase() === 'br';
+};
+
+const followsLineBreak = (node: Text, parent: Parents | undefined): boolean => {
+  const siblings = (parent?.children ?? []) as Nodes[];
+  const previous = siblings[siblings.indexOf(node) - 1];
+
+  return !!previous && isLineBreak(previous);
+};
+
+/**
+ * Re-escapes a leading block marker (`-`, `+`, `#`, `>`) at the start of a table cell, or
+ * after a `<br />` within one.
+ *
+ * A cell is serialized mid-line, so the `atBreak` patterns that escape these characters
+ * never fire and an author's `| \- one |` round trips to `| - one |` (RM-17203). Cells are
+ * serialized as `containerPhrasing(cell, { before: '|' })`, so `|` marks the cell start.
+ */
+export const escapeCellStartBlockMarker = (
+  serialized: string,
+  node: Text,
+  parent: Parents | undefined,
+  state: State,
+  info: Info,
+): string => {
+  if (serialized.startsWith('\\') || !CELL_START_BLOCK_MARKER.test(serialized)) return serialized;
+  if (!state.stack.includes('tableCell') || !(info.before === '|' || followsLineBreak(node, parent))) return serialized;
+
+  return `\\${serialized}`;
+};

--- a/processor/compile/text.ts
+++ b/processor/compile/text.ts
@@ -3,15 +3,20 @@ import type { Info, State } from 'mdast-util-to-markdown';
 
 import { defaultHandlers } from 'mdast-util-to-markdown';
 
+import { escapeCellStartBlockMarker } from './table-cell-block-markers';
+
 // A `_` flanked by word characters can never open or close emphasis under
 // CommonMark's flanking rules, so the escape mdast-util-to-markdown adds to
 // intraword underscores is unnecessary and only produces noisy `\_` diffs.
 // Uses Unicode letter/number classes so non-ASCII words (e.g. `é_pay`) match.
 const INTRAWORD_UNDERSCORE_ESCAPE = /(?<=[\p{L}\p{N}_])\\_(?=[\p{L}\p{N}_]|\\_)/gu;
 
-const text = (node: Text, parent: Parents | undefined, state: State, info: Info): string => {
+export const text = (node: Text, parent: Parents | undefined, state: State, info: Info): string => {
   const serialized = defaultHandlers.text(node, parent, state, info);
-  return serialized.replace(INTRAWORD_UNDERSCORE_ESCAPE, '_');
+  return escapeCellStartBlockMarker(serialized, node, parent, state, info);
 };
 
-export default text;
+const mdxishText = (node: Text, parent: Parents | undefined, state: State, info: Info): string =>
+  text(node, parent, state, info).replace(INTRAWORD_UNDERSCORE_ESCAPE, '_');
+
+export default mdxishText;


### PR DESCRIPTION
| 🎫 Resolve RM-17203 |
| :-----------------: |

## 🎯 What does this PR do?

**The bug**
If you write `\- one` in a table cell, saving the doc turns it into `- one`. The backslash disappears

**Root cause**
The markdown serializer only adds a backslash before `-` when the `-` is at the **start of a line**, since that's the only place a `-` **could accidentally become a bullet list**. Inside a table cell the text sits in the middle of a line (between the pipes), so the serializer decides no backslash is needed and drops it

The same applies to `+`, `#` and `>`. (`*` and `1.` are already escaped in cells for other reasons, so they were never affected.)

**fix**
`escapeCellStartBlockMarker` runs after the serializer does its normal work on a piece of text and checks three things:

- Are we inside a table cell?
- Is this text at the very start of that cell?
- Does it begin with `-`, `+`, `#` or `>`?

If all three, it puts the backslash back. Text right after a `<br />` counts as "start of a cell" too

**Why the compiler is split**
The legacy MarkdownEditor serializes through `mdx(mdast)`, which uses the shared compilers set. That set had no `text` handler, so the legacy editor lost the backslash as well. `text` now registers the cell escape for both serializers, while `mdxishText` keeps the intraword-underscore stripping from #1546 scoped to mdxish, so legacy RMDX output is otherwise unchanged
  

## 🧪 QA tips

<!-- Unique code decisions, code walkthroughs, how to test them -->

- [ ]

## 📸 Screenshot or Loom

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/2cd08c75-a86b-4f60-9242-65a16d901d7b

</td>
<td>

https://github.com/user-attachments/assets/a036ff64-a567-4207-91be-ba9ab4ae73e7

</td>
</tr>
</table>

<!-- all PRs should have a Loom or screenshot! -->
