### PR TITLE
fix(mdxish): keep inline <Image> inline under the tailwind wrapper

### DIFF
--- a/__tests__/regression/__snapshots__/equivalence.test.ts.snap
+++ b/__tests__/regression/__snapshots__/equivalence.test.ts.snap
@@ -612,6 +612,100 @@ exports[`MDX↔MDXish equivalence > indented-markdown-islands-in-html 1`] = `
 }
 `;
 
+exports[`MDX↔MDXish equivalence > inline-image-tailwind 1`] = `
+{
+  "changes": [
+    {
+      "attrName": "aria-label",
+      "kind": "attr",
+      "left": "Expand image",
+      "path": "/p[0]/span[1]",
+      "right": null,
+      "severity": "cosmetic",
+    },
+    {
+      "attrName": "class",
+      "kind": "attr",
+      "left": "closed img lightbox",
+      "path": "/p[0]/span[1]",
+      "right": "readme-tailwind",
+      "severity": "structural",
+    },
+    {
+      "attrName": "role",
+      "kind": "attr",
+      "left": "button",
+      "path": "/p[0]/span[1]",
+      "right": null,
+      "severity": "structural",
+    },
+    {
+      "attrName": "tabindex",
+      "kind": "attr",
+      "left": "0",
+      "path": "/p[0]/span[1]",
+      "right": null,
+      "severity": "structural",
+    },
+    {
+      "attrName": "aria-label",
+      "kind": "attr",
+      "left": null,
+      "path": "/p[0]/span[1]/span[0]",
+      "right": "Expand image",
+      "severity": "cosmetic",
+    },
+    {
+      "attrName": "class",
+      "kind": "attr",
+      "left": "lightbox-inner",
+      "path": "/p[0]/span[1]/span[0]",
+      "right": "closed img lightbox",
+      "severity": "structural",
+    },
+    {
+      "attrName": "role",
+      "kind": "attr",
+      "left": null,
+      "path": "/p[0]/span[1]/span[0]",
+      "right": "button",
+      "severity": "structural",
+    },
+    {
+      "attrName": "tabindex",
+      "kind": "attr",
+      "left": null,
+      "path": "/p[0]/span[1]/span[0]",
+      "right": "0",
+      "severity": "structural",
+    },
+    {
+      "kind": "tag",
+      "left": "img",
+      "path": "/p[0]/span[1]/span[0]/img[0]",
+      "right": "span",
+      "severity": "structural",
+    },
+    {
+      "kind": "tag",
+      "left": "span",
+      "path": "/span[2]",
+      "right": "div",
+      "severity": "structural",
+    },
+    {
+      "kind": "tag",
+      "left": "span",
+      "path": "/span[4]",
+      "right": "div",
+      "severity": "structural",
+    },
+  ],
+  "severity": "structural",
+  "status": "differ",
+}
+`;
+
 exports[`MDX↔MDXish equivalence > jsx-attribute-entities 1`] = `
 {
   "changes": [

--- a/__tests__/regression/__snapshots__/snapshots.test.ts.snap
+++ b/__tests__/regression/__snapshots__/snapshots.test.ts.snap
@@ -519,6 +519,24 @@ exports[`Render engine regressions tests > indented-markdown-islands-in-html (md
 </div>"
 `;
 
+exports[`Render engine regressions tests > inline-image-tailwind (mdx) 1`] = `
+"<p>An inline <span aria-label="Expand image" class="img lightbox closed" role="button" tabindex="0"><span class="lightbox-inner"><img alt="menu icon" class="img  " height="auto" loading="lazy" src="https://files.readme.io/a.png" title="" width="15px"/></span></span> image should stay on the same line as this text.</p>
+<p>Line 1</p>
+<span aria-label="Expand image" class="img lightbox closed" role="button" tabindex="0"><span class="lightbox-inner"><img alt="menu icon" class="img  " height="auto" loading="lazy" src="https://files.readme.io/a.png" title="" width="15px"/></span></span>
+<p>Line 2</p>
+<span aria-label="Expand image" class="img lightbox closed" role="button" tabindex="0"><span class="lightbox-inner"><img alt="menu icon" class="img  " height="auto" loading="lazy" src="https://files.readme.io/a.png" title="" width="15px"/></span></span>
+<p>A plain inline <span>span</span> tag stays inline as regular HTML.</p>"
+`;
+
+exports[`Render engine regressions tests > inline-image-tailwind (mdxish) 1`] = `
+"<p>An inline <span class="readme-tailwind"><span aria-label="Expand image" class="img lightbox closed" role="button" tabindex="0"><span class="lightbox-inner"><img alt="menu icon" class="img  " height="auto" loading="lazy" src="https://files.readme.io/a.png" title="" width="15px"/></span></span></span> image should stay on the same line as this text.</p>
+<p>Line 1</p>
+<div class="readme-tailwind"><span aria-label="Expand image" class="img lightbox closed" role="button" tabindex="0"><span class="lightbox-inner"><img alt="menu icon" class="img  " height="auto" loading="lazy" src="https://files.readme.io/a.png" title="" width="15px"/></span></span></div>
+<p>Line 2</p>
+<div class="readme-tailwind"><span aria-label="Expand image" class="img lightbox closed" role="button" tabindex="0"><span class="lightbox-inner"><img alt="menu icon" class="img  " height="auto" loading="lazy" src="https://files.readme.io/a.png" title="" width="15px"/></span></span></div>
+<p>A plain inline <span>span</span> tag stays inline as regular HTML.</p>"
+`;
+
 exports[`Render engine regressions tests > jsx-attribute-entities (mdx) 1`] = `
 "<h1 class="heading heading-1 header-scroll"><div class="heading-anchor anchor waypoint" id="jsx-attribute-entities"></div><div class="heading-text">JSX attribute entities</div><a aria-label="Skip link to JSX attribute entities" class="heading-anchor-icon fa fa-regular fa-anchor" href="#jsx-attribute-entities"></a></h1>
 <blockquote class="callout callout_warn" theme="🚧"><span class="callout-icon">🚧</span><p>Numeric-entity emoji in <code class="rdmd-code lang-undefined theme-undefined">icon</code> should decode to the construction sign.</p></blockquote>

--- a/__tests__/regression/fixtures/inline-image-tailwind/README.md
+++ b/__tests__/regression/fixtures/inline-image-tailwind/README.md
@@ -1,0 +1,26 @@
+# `inline-image-tailwind` Fixture
+
+Pins how an `<Image>` (and other custom components) wrap in the tailwind
+`<TailwindRoot>` depending on whether they sit inline or block, across both
+engines.
+
+## Source bug
+
+- RM-18331 — After moving from MDX to MDXish, an inline
+  `<Image>` (e.g. `text <Image /> text`) rendered on its own line. MDXish tokenizes
+  the inline `<Image>` as a flow element, so the tailwind transformer wrapped it in a
+  block `<div class="readme-tailwind">`; a `<div>` inside a `<p>` is split out by the
+  browser, breaking inline flow. The fix derives the wrapper's `flow` from the parent's
+  content model (`INLINE_ONLY_PARENT_TYPES`), so an inline component gets an inline
+  `<span>` wrapper and matches MDX.
+
+## What it covers
+
+- An inline `<Image>` flanked by text — stays inline (`span` wrapper).
+- An `<Image>` on its own line between text, and one separated by blank lines —
+  stay block (`div` wrapper); this is the unchanged behavior guarded against
+  regression.
+- A plain HTML `<span>` — never wrapped, always inline (control).
+
+The inline/block generalization to other custom components and HTML tags is
+covered directly at the AST level in `__tests__/transformers/tailwind.test.tsx`.

--- a/__tests__/regression/fixtures/inline-image-tailwind/body.md
+++ b/__tests__/regression/fixtures/inline-image-tailwind/body.md
@@ -1,0 +1,9 @@
+An inline <Image alt="menu icon" width="15px" src="https://files.readme.io/a.png" /> image should stay on the same line as this text.
+
+Line 1
+<Image alt="menu icon" width="15px" src="https://files.readme.io/a.png" />
+Line 2
+
+<Image alt="menu icon" width="15px" src="https://files.readme.io/a.png" />
+
+A plain inline <span>span</span> tag stays inline as regular HTML.

--- a/__tests__/regression/fixtures/inline-image-tailwind/context.json
+++ b/__tests__/regression/fixtures/inline-image-tailwind/context.json
@@ -1,0 +1,7 @@
+{
+  "variables": {
+    "defaults": [],
+    "user": {}
+  },
+  "glossary": []
+}

--- a/__tests__/transformers/tailwind.test.tsx
+++ b/__tests__/transformers/tailwind.test.tsx
@@ -1,0 +1,190 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+
+import { mdxish, renderMdxish } from '../../lib';
+import { findAllElementsByTagName, findElementByTagName } from '../helpers';
+
+/**
+ * The tailwind transformer wraps custom components in a `<TailwindRoot>` whose
+ * `flow` prop drives a `div` (block) vs `span` (inline) render. A component
+ * sitting inside an inline-only parent (e.g. an `<Image>` mid-paragraph) must
+ * stay inline; a block `div` there is split out of its `<p>` by the browser and
+ * drops onto its own line (RM-18331). These cover the flow/inline decision at
+ * both the HAST and the rendered-HTML level, and lock in the MDX parity that
+ * regressed when customers moved from MDX to MDXish.
+ */
+
+const IMAGE = '<Image alt="menu icon" width="15px" src="https://files.readme.io/a.png" />';
+
+const toHast = (md: string) => mdxish(md, { useTailwind: true, components: { Foo: '<span>hi</span>' } });
+
+const toHtml = (md: string) => {
+  const mod = renderMdxish(toHast(md));
+  const { container } = render(React.createElement(mod.default as React.FC));
+  return container.innerHTML;
+};
+
+const topLevelWrappers = (md: string) => toHast(md).children.filter(c => 'tagName' in c && c.tagName === 'TailwindRoot');
+
+describe('tailwind transformer', () => {
+  describe('flow/inline wrapping', () => {
+    describe('inline context → span wrapper', () => {
+      it('keeps an Image inline when flanked by text on one line', () => {
+        const hast = toHast(`line 1 ${IMAGE} line 2`);
+  
+        expect(hast.children).toMatchObject([
+          {
+            tagName: 'p',
+            children: [
+              { type: 'text', value: 'line 1 ' },
+              { tagName: 'TailwindRoot', children: [{ tagName: 'img' }] },
+              { type: 'text', value: ' line 2' },
+            ],
+          },
+        ]);
+        // `flow` is dropped (false)
+        expect(findElementByTagName(hast, 'TailwindRoot')?.properties).toStrictEqual({});
+        expect(topLevelWrappers(`line 1 ${IMAGE} line 2`)).toHaveLength(0);
+      });
+  
+      it('keeps an Image inline with a soft break after it', () => {
+        const md = `line 1 ${IMAGE}\nline 2`;
+        const hast = toHast(md);
+  
+        // Not a block wrapper, and the span wrapper lives inside the paragraph.
+        expect(topLevelWrappers(md)).toHaveLength(0);
+        const paragraph = hast.children[0];
+        expect(paragraph).toMatchObject({ tagName: 'p' });
+        expect(findElementByTagName(paragraph, 'TailwindRoot')).toMatchObject({
+          properties: {},
+          children: [{ tagName: 'img' }],
+        });
+      });
+  
+      it('generalizes to any self-closing custom component, not just Image', () => {
+        const hast = toHast('line 1 <Foo /> line 2');
+  
+        expect(hast.children).toMatchObject([
+          {
+            tagName: 'p',
+            children: [
+              { type: 'text', value: 'line 1 ' },
+              { tagName: 'TailwindRoot', properties: {}, children: [{ tagName: 'Foo' }] },
+              { type: 'text', value: ' line 2' },
+            ],
+          },
+        ]);
+      });
+
+      it('keeps an Image inline when the text is wrapped in a single-line HTML tag', () => {
+        // A single-line `<div>` keeps its inline content as direct children (no
+        // `<p>`), so the parent type alone can't tell this apart from a block.
+        const md = `<div>line 1 ${IMAGE} line 2</div>`;
+        const hast = toHast(md);
+
+        expect(hast.children).toMatchObject([
+          {
+            tagName: 'div',
+            children: [
+              { type: 'text', value: 'line 1 ' },
+              { tagName: 'TailwindRoot', properties: {}, children: [{ tagName: 'img' }] },
+              { type: 'text', value: ' line 2' },
+            ],
+          },
+        ]);
+        expect(topLevelWrappers(md)).toHaveLength(0);
+      });
+
+      it('keeps an Image inline next to text in a list item', () => {
+        const hast = toHast(`- item ${IMAGE}`);
+
+        expect(findElementByTagName(hast, 'li')).toMatchObject({
+          children: [
+            { type: 'text', value: 'item ' },
+            { tagName: 'TailwindRoot', properties: {}, children: [{ tagName: 'img' }] },
+          ],
+        });
+      });
+    });
+  
+    describe('block context → div wrapper (unchanged behavior)', () => {
+      it('wraps an Image on its own line between text as a block', () => {
+        const md = `Line 1\n${IMAGE}\nLine 2`;
+        const hast = toHast(md);
+  
+        expect(topLevelWrappers(md)).toMatchObject([{ tagName: 'TailwindRoot', properties: { flow: true }, children: [{ tagName: 'img' }] }]);
+        // Flanking text stays in its own paragraphs, so nothing is inline here.
+        expect(hast.children[0]).toMatchObject({ tagName: 'p', children: [{ type: 'text', value: 'Line 1' }] });
+      });
+  
+      it('wraps a blank-line separated Image as a block', () => {
+        const md = `Line 1\n\n${IMAGE}\n\nLine 2`;
+        expect(topLevelWrappers(md)).toMatchObject([{ tagName: 'TailwindRoot', properties: { flow: true }, children: [{ tagName: 'img' }] }]);
+      });
+  
+      it('wraps a block-level custom component as a block', () => {
+        const md = 'Line 1\n\n<Foo>hi</Foo>\n\nLine 2';
+        expect(topLevelWrappers(md)).toMatchObject([{ tagName: 'TailwindRoot', properties: { flow: true }, children: [{ tagName: 'Foo' }] }]);
+      });
+
+      it.each([
+        ['on one line', `<div>${IMAGE}</div>`],
+        ['with whitespace-only siblings', `<div>\n${IMAGE}\n</div>`],
+      ])('wraps a lone Image inside an HTML tag as a block %s', (_, md) => {
+        expect(findElementByTagName(toHast(md), 'div')).toMatchObject({
+          children: [{ tagName: 'TailwindRoot', properties: { flow: true }, children: [{ tagName: 'img' }] }],
+        });
+      });
+
+      it('wraps a lone Image in a list item as a block', () => {
+        const wrapper = findElementByTagName(toHast(`- ${IMAGE}`), 'TailwindRoot');
+        expect(wrapper).toMatchObject({ properties: { flow: true }, children: [{ tagName: 'img' }] });
+      });
+    });
+  
+    describe('plain HTML tags are never wrapped', () => {
+      it('leaves an inline lowercase <image> unwrapped and inline', () => {
+        const hast = toHast('line 1 <image />\nline 2');
+  
+        expect(findAllElementsByTagName(hast, 'TailwindRoot')).toHaveLength(0);
+        const paragraph = findElementByTagName(hast, 'p');
+        expect(paragraph?.children[0]).toMatchObject({ type: 'text', value: 'line 1 ' });
+        expect(findElementByTagName(hast, 'img')).not.toBeNull();
+      });
+  
+      it('leaves an inline <span> unwrapped and inline', () => {
+        const hast = toHast('line 1 <span>hi</span> line 2');
+  
+        expect(findAllElementsByTagName(hast, 'TailwindRoot')).toHaveLength(0);
+        expect(hast.children).toMatchObject([
+          {
+            tagName: 'p',
+            children: [
+              { type: 'text', value: 'line 1 ' },
+              { tagName: 'span', children: [{ type: 'text', value: 'hi' }] },
+              { type: 'text', value: ' line 2' },
+            ],
+          },
+        ]);
+      });
+    });
+  
+    describe('rendered HTML', () => {
+      it('renders an inline Image as a span inside the paragraph', () => {
+        expect(toHtml(`line 1 ${IMAGE} line 2`)).toContain('<p>line 1 <span class="readme-tailwind">');
+      });
+  
+      it('renders an Image inside a single-line HTML tag as an inline span', () => {
+        expect(toHtml(`<div>line 1 ${IMAGE} line 2</div>`)).toContain('<div>line 1 <span class="readme-tailwind">');
+      });
+
+      it('renders an own-line Image as a block div outside the paragraph', () => {
+        const html = toHtml(`Line 1\n${IMAGE}\nLine 2`);
+        expect(html).toMatch(/<p>Line 1<\/p>/);
+        expect(html).toContain('<div class="readme-tailwind">');
+      });
+    });
+  });
+});
+
+

--- a/processor/transform/tailwind.tsx
+++ b/processor/transform/tailwind.tsx
@@ -1,10 +1,12 @@
-import type { PhrasingContent, BlockContent, Root } from 'mdast';
+import type { PhrasingContent, BlockContent, Parents, Root, RootContent } from 'mdast';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
 import type { Plugin } from 'unified';
 import type { VFile } from 'vfile';
 
+import { phrasing } from 'mdast-util-phrasing';
 import { visit, SKIP } from 'unist-util-visit';
 
+import { INLINE_ONLY_PARENT_TYPES } from '../../lib/constants';
 import { isMDXElement, toAttributes, getExports } from '../utils';
 
 interface TailwindRootOptions {
@@ -16,6 +18,18 @@ type Visitor =
   | ((node: MdxJsxFlowElement, index: number, parent: BlockContent) => undefined | void)
   | ((node: MdxJsxTextElement, index: number, parent: PhrasingContent) => undefined | void);
 
+/** Whitespace-only text is layout between blocks, not inline flow. */
+const isInlineContent = (node: RootContent) => phrasing(node) && !(node.type === 'text' && node.value.trim() === '');
+
+/**
+ * Whether the child at `index` sits in inline flow: its parent only allows
+ * phrasing content (e.g. a paragraph), or it is flanked by phrasing siblings
+ * (e.g. `<div>text <Image /> text</div>`, whose children skip the paragraph).
+ */
+const isInlineInContext = (index: number, parent: Parents) =>
+  INLINE_ONLY_PARENT_TYPES.has(parent.type) ||
+  parent.children.some((sibling, siblingIndex) => siblingIndex !== index && isInlineContent(sibling));
+
 const injectTailwindRoot =
   ({ components = {} }): Visitor =>
   (node, index, parent) => {
@@ -23,8 +37,11 @@ const injectTailwindRoot =
     if (!(node.name in components)) return;
     if (!('children' in parent)) return;
 
+    // mdxish tokenizes an inline `<Image />` as a flow element, so decide the
+    // wrapper from context: a block `div` inside inline flow gets split out of
+    // its `<p>` by the browser and drops onto its own line (RM-18331).
     const attrs = {
-      flow: node.type === 'mdxJsxFlowElement',
+      flow: node.type === 'mdxJsxFlowElement' && !isInlineInContext(index, parent),
     };
 
     const wrapper = {

--- a/processor/transform/tailwind.tsx
+++ b/processor/transform/tailwind.tsx
@@ -37,9 +37,6 @@ const injectTailwindRoot =
     if (!(node.name in components)) return;
     if (!('children' in parent)) return;
 
-    // mdxish tokenizes an inline `<Image />` as a flow element, so decide the
-    // wrapper from context: a block `div` inside inline flow gets split out of
-    // its `<p>` by the browser and drops onto its own line (RM-18331).
     const attrs = {
       flow: node.type === 'mdxJsxFlowElement' && !isInlineInContext(index, parent),
     };


### PR DESCRIPTION
| 🎫 Resolve RM-18331 |
| :-----------------: |

## 🎯 What does this PR do?

- In MDXish, an inline `<Image />` (e.g. `text <Image /> text`) rendered on its own line even though on MDX it was in-lined. This is because MDXish tokenizes MDX elements like `<Image>` as a flow (block-level), and then the tailwind transformer wrapped it in a `<div>` block as it sees a flow element
- The fix is we should do an additional check in the Tailwind transformer for the parent element as well, because a flow element in an inline-only parent should stay inline. It now wraps inline (`span`) when the parent is inline-only or the node has phrasing siblings, otherwise block (`div`). This now matches MDX for all shapes (own-line / blank-line / lone-in-`<div>` / lone-in-list stay block).

## 🧪 QA tips

- [ ] `__tests__/transformers/tailwind.test.tsx` covers the flow/inline decision at HAST and rendered-HTML level; new regression fixture `inline-image-tailwind` locks the MDXish render.
- [ ] Render `Left <Image width="15px" src="..." /> right` with tailwind enabled — image stays on the same line.

## 📸 Screenshot or Loom

Before: 

<img width="741" height="321" alt="Screenshot 2026-09-09 at 5 25 10 pm" src="https://github.com/user-attachments/assets/9357d2ee-4de2-4181-a447-463d9a30424d" />

After:

<img width="751" height="348" alt="Screenshot 2026-09-09 at 5 23 05 pm" src="https://github.com/user-attachments/assets/7ef0c2dc-edc1-48bd-a487-cc550188302d" />
