### PR TITLE
feat: support scoping the dark: variant to a root selector in tailwindCompiler

### DIFF
--- a/__tests__/components/TailwindStyle.test.tsx
+++ b/__tests__/components/TailwindStyle.test.tsx
@@ -31,11 +31,30 @@ describe('TailwindStyle', () => {
         );
       });
     });
+
+    it('passes darkModeRootSelector through to tailwindCompiler', async () => {
+      render(
+        <TailwindStyle darkModeDataAttribute="data-color-mode" darkModeRootSelector=".rm-ReadMe">
+          <div className={`${tailwindPrefix} dark:text-blue-500`} />
+        </TailwindStyle>,
+      );
+
+      await waitFor(() => {
+        expect(tailwindCompiler).toHaveBeenCalledWith(
+          expect.arrayContaining(['dark:text-blue-500']),
+          expect.objectContaining({ darkModeDataAttribute: 'data-color-mode', darkModeRootSelector: '.rm-ReadMe' }),
+        );
+      });
+    });
   });
 
   describe('MutationObserver', () => {
     it('collects classes when a direct .readme-tailwind node is added', async () => {
-      const { container } = render(<TailwindStyle><div /></TailwindStyle>);
+      const { container } = render(
+        <TailwindStyle>
+          <div />
+        </TailwindStyle>,
+      );
 
       vi.clearAllMocks();
 
@@ -55,7 +74,11 @@ describe('TailwindStyle', () => {
       // inserting a parent wrapper whose children contain TailwindRoot elements.
       // addedNodes only contains the parent — without the fix, the nested .readme-tailwind
       // was never traversed and its Tailwind classes were never compiled.
-      const { container } = render(<TailwindStyle><div /></TailwindStyle>);
+      const { container } = render(
+        <TailwindStyle>
+          <div />
+        </TailwindStyle>,
+      );
 
       vi.clearAllMocks();
 
@@ -102,7 +125,11 @@ describe('TailwindStyle', () => {
     });
 
     it('collects classes when a class attribute is updated on an existing element', async () => {
-      const { container } = render(<TailwindStyle><div /></TailwindStyle>);
+      const { container } = render(
+        <TailwindStyle>
+          <div />
+        </TailwindStyle>,
+      );
 
       const target = document.createElement('div');
       target.classList.add(tailwindPrefix);
@@ -117,10 +144,7 @@ describe('TailwindStyle', () => {
       });
 
       await waitFor(() => {
-        expect(tailwindCompiler).toHaveBeenCalledWith(
-          expect.arrayContaining(['p-4', 'shadow-md']),
-          expect.anything(),
-        );
+        expect(tailwindCompiler).toHaveBeenCalledWith(expect.arrayContaining(['p-4', 'shadow-md']), expect.anything());
       });
     });
   });

--- a/__tests__/utils/tailwind-compiler.test.ts
+++ b/__tests__/utils/tailwind-compiler.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// The real `tailwindcss.compile()` needs this package's production build pipeline
+// (CSS files imported as raw strings) to produce actual utility output — that
+// pipeline isn't wired up under vitest (see TailwindStyle.test.tsx, which mocks
+// `tailwindCompiler` entirely for the same reason). Spy on `compile` instead, to
+// unit-test the `@custom-variant dark (...)` string this file builds without
+// depending on a full real compile.
+const compileSpy = vi.fn().mockReturnValue({ build: () => '' });
+vi.mock('tailwindcss', () => ({ compile: (...args: unknown[]) => compileSpy(...args) }));
+
+// eslint-disable-next-line import/first
+import { tailwindCompiler } from '../../utils/tailwind-compiler';
+
+describe('tailwindCompiler', () => {
+  describe('darkModeRootSelector', () => {
+    it('scopes the dark: variant to the root selector, self or descendant, when supplied', async () => {
+      await tailwindCompiler(['dark:bg-red-500'], {
+        prefix: '.tw',
+        darkModeDataAttribute: 'data-color-mode',
+        darkModeRootSelector: '.rm-ReadMe',
+      });
+
+      const [css] = compileSpy.mock.calls.at(-1) as [string];
+      expect(css).toContain(
+        '@custom-variant dark (&:where(.rm-ReadMe[data-color-mode=dark], .rm-ReadMe[data-color-mode=dark] *));',
+      );
+    });
+
+    it('falls back to matching any ancestor when omitted, unchanged from before this option existed', async () => {
+      await tailwindCompiler(['dark:bg-red-500'], {
+        prefix: '.tw',
+        darkModeDataAttribute: 'data-color-mode',
+      });
+
+      const [css] = compileSpy.mock.calls.at(-1) as [string];
+      expect(css).toContain('@custom-variant dark (&:where([data-color-mode=dark], [data-color-mode=dark] *));');
+    });
+
+    it('does not scope dark mode at all when darkModeDataAttribute is omitted, root selector or not', async () => {
+      await tailwindCompiler(['dark:bg-red-500'], {
+        prefix: '.tw',
+        darkModeRootSelector: '.rm-ReadMe',
+      });
+
+      const [css] = compileSpy.mock.calls.at(-1) as [string];
+      expect(css).not.toContain('@custom-variant');
+      expect(css).not.toContain('.rm-ReadMe');
+    });
+  });
+});

--- a/components/TailwindStyle/index.tsx
+++ b/components/TailwindStyle/index.tsx
@@ -14,9 +14,11 @@ const traverse = (node: Node, callback: (element: Node) => void) => {
 interface Props {
   children: React.ReactNode;
   darkModeDataAttribute?: string | null;
+  /** See the matching param on `tailwindCompiler` in `utils/tailwind-compiler.ts`. */
+  darkModeRootSelector?: string | null;
 }
 
-const TailwindStyle = ({ children, darkModeDataAttribute }: Props) => {
+const TailwindStyle = ({ children, darkModeDataAttribute, darkModeRootSelector }: Props) => {
   const [stylesheet, setStylesheet] = useState('');
   const classesSet = useRef(new Set<string>());
   const ref = useRef<HTMLStyleElement>(null);
@@ -43,6 +45,7 @@ const TailwindStyle = ({ children, darkModeDataAttribute }: Props) => {
       const sheet = await tailwindCompiler(classes, {
         prefix: `.${tailwindPrefix}`,
         darkModeDataAttribute,
+        darkModeRootSelector,
       });
       /* @note: don't insert an empty stylesheet */
       if (sheet.css.match(/^@layer utilities;/m)) return;
@@ -51,7 +54,7 @@ const TailwindStyle = ({ children, darkModeDataAttribute }: Props) => {
     };
 
     run();
-  }, [classes, darkModeDataAttribute]);
+  }, [classes, darkModeDataAttribute, darkModeRootSelector]);
 
   /*
    * @note: execute once on load

--- a/utils/tailwind-compiler.ts
+++ b/utils/tailwind-compiler.ts
@@ -54,7 +54,13 @@ async function loadModule(): Promise<never> {
   throw new Error('The browser build does not support plugins or config files.');
 }
 
-async function createCompiler({ darkModeDataAttribute }: { darkModeDataAttribute?: string | null }) {
+async function createCompiler({
+  darkModeDataAttribute,
+  darkModeRootSelector,
+}: {
+  darkModeDataAttribute?: string | null;
+  darkModeRootSelector?: string | null;
+}) {
   let css = `
 @layer theme, base, components, utilities;
 
@@ -63,9 +69,12 @@ async function createCompiler({ darkModeDataAttribute }: { darkModeDataAttribute
 `;
 
   if (darkModeDataAttribute) {
+    // Anchors `dark:` to `darkModeRootSelector`'s own attribute instead of any ancestor's,
+    // when supplied — see the `darkModeRootSelector` param doc below for why there's no default.
+    const root = darkModeRootSelector || '';
     css += `
 
-@custom-variant dark (&:where([${darkModeDataAttribute}=dark], [${darkModeDataAttribute}=dark] *));`;
+@custom-variant dark (&:where(${root}[${darkModeDataAttribute}=dark], ${root}[${darkModeDataAttribute}=dark] *));`;
   }
 
   return tailwindcss.compile(css, {
@@ -77,9 +86,28 @@ async function createCompiler({ darkModeDataAttribute }: { darkModeDataAttribute
 
 export async function tailwindCompiler(
   classes: string[],
-  { prefix, darkModeDataAttribute }: { darkModeDataAttribute?: string | null; prefix: string },
+  {
+    prefix,
+    darkModeDataAttribute,
+    darkModeRootSelector,
+  }: {
+    darkModeDataAttribute?: string | null;
+    /**
+     * Scopes the `dark:` variant to `darkModeRootSelector[darkModeDataAttribute=dark]`
+     * (self or descendant) instead of matching `[darkModeDataAttribute=dark]` on *any*
+     * ancestor. Matches `when-color-mode-dark($root)` in `styles/mixins/when-color-mode-dark.scss`
+     * — see that mixin's doc comment for the full rationale (two independent
+     * `data-color-mode` scopes on one page, e.g. readme's SuperHub admin shell vs. the
+     * hub content it's previewing) and why there's no default: this package ships one
+     * precompiled stylesheet, so whatever a caller passes is permanent for every
+     * installer, and readme (this package's only real consumer today) is expected to
+     * pass its hub color-mode root, `.rm-ReadMe`.
+     */
+    darkModeRootSelector?: string | null;
+    prefix: string;
+  },
 ) {
-  const compiler = await createCompiler({ darkModeDataAttribute });
+  const compiler = await createCompiler({ darkModeDataAttribute, darkModeRootSelector });
   const css = compiler.build(Array.from(classes));
 
   return postcss([prefixer({ prefix })]).process(css, { from: undefined });


### PR DESCRIPTION
## Summary
- `tailwindCompiler`/`TailwindStyle` accept a new `darkModeRootSelector` option. When supplied, the generated `dark:` custom-variant is scoped to that root's own `[darkModeDataAttribute]`, self or descendant, instead of matching the attribute on *any* ancestor.
- Omitted (the default), behavior is byte-for-byte unchanged from today.
- Mirrors `when-color-mode-dark($root)` (`styles/mixins/when-color-mode-dark.scss`, added in #1596) — same rationale: a page can have two independent `data-color-mode` scopes (e.g. readme's SuperHub admin shell vs. the hub content it's previewing), and the current ancestor-matching selector can't tell them apart. No default root selector is provided, for the same reason `when-color-mode-dark` doesn't have one — see that mixin's doc comment, and the new doc comment on `tailwindCompiler`'s `darkModeRootSelector` param, for the full reasoning.

## Test plan
- [x] `__tests__/utils/tailwind-compiler.test.ts` (new) — unit-tests the generated `@custom-variant dark (...)` string directly (spies on `tailwindcss.compile` since the real compile pipeline needs this package's production string-import loaders, which aren't wired into vitest — same reason the existing `TailwindStyle.test.tsx` mocks `tailwindCompiler` rather than exercising real output)
- [x] `__tests__/components/TailwindStyle.test.tsx` — new case confirming `darkModeRootSelector` threads through to `tailwindCompiler`
- [x] `npx vitest run` on both files — 9/9 passing
- [x] `npx eslint` — clean
- [x] `npx tsc --noEmit` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)